### PR TITLE
[migrated] Converter templates for more efficient processing 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -171,6 +171,15 @@ test_script:
       if ($env:ANALYSIS) {
         Write-Host "Static analysis, skipping tests" -ForegroundColor Magenta
       } else {
+        $test_name = "utility_test"
+        Write-Host "Running $Env:CONFIGURATION build test: $test_name" -ForegroundColor Magenta
+        $cmd = 'ctest -V --output-on-failure -C ' + $Env:CONFIGURATION + ' -R ' + $test_name
+        iex "& $cmd"
+        if ($LastExitCode -ne 0) {
+          Write-Host "Tests failure, uploading Testing/Temporary/LastTest.log to artifacts" -ForegroundColor Magenta
+          Push-AppveyorArtifact Testing\Temporary\LastTest.log
+          $host.SetShouldExit($LastExitCode)
+        }
         if ($env:DB -Match "MSSQL2008") {
           $env:NANODBC_TEST_CONNSTR_MSSQL="Driver={ODBC Driver 11 for SQL Server};Server=(local)\SQL2008R2SP2;Database=master;UID=sa;PWD=Password12!;"
           $test_name = "mssql_test"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,28 @@ include_directories(${CMAKE_SOURCE_DIR} ${ODBC_INCLUDE_DIR})
 link_directories(${CMAKE_BINARY_DIR}/lib)
 file(GLOB headers *.h *.hpp)
 add_custom_target(tests DEPENDS tests catch)
+
+# Common utilities tests
+add_executable(utility_tests utility_test.cpp)
+target_include_directories(utility_tests PRIVATE ${CMAKE_SOURCE_DIR}/nanodbc)
+if (BUILD_SHARED_LIBS)
+  target_link_libraries(utility_tests nanodbc Catch "${ODBC_LINK_FLAGS}")
+else()
+  target_link_libraries(utility_tests nanodbc Catch ${ODBC_LIBRARIES})
+endif()
+set_target_properties(utility_tests PROPERTIES VERSION ${NANODBC_VERSION})
+add_test(NAME utility_tests COMMAND utility_tests)
+if(NOT CMAKE_GENERATOR MATCHES "^Visual Studio")
+  add_custom_target(utility_test
+    COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R utility_tests)
+  add_custom_target(${test_item}_check
+    COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R utility_tests
+    DEPENDS utility_tests)
+endif()
+add_dependencies(tests utility_tests)
+
+
+# Database-specific tests
 set(test_list mssql mysql postgresql sqlite vertica) # odbc_test.cpp is a dummy
 
 # Travis CI and AppVeyor set common environment variable CI

--- a/test/utility_test.cpp
+++ b/test/utility_test.cpp
@@ -1,0 +1,124 @@
+#define CATCH_CONFIG_MAIN
+#include "catch/catch.hpp"
+
+// clang-format off
+#define NANODBC_DISABLE_NANODBC_NAMESPACE_FOR_INTERNAL_TESTS
+#include "nanodbc.cpp" // access private conversion routines
+// clang-format on
+
+#include <string>
+
+TEST_CASE("convert", "[string]")
+{
+    std::string const u8 = u8"Hello ツ World";
+    std::u16string const u16 = u"Hello ツ World";
+    std::u32string const u32 = U"Hello ツ World";
+    std::wstring const w = L"Hello ツ World";
+
+    SECTION("identity conversion")
+    {
+        SECTION("std::string to std::string (UTF-8)")
+        {
+            std::string out;
+            convert(u8, out);
+            REQUIRE(u8 == out);
+        }
+
+        SECTION("std::wstring to std::wstring (UTF-16 or UTF-32)")
+        {
+            std::wstring out;
+            convert(w, out);
+            REQUIRE(w == out);
+        }
+
+        SECTION("std::u16string to std::u16string")
+        {
+            std::u16string out;
+            convert(u16, out);
+            REQUIRE(u16 == out);
+        }
+
+        SECTION("std::u32string to std::u32string")
+        {
+            std::u32string out;
+            convert(u32, out);
+            REQUIRE(u32 == out);
+        }
+    }
+
+    SECTION("widening conversion"){
+#ifndef _MSC_VER
+        SECTION("std::string to std::u16string"){std::u16string out;
+    convert(u8, out);
+    REQUIRE(u16 == out);
+}
+#else
+        SECTION("std::string to std::wstring"){std::wstring out;
+    convert(u8, out);
+    REQUIRE(w == out);
+}
+#endif
+
+#ifdef NANODBC_USE_IODBC_WIDE_STRINGS
+SECTION("std::string to std::u32string")
+{
+    std::u32string out;
+    convert(u8, out);
+    REQUIRE(u32 == out);
+}
+#endif
+}
+
+SECTION("narrowing conversion")
+{
+#ifndef _MSC_VER
+    SECTION("std::u16string to std::string")
+    {
+        std::string out;
+        convert(u16, out);
+        REQUIRE(u8 == out);
+    }
+#else
+    SECTION("std::wstring to std::string")
+    {
+        std::string out;
+        convert(w, out);
+        REQUIRE(u8 == out);
+    }
+#endif
+
+#ifdef NANODBC_USE_IODBC_WIDE_STRINGS
+    SECTION("std::u32string to std::string")
+    {
+        std::string out;
+        convert(u32, out);
+        REQUIRE(u8 == out);
+    }
+#endif
+
+    SECTION("SQLWCHAR via nanodbc::wide_char_t to std::string")
+    {
+#ifdef NANODBC_USE_IODBC_WIDE_STRINGS
+        static_assert(sizeof(WCHAR) == sizeof(char32_t), "WCHAR size is invalid");
+        static_assert(sizeof(WCHAR) == sizeof(nanodbc::wide_char_t), "WCHAR size is invalid");
+
+        std::string out;
+        SQLWCHAR const* s = reinterpret_cast<WCHAR const*>(u32.data());
+        auto const us = reinterpret_cast<nanodbc::wide_char_t const*>(
+            s); // no-op or unsigned short to signed char16_t
+        convert(us, u32.size(), out);
+        REQUIRE(u8 == out);
+#else
+        static_assert(sizeof(WCHAR) == sizeof(char16_t), "WCHAR size is invalid");
+        static_assert(sizeof(WCHAR) == sizeof(nanodbc::wide_char_t), "WCHAR size is invalid");
+
+        std::string out;
+        SQLWCHAR const* s = reinterpret_cast<WCHAR const*>(u16.data());
+        auto const us = reinterpret_cast<nanodbc::wide_char_t const*>(
+            s); // no-op or unsigned short to signed char16_t
+        convert(us, u16.size(), out);
+        REQUIRE(u8 == out);
+#endif
+    }
+}
+}

--- a/utility/ci/travis/script.sh
+++ b/utility/ci/travis/script.sh
@@ -56,5 +56,7 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       ..
 make
 cd test
+make utility_tests
+ctest -VV --output-on-failure -R utility_tests
 make ${DB}_tests
 ctest -VV --output-on-failure -R ${DB}_tests


### PR DESCRIPTION
Moved from PR https://github.com/lexicalunit/nanodbc/pull/201 by @mcg1969 and based on the latest master branch

## What does this PR do?

I'm really digging Visual 2015's profiler, which has made it easier for me to see the performance bottlenecks in my code. Even after my latest converter PR, one of the performance bottlenecks remained in the converter code. What is interesting is that this bottleneck didn't go away even when I adjusted my code so that no conversion is necessary. Another bottleneck turned out to be a large number of unnecessary allocations as well, particularly when going between C-style and C++-style strings.

The set of convert functions provided here attempt to address this problem. Using template specialization we can use move semantics when that is appropriate, straight copying when conversion is unnecessary, and full conversion only when that is warranted. Because the decisions are made at compile time this should be a net win.

The result is not only a performance improvement in my specific case, but what I believe to be simpler code in many places throughout.

I've marked this WIP simply because I haven't yet investigated the interaction with existing tests

## Tasklist

 - [x] Add test case(s)
 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed
