### PR TITLE
[Travis CI] Run clang-format 5.0 to check for code formatting errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,10 @@ ref:
   sources: &sources
     - boost-latest
     - george-edison55-precise-backports
+    - llvm-toolchain-precise
     - ubuntu-toolchain-r-test
   packages: &packages
+    - clang-format-5.0
     - cmake
     - cmake-data
     - g++-5

--- a/example/example_unicode_utils.h
+++ b/example/example_unicode_utils.h
@@ -26,9 +26,9 @@ inline nanodbc::string convert(std::string const& in)
     nanodbc::string out;
 #if defined(__GNUC__) && __GNUC__ < 5
     std::vector<wchar_t> characters(in.length());
-    for (size_t i=0; i<in.length(); i++)
+    for (size_t i = 0; i < in.length(); i++)
         characters[i] = in[i];
-    const wchar_t * source = characters.data();
+    const wchar_t* source = characters.data();
     size_t size = wcsnrtombs(nullptr, &source, characters.size(), 0, nullptr);
     if (size == std::string::npos)
         throw std::range_error("UTF-16 -> UTF-8 conversion error");
@@ -57,10 +57,10 @@ inline std::string convert(nanodbc::string const& in)
     if (size == std::string::npos)
         throw std::range_error("UTF-8 -> UTF-16 conversion error");
     std::vector<wchar_t> characters(size);
-    const char * source = in.data();
+    const char* source = in.data();
     mbsnrtowcs(&characters[0], &source, in.length(), characters.size(), nullptr);
     out.resize(size);
-    for (size_t i=0; i<in.length(); i++)
+    for (size_t i = 0; i < in.length(); i++)
         out[i] = characters[i];
 #elif defined(_MSC_VER) && (_MSC_VER >= 1900)
     // Workaround for confirmed bug in VS2015 and VS2017 too

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -213,7 +213,6 @@ using nanodbc::wide_string;
 // MARK: Error Handling -
 // clang-format on
 
-
 namespace
 {
 #ifdef NANODBC_ODBC_API_DEBUG
@@ -254,7 +253,7 @@ inline bool success(RETCODE rc)
 using std::size;
 #else
 template <class T, std::size_t N>
-constexpr std::size_t size(const T(&array)[N]) noexcept
+constexpr std::size_t size(const T (&array)[N]) noexcept
 {
     return N;
 }
@@ -1820,7 +1819,7 @@ public:
             param_size,          // column size ignored for many types, but needed for strings
             param.scale_,        // decimal digits
             (SQLPOINTER)buffer.values_, // parameter value
-            value_size,          // buffer length
+            value_size,                 // buffer length
             bind_len_or_null_[param.index_].data());
 
         if (!success(rc))
@@ -2988,7 +2987,8 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
                             ValueLenOrInd / sizeof(wide_char_t),
                             (buffer_size / sizeof(wide_char_t)) - 1));
                 else if (ValueLenOrInd == SQL_NULL_DATA)
-                    col.cbdata_[static_cast<std::size_t>(rowset_position_)] = (SQLINTEGER)SQL_NULL_DATA;
+                    col.cbdata_[static_cast<std::size_t>(rowset_position_)] =
+                        (SQLINTEGER)SQL_NULL_DATA;
                 // Sequence of successful calls is:
                 // SQL_NO_DATA or SQL_SUCCESS_WITH_INFO followed by SQL_SUCCESS.
             } while (rc == SQL_SUCCESS_WITH_INFO);
@@ -3003,7 +3003,8 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
             // Type is unicode in the database, convert if necessary
             const SQLWCHAR* s =
                 reinterpret_cast<SQLWCHAR*>(col.pdata_ + rowset_position_ * col.clen_);
-            const string::size_type str_size = col.cbdata_[static_cast<size_t>(rowset_position_)] / sizeof(SQLWCHAR);
+            const string::size_type str_size =
+                col.cbdata_[static_cast<size_t>(rowset_position_)] / sizeof(SQLWCHAR);
             wide_string temp(s, s + str_size);
             convert(temp, result);
         }
@@ -3493,9 +3494,7 @@ connection::connection(const connection& rhs)
 }
 
 #ifndef NANODBC_NO_MOVE_CTOR
-connection::connection(connection&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_))
-{
-}
+connection::connection(connection&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_)) {}
 #endif
 
 connection& connection::operator=(connection rhs)
@@ -3520,9 +3519,7 @@ connection::connection(const string& connection_string, long timeout)
 {
 }
 
-connection::~connection() NANODBC_NOEXCEPT
-{
-}
+connection::~connection() NANODBC_NOEXCEPT {}
 
 void connection::connect(const string& dsn, const string& user, const string& pass, long timeout)
 {
@@ -3660,9 +3657,7 @@ transaction::transaction(const transaction& rhs)
 }
 
 #ifndef NANODBC_NO_MOVE_CTOR
-transaction::transaction(transaction&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_))
-{
-}
+transaction::transaction(transaction&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_)) {}
 #endif
 
 transaction& transaction::operator=(transaction rhs)
@@ -3677,9 +3672,7 @@ void transaction::swap(transaction& rhs) NANODBC_NOEXCEPT
     swap(impl_, rhs.impl_);
 }
 
-transaction::~transaction() NANODBC_NOEXCEPT
-{
-}
+transaction::~transaction() NANODBC_NOEXCEPT {}
 
 void transaction::commit()
 {
@@ -3739,9 +3732,7 @@ statement::statement(class connection& conn)
 }
 
 #ifndef NANODBC_NO_MOVE_CTOR
-statement::statement(statement&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_))
-{
-}
+statement::statement(statement&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_)) {}
 #endif
 
 statement::statement(class connection& conn, const string& query, long timeout)
@@ -3766,9 +3757,7 @@ void statement::swap(statement& rhs) NANODBC_NOEXCEPT
     swap(impl_, rhs.impl_);
 }
 
-statement::~statement() NANODBC_NOEXCEPT
-{
-}
+statement::~statement() NANODBC_NOEXCEPT {}
 
 void statement::open(class connection& conn)
 {
@@ -4581,9 +4570,7 @@ result::result()
 {
 }
 
-result::~result() NANODBC_NOEXCEPT
-{
-}
+result::~result() NANODBC_NOEXCEPT {}
 
 result::result(statement stmt, long rowset_size)
     : impl_(new result_impl(stmt, rowset_size))
@@ -4591,9 +4578,7 @@ result::result(statement stmt, long rowset_size)
 }
 
 #ifndef NANODBC_NO_MOVE_CTOR
-result::result(result&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_))
-{
-}
+result::result(result&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_)) {}
 #endif
 
 result::result(const result& rhs)

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -10,8 +10,8 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <sstream>
 #include <locale>
+#include <sstream>
 
 #if defined(_MSC_VER) && _MSC_VER <= 1800
 // These versions of Visual C++ do not yet support noexcept or override.
@@ -37,9 +37,9 @@
 #endif
 #include <windows.h>
 #endif
+#include <locale>
 #include <sql.h>
 #include <sqlext.h>
-#include <locale>
 
 namespace nanodbc
 {
@@ -120,18 +120,15 @@ inline nanodbc::string convert(std::string const& in)
 
 struct Config
 {
-    nanodbc::string get_connection_string() const
-    {
-        return convert(connection_string_);
-    }
+    nanodbc::string get_connection_string() const { return convert(connection_string_); }
 
     std::string connection_string_;
     std::string data_path_;
     std::string test_; // if set, itis test name, pattern or tags
     bool show_help_{false};
 };
-
-}} // namespace nanodbc::test
+}
+} // namespace nanodbc::test
 
 extern nanodbc::test::Config cfg;
 
@@ -358,7 +355,8 @@ struct base_test_fixture
         infile.open(filename);
         std::string buffer;
         infile >> buffer;
-        if (buffer.empty()) return {};
+        if (buffer.empty())
+            return {};
 
         auto beg = buffer.begin();
         while (*beg == ' ' || *beg == '\0')
@@ -381,7 +379,6 @@ struct base_test_fixture
 #undef NANODBC_SEP
     }
 
-
     nanodbc::string get_env(char const* var) const
     {
         char* env_value = nullptr;
@@ -401,7 +398,7 @@ struct base_test_fixture
         value = env_value;
 #endif
 #ifdef NANODBC_ENABLE_UNICODE
-		return nanodbc::test::convert(value);
+        return nanodbc::test::convert(value);
 #else
         return value;
 #endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -16,23 +16,18 @@ int main(int argc, char* argv[])
     try
     {
         // Specify custom command line options
-        auto cli
-            = Catch::clara::Help(cfg.show_help_)
-            | Catch::clara::Opt(cfg.connection_string_, "connection")
-                ["-z"]["--connection-string"]
-                ("connection string to test database; if not specified, "
+        auto cli =
+            Catch::clara::Help(cfg.show_help_) |
+            Catch::clara::Opt(cfg.connection_string_, "connection")["-z"]["--connection-string"](
+                "connection string to test database; if not specified, "
                 "an attempt will be made to read it from environment variables: "
-                 "NANODBC_TEST_CONNSTR or NANODBC_TEST_CONNSTR_<DB>")
-            | Catch::clara::Arg(cfg.test_, "test")
-                ("test name|pattern|tags to run");
+                "NANODBC_TEST_CONNSTR or NANODBC_TEST_CONNSTR_<DB>") |
+            Catch::clara::Arg(cfg.test_, "test")("test name|pattern|tags to run");
         auto parse_result = cli.parse(Catch::clara::Args(argc, argv));
         if (!parse_result)
         {
-            Catch::cerr()
-                << Catch::Colour(Catch::Colour::Red)
-                << "\nError(s) in input:\n"
-                << Catch::Column(parse_result.errorMessage()).indent(2)
-                << "\n\n";
+            Catch::cerr() << Catch::Colour(Catch::Colour::Red) << "\nError(s) in input:\n"
+                          << Catch::Column(parse_result.errorMessage()).indent(2) << "\n\n";
             Catch::cerr() << "Run with -? for usage\n" << std::endl;
             return EXIT_FAILURE;
         }
@@ -52,15 +47,13 @@ int main(int argc, char* argv[])
         {
             session.showHelp();
 
-            Catch::cerr()
-                << Catch::Colour(Catch::Colour::Yellow)
-                << "nanodbc\n"
-                << cli << std::endl;
+            Catch::cerr() << Catch::Colour(Catch::Colour::Yellow) << "nanodbc\n"
+                          << cli << std::endl;
 
             return EXIT_FAILURE;
         }
 
-        // Path to data folder with data files used in some tests
+            // Path to data folder with data files used in some tests
 #ifdef NANODBC_TEST_DATA
         if (cfg.data_path_.empty())
             cfg.data_path_ = std::string(NANODBC_TEST_DATA);
@@ -75,16 +68,11 @@ int main(int argc, char* argv[])
     }
     catch (std::exception const& e)
     {
-        Catch::cerr()
-            << Catch::Colour(Catch::Colour::Red)
-            << "\nError(s):\n"
-            << e.what() << '\n';
+        Catch::cerr() << Catch::Colour(Catch::Colour::Red) << "\nError(s):\n" << e.what() << '\n';
     }
     catch (...)
     {
-        Catch::cerr()
-            << Catch::Colour(Catch::Colour::Red)
-            << "\nError(s): uncaught exception\n";
+        Catch::cerr() << Catch::Colour(Catch::Colour::Red) << "\nError(s): uncaught exception\n";
     }
     return EXIT_FAILURE;
 }

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -152,10 +152,12 @@ TEST_CASE_METHOD(mssql_fixture, "test_large_blob", "[mssql][blob][binary][varbin
         blob = from_hex(hex);
     }
 
-    // Test executing prepared statement with size of blbo larger than max (eg. SQL Server 8000 Bytes)
+    // Test executing prepared statement with size of blbo larger than max (eg. SQL Server 8000
+    // Bytes)
     auto connection = connect();
     {
-        create_table(connection, NANODBC_TEXT("test_large_blob"), NANODBC_TEXT("(data varbinary(max))"));
+        create_table(
+            connection, NANODBC_TEXT("test_large_blob"), NANODBC_TEXT("(data varbinary(max))"));
         nanodbc::statement stmt(connection);
         prepare(stmt, NANODBC_TEXT("INSERT INTO test_large_blob (data) VALUES (?)"));
 
@@ -165,7 +167,10 @@ TEST_CASE_METHOD(mssql_fixture, "test_large_blob", "[mssql][blob][binary][varbin
     }
 }
 
