### PR TITLE
Update catch git repo url and set to Catch1.x branch. #70

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,8 @@ find_package(Git REQUIRED)
 ExternalProject_Add(
   catch
   PREFIX ${CMAKE_BINARY_DIR}/catch
-  GIT_REPOSITORY https://github.com/philsquared/Catch.git
+  GIT_REPOSITORY https://github.com/catchorg/Catch.git
+  GIT_TAG "Catch1.x"
   TIMEOUT 10
   UPDATE_COMMAND ${GIT_EXECUTABLE} pull
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
## What does this PR do?
Set the catch git tag to the Catch1.x branch and update new git url for catch group name change.

## What are related issues/pull requests?
#70

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments

## Environment

Provide environment details, if relevant:

* DBMS name/version: N/A
* ODBC connection string: N/A
* OS and Compiler: linux gcc-6
