### PR TITLE
Catch up with breaking change in SQLite ODBC 0.9996

### DIFF
--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cassert>
 #include <fstream>
+#include <initializer_list>
 #include <iomanip>
 #include <iostream>
 #include <locale>
@@ -127,6 +128,44 @@ struct Config
     std::string test_; // if set, itis test name, pattern or tags
     bool show_help_{false};
 };
+
+// Custom matcher for Catch to use with REQUIRE_THAT(a, IsAnyOf({a, b, c}));
+class IntAnyOf : public Catch::MatcherBase<int>
+{
+    std::vector<int> m_values;
+
+public:
+    IntAnyOf(std::initializer_list<int> v)
+        : m_values(v)
+    {
+    }
+
+    // Performs the test for this matcher
+    virtual bool match(int const& i) const override
+    {
+        return std::any_of(m_values.begin(), m_values.end(), [&i](int v) { return v == i; });
+    }
+
+    // Produces a string describing what this matcher does. It should
+    // include any provided data (the begin/ end in this case) and
+    // be written as if it were stating a fact (in the output it will be
+    // preceded by the value under test).
+    virtual std::string describe() const
+    {
+        std::ostringstream ss;
+        ss << "is not member of values [";
+        for (auto& v : m_values)
+            ss << v << ',';
+        ss << ']';
+        return ss.str();
+    }
+};
+
+// The builder function
+inline IntAnyOf IsAnyOf(std::initializer_list<int> v)
+{
+    return IntAnyOf(std::move(v));
+}
 }
 } // namespace nanodbc::test
 

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -80,7 +80,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_affected_rows", "[sqlite][affected_rows]"
         // then DROP TABLE
         {
             auto result2 = execute(conn, NANODBC_TEXT("DROP TABLE nanodbc_test_temp_table"));
-            REQUIRE(result2.affected_rows() == 2);
+
+            // NOTE: Older SQLite ODBC seem to return value cached from previous executions.
+            //       Since SQLite ODBC 0.9996, this buggy behaviour has been fixed and
+            //       now SQLRowCount always returns 0 for any DLL statement.
+            REQUIRE_THAT(result2.affected_rows(), nanodbc::test::IsAnyOf({0, 2}));
         }
     }
 
@@ -91,7 +95,10 @@ TEST_CASE_METHOD(sqlite_fixture, "test_affected_rows", "[sqlite][affected_rows]"
         execute(conn, NANODBC_TEXT("INSERT INTO nanodbc_test_temp_table VALUES (2)"));
 
         auto result = execute(conn, NANODBC_TEXT("DROP TABLE nanodbc_test_temp_table"));
-        REQUIRE(result.affected_rows() == 1);
+        // NOTE: Older SQLite ODBC seem to return value cached from previous executions.
+        //       Since SQLite ODBC 0.9996, this buggy behaviour has been fixed and
+        //       now SQLRowCount always returns 0 for any DLL statement.
+        REQUIRE_THAT(result.affected_rows(), nanodbc::test::IsAnyOf({0, 1}));
     }
 }
 #endif


### PR DESCRIPTION
## What does this PR do?

Updates tests to accommodate the driver's SQLRowCount returning 0 for DDL, as per the ChangeLog at http://www.ch-werner.de/sqliteodbc/html/index.html

> Sat Feb 24 2018 version 0.9996 released
>   * fixes in handling DDL in SQLExecDirect() et.al.

## Tasklist

 - [ ] All CI builds and checks have passed