-TEST_CASE_METHOD(mssql_fixture, "test_large_blob_geometry", "[mssql][blob][binary][varbinary][geometry]")
+TEST_CASE_METHOD(
+    mssql_fixture,
+    "test_large_blob_geometry",
+    "[mssql][blob][binary][varbinary][geometry]")
 {
     if (get_env("DB") == NANODBC_TEXT("MSSQL2008"))
     {
@@ -180,12 +185,17 @@ TEST_CASE_METHOD(mssql_fixture, "test_large_blob_geometry", "[mssql][blob][binar
         blob = from_hex(hex);
     }
 
-    // Test executing prepared statement with size of blbo larger than max (eg. SQL Server 8000 Bytes)
+    // Test executing prepared statement with size of blbo larger than max (eg. SQL Server 8000
+    // Bytes)
     auto connection = connect();
     {
-        create_table(connection, NANODBC_TEXT("test_large_blob_geometry"), NANODBC_TEXT("(data GEOMETRY)"));
+        create_table(
+            connection, NANODBC_TEXT("test_large_blob_geometry"), NANODBC_TEXT("(data GEOMETRY)"));
         nanodbc::statement stmt(connection);
-        prepare(stmt, NANODBC_TEXT("INSERT INTO test_large_blob_geometry (data) VALUES (geometry::STGeomFromWKB(?, 0))"));
+        prepare(
+            stmt,
+            NANODBC_TEXT("INSERT INTO test_large_blob_geometry (data) VALUES "
+                         "(geometry::STGeomFromWKB(?, 0))"));
 
         std::vector<std::vector<std::uint8_t>> rows = {blob};
         stmt.bind(0, rows);

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -305,8 +305,7 @@ struct test_case_fixture : public base_test_fixture
                     NANODBC_TEXT("c2 float NULL,") + NANODBC_TEXT("c3 decimal(9, 3),") +
                     NANODBC_TEXT("c4 date,") // seems more portable than datetime (SQL Server),
                                              // timestamp (PostgreSQL, MySQL)
-                    +
-                    NANODBC_TEXT("c5 varchar(60) DEFAULT \'sample value\',") +
+                    + NANODBC_TEXT("c5 varchar(60) DEFAULT \'sample value\',") +
                     NANODBC_TEXT("c6 varchar(120),") + NANODBC_TEXT("c7 ") + text_type_name +
                     NANODBC_TEXT(",") + NANODBC_TEXT("c8 ") + binary_type_name +
                     NANODBC_TEXT(");"));

--- a/utility/ci/travis/script.sh
+++ b/utility/ci/travis/script.sh
@@ -1,5 +1,24 @@
 #!/bin/bash -ue
 
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    chmod +x ./utility/format.sh
+    ./utility/format.sh
+
+    MSG="The following files have been modified:"
+    dirty=$(git ls-files --modified)
+
+    if [[ $dirty ]]; then
+        echo $MSG
+        echo $dirty
+        # TODO: Enable hard error on formating changes
+        #exit 1
+    fi
+fi
+
 if [[ -z ${BUILD_SHARED_LIBS+v} ]]; then
     export BUILD_SHARED_LIBS=OFF
 fi

--- a/utility/format.sh
+++ b/utility/format.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Source https://github.com/Project-OSRM/osrm-backend
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Runs the Clang Formatter in parallel on the code base.
+# Return codes:
+#  - 1 there are files to be formatted
+#  - 0 everything looks fine
+
+# Get CPU count
+OS=$(uname)
+NPROC=1
+if [[ $OS = "Linux" ]] ; then
+    NPROC=$(nproc)
+elif [[ ${OS} = "Darwin" ]] ; then
+    NPROC=$(sysctl -n hw.physicalcpu)
+fi
+
+# Discover clang-format
+if type clang-format-5.0 2> /dev/null ; then
+    CLANG_FORMAT=clang-format-5.0
+elif type clang-format 2> /dev/null ; then
+    # Clang format found, but need to check version
+    CLANG_FORMAT=clang-format
+    V=$(clang-format --version)
+    if [[ $V != *5.0* ]] ; then
+        echo "clang-format is not 5.0 (returned ${V})"
+        #exit 1
+    fi
+else
+    echo "No appropriate clang-format found (expected clang-format-5.0, or clang-format)"
+    exit 1
+fi
+
+find nanodbc test example -type f -name '*.h' -o -name '*.cpp' \
+  | xargs -I{} -P ${NPROC} ${CLANG_FORMAT} -i -style=file {}


### PR DESCRIPTION
## What does this PR do?

Configures Travis CI to run clang-format 5.0 prior the library build and tests run as early check for any errors in code formatting as specified in the current `.clang-format`.

## What are related issues/pull requests?

Closes #150

## Tasklist

 - [x] All CI builds and checks have passed