### PR TITLE
Handle SQLGetData retun value of SQL_NO_TOTAL

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2924,7 +2924,9 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
                     buffer,          // TargetValuePtr
                     buffer_size,     // BufferLength
                     &ValueLenOrInd); // StrLen_or_IndPtr
-                if (ValueLenOrInd > 0)
+                if (ValueLenOrInd == SQL_NO_TOTAL)
+                    out.append(buffer, col.ctype_ == SQL_C_BINARY ? buffer_size : buffer_size - 1);
+                else if (ValueLenOrInd > 0)
                     out.append(
                         buffer,
                         std::min<std::size_t>(
@@ -2980,7 +2982,9 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
                     buffer,          // TargetValuePtr
                     buffer_size,     // BufferLength
                     &ValueLenOrInd); // StrLen_or_IndPtr
-                if (ValueLenOrInd > 0)
+                if (ValueLenOrInd == SQL_NO_TOTAL)
+                    out.append(buffer, (buffer_size / sizeof(wide_char_t)) - 1);
+                else if (ValueLenOrInd > 0)
                     out.append(
                         buffer,
                         std::min<std::size_t>(
@@ -3261,7 +3265,7 @@ auto from_string(std::string const& s, R)
         throw std::range_error("from_string argument out of range");
     return static_cast<R>(integer);
 }
-}
+} // namespace detail
 
 template <typename R>
 auto from_string(std::string const& s) -> R

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1396,6 +1396,27 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(ref == name);
     }
 
+    void test_string_with_varchar_max()
+    {
+        nanodbc::connection connection = connect();
+        drop_table(connection, NANODBC_TEXT("test_string_with_varchar_max"));
+        execute(
+            connection,
+            NANODBC_TEXT("create table test_string_with_varchar_max (s varchar(max));"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_string_with_varchar_max(s) ")
+                NANODBC_TEXT("values (REPLICATE(CAST(\'a\' AS varchar(MAX)), 15000))"));
+
+        nanodbc::result results =
+            execute(connection, NANODBC_TEXT("select s from test_string_with_varchar_max;"));
+        REQUIRE(results.next());
+
+        nanodbc::string select;
+        results.get_ref(0, select);
+        REQUIRE(select.size() == 15000);
+    }
+
     void test_string_vector()
     {
         nanodbc::connection connection = connect();


### PR DESCRIPTION
## What does this PR do?

Fix truncated results for varchar(max) and nvarchar(max) fields.


Fix truncated results for `varchar(max)` and `nvarchar(max)` fields.
Add `test_string_with_varchar_max` and `test_string_with_nvarchar_max`
 - currently, run against SQL Server only
 - tested using `{ODBC Driver 17 for SQL Server}` and `{SQL Server Native Client 11.0}`
   unable to reproduce the `SQLGetData` retuning `SQL_NO_TOTAL`.
 - possibly, this is the Simba driver-specific behaviour on MacOS.

## What are related issues/pull requests?

Closes #160
/cc @jimhester 

## Tasklist

 - [x] Add test case(s)
 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed
