### PR TITLE
Remove pre-C++11 workarounds for MSVC from VS2013 or earlier

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -418,7 +418,7 @@ type_incompatible_error::type_incompatible_error()
 {
 }
 
-const char* type_incompatible_error::what() const NANODBC_NOEXCEPT
+const char* type_incompatible_error::what() const noexcept
 {
     return std::runtime_error::what();
 }
@@ -428,7 +428,7 @@ null_access_error::null_access_error()
 {
 }
 
-const char* null_access_error::what() const NANODBC_NOEXCEPT
+const char* null_access_error::what() const noexcept
 {
     return std::runtime_error::what();
 }
@@ -438,7 +438,7 @@ index_range_error::index_range_error()
 {
 }
 
-const char* index_range_error::what() const NANODBC_NOEXCEPT
+const char* index_range_error::what() const noexcept
 {
     return std::runtime_error::what();
 }
@@ -448,7 +448,7 @@ programming_error::programming_error(const std::string& info)
 {
 }
 
-const char* programming_error::what() const NANODBC_NOEXCEPT
+const char* programming_error::what() const noexcept
 {
     return std::runtime_error::what();
 }
@@ -462,17 +462,17 @@ database_error::database_error(void* handle, short handle_type, const std::strin
               recent_error(handle, handle_type, native_error, sql_state);
 }
 
-const char* database_error::what() const NANODBC_NOEXCEPT
+const char* database_error::what() const noexcept
 {
     return message.c_str();
 }
 
-const long database_error::native() const NANODBC_NOEXCEPT
+const long database_error::native() const noexcept
 {
     return native_error;
 }
 
-const std::string database_error::state() const NANODBC_NOEXCEPT
+const std::string database_error::state() const noexcept
 {
     return sql_state;
 }
@@ -833,7 +833,7 @@ public:
         }
     }
 
-    ~connection_impl() NANODBC_NOEXCEPT
+    ~connection_impl() noexcept
     {
         try
         {
@@ -1153,7 +1153,7 @@ public:
         conn_.ref_transaction();
     }
 
-    ~transaction_impl() NANODBC_NOEXCEPT
+    ~transaction_impl() noexcept
     {
         if (!committed_)
         {
@@ -1192,7 +1192,7 @@ public:
         }
     }
 
-    void rollback() NANODBC_NOEXCEPT
+    void rollback() noexcept
     {
         if (committed_)
             return;
@@ -1281,7 +1281,7 @@ public:
         prepare(conn, query, timeout);
     }
 
-    ~statement_impl() NANODBC_NOEXCEPT
+    ~statement_impl() noexcept
     {
         if (open() && connected())
         {
@@ -1674,7 +1674,7 @@ public:
         return cols;
     }
 
-    void reset_parameters() NANODBC_NOEXCEPT { NANODBC_CALL(SQLFreeStmt, stmt_, SQL_RESET_PARAMS); }
+    void reset_parameters() noexcept { NANODBC_CALL(SQLFreeStmt, stmt_, SQL_RESET_PARAMS); }
 
     short parameters() const
     {
@@ -2207,7 +2207,7 @@ public:
         auto_bind();
     }
 
-    ~result_impl() NANODBC_NOEXCEPT { cleanup_bound_columns(); }
+    ~result_impl() noexcept { cleanup_bound_columns(); }
 
     void* native_statement_handle() const { return stmt_.native_statement_handle(); }
 
@@ -2215,7 +2215,7 @@ public:
 
     long affected_rows() const { return stmt_.affected_rows(); }
 
-    long rows() const NANODBC_NOEXCEPT
+    long rows() const noexcept
     {
         NANODBC_ASSERT(row_count_ <= static_cast<SQLULEN>(std::numeric_limits<long>::max()));
         return static_cast<long>(row_count_);
@@ -2322,7 +2322,7 @@ public:
         return static_cast<unsigned long>(pos) + rowset_position_;
     }
 
-    bool at_end() const NANODBC_NOEXCEPT
+    bool at_end() const noexcept
     {
         if (at_end_)
             return true;
@@ -2568,7 +2568,7 @@ private:
     template <class T, typename std::enable_if<is_character<T>::value, int>::type = 0>
     void get_ref_from_string_column(short column, T& result) const;
 
-    void before_move() NANODBC_NOEXCEPT
+    void before_move() noexcept
     {
         for (short i = 0; i < bound_columns_size_; ++i)
         {
@@ -2580,7 +2580,7 @@ private:
         }
     }
 
-    void release_bound_resources(short column) NANODBC_NOEXCEPT
+    void release_bound_resources(short column) noexcept
     {
         NANODBC_ASSERT(column < bound_columns_size_);
         bound_column& col = bound_columns_[column];
@@ -2589,7 +2589,7 @@ private:
         col.clen_ = 0;
     }
 
-    void cleanup_bound_columns() NANODBC_NOEXCEPT
+    void cleanup_bound_columns() noexcept
     {
         before_move();
         delete[] bound_columns_;
@@ -3493,9 +3493,10 @@ connection::connection(const connection& rhs)
 {
 }
 
-#ifndef NANODBC_NO_MOVE_CTOR
-connection::connection(connection&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_)) {}
-#endif
+connection::connection(connection&& rhs) noexcept
+    : impl_(std::move(rhs.impl_))
+{
+}
 
 connection& connection::operator=(connection rhs)
 {
@@ -3503,7 +3504,7 @@ connection& connection::operator=(connection rhs)
     return *this;
 }
 
-void connection::swap(connection& rhs) NANODBC_NOEXCEPT
+void connection::swap(connection& rhs) noexcept
 {
     using std::swap;
     swap(impl_, rhs.impl_);
@@ -3519,7 +3520,7 @@ connection::connection(const string& connection_string, long timeout)
 {
 }
 
-connection::~connection() NANODBC_NOEXCEPT {}
+connection::~connection() noexcept {}
 
 void connection::connect(const string& dsn, const string& user, const string& pass, long timeout)
 {
@@ -3656,9 +3657,10 @@ transaction::transaction(const transaction& rhs)
 {
 }
 
-#ifndef NANODBC_NO_MOVE_CTOR
-transaction::transaction(transaction&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_)) {}
-#endif
+transaction::transaction(transaction&& rhs) noexcept
+    : impl_(std::move(rhs.impl_))
+{
+}
 
 transaction& transaction::operator=(transaction rhs)
 {
@@ -3666,20 +3668,20 @@ transaction& transaction::operator=(transaction rhs)
     return *this;
 }
 
-void transaction::swap(transaction& rhs) NANODBC_NOEXCEPT
+void transaction::swap(transaction& rhs) noexcept
 {
     using std::swap;
     swap(impl_, rhs.impl_);
 }
 
-transaction::~transaction() NANODBC_NOEXCEPT {}
+transaction::~transaction() noexcept {}
 
 void transaction::commit()
 {
     impl_->commit();
 }
 
-void transaction::rollback() NANODBC_NOEXCEPT
+void transaction::rollback() noexcept
 {
     impl_->rollback();
 }
@@ -3731,9 +3733,10 @@ statement::statement(class connection& conn)
 {
 }
 
-#ifndef NANODBC_NO_MOVE_CTOR
-statement::statement(statement&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_)) {}
-#endif
+statement::statement(statement&& rhs) noexcept
+    : impl_(std::move(rhs.impl_))
+{
+}
 
 statement::statement(class connection& conn, const string& query, long timeout)
     : impl_(new statement_impl(conn, query, timeout))
@@ -3751,13 +3754,13 @@ statement& statement::operator=(statement rhs)
     return *this;
 }
 
-void statement::swap(statement& rhs) NANODBC_NOEXCEPT
+void statement::swap(statement& rhs) noexcept
 {
     using std::swap;
     swap(impl_, rhs.impl_);
 }
 
-statement::~statement() NANODBC_NOEXCEPT {}
+statement::~statement() noexcept {}
 
 void statement::open(class connection& conn)
 {
@@ -3913,7 +3916,7 @@ short statement::parameters() const
     return impl_->parameters();
 }
 
-void statement::reset_parameters() NANODBC_NOEXCEPT
+void statement::reset_parameters() noexcept
 {
     impl_->reset_parameters();
 }
@@ -4570,16 +4573,17 @@ result::result()
 {
 }
 
-result::~result() NANODBC_NOEXCEPT {}
+result::~result() noexcept {}
 
 result::result(statement stmt, long rowset_size)
     : impl_(new result_impl(stmt, rowset_size))
 {
 }
 
-#ifndef NANODBC_NO_MOVE_CTOR
-result::result(result&& rhs) NANODBC_NOEXCEPT : impl_(std::move(rhs.impl_)) {}
-#endif
+result::result(result&& rhs) noexcept
+    : impl_(std::move(rhs.impl_))
+{
+}
 
 result::result(const result& rhs)
     : impl_(rhs.impl_)
@@ -4592,7 +4596,7 @@ result& result::operator=(result rhs)
     return *this;
 }
 
-void result::swap(result& rhs) NANODBC_NOEXCEPT
+void result::swap(result& rhs) noexcept
 {
     using std::swap;
     swap(impl_, rhs.impl_);
@@ -4603,7 +4607,7 @@ void* result::native_statement_handle() const
     return impl_->native_statement_handle();
 }
 
-long result::rowset_size() const NANODBC_NOEXCEPT
+long result::rowset_size() const noexcept
 {
     return impl_->rowset_size();
 }
@@ -4613,7 +4617,7 @@ long result::affected_rows() const
     return impl_->affected_rows();
 }
 
-long result::rows() const NANODBC_NOEXCEPT
+long result::rows() const noexcept
 {
     return impl_->rows();
 }
@@ -4670,7 +4674,7 @@ unsigned long result::position() const
     return impl_->position();
 }
 
-bool result::at_end() const NANODBC_NOEXCEPT
+bool result::at_end() const noexcept
 {
     return impl_->at_end();
 }

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -200,14 +200,6 @@ typedef unspecified - type string;
 typedef unspecified - type null_type;
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER <= 1800
-// These versions of Visual C++ do not yet support \c noexcept or \c std::move.
-#define NANODBC_NOEXCEPT
-#define NANODBC_NO_MOVE_CTOR
-#else
-#define NANODBC_NOEXCEPT noexcept
-#endif
-
 #if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
 // [[deprecated]] is only available in C++14
 #define NANODBC_DEPRECATED [[deprecated]]
@@ -252,7 +244,7 @@ class type_incompatible_error : public std::runtime_error
 {
 public:
     type_incompatible_error();
-    const char* what() const NANODBC_NOEXCEPT;
+    const char* what() const noexcept;
 };
 
 /// \brief Accessed null data.
@@ -261,7 +253,7 @@ class null_access_error : public std::runtime_error
 {
 public:
     null_access_error();
-    const char* what() const NANODBC_NOEXCEPT;
+    const char* what() const noexcept;
 };
 
 /// \brief Index out of range.
@@ -270,7 +262,7 @@ class index_range_error : public std::runtime_error
 {
 public:
     index_range_error();
-    const char* what() const NANODBC_NOEXCEPT;
+    const char* what() const noexcept;
 };
 
 /// \brief Programming logic error.
@@ -279,7 +271,7 @@ class programming_error : public std::runtime_error
 {
 public:
     explicit programming_error(const std::string& info);
-    const char* what() const NANODBC_NOEXCEPT;
+    const char* what() const noexcept;
 };
 
 /// \brief General database error.
@@ -292,9 +284,9 @@ public:
     /// \param handle_type The native ODBC handle type code for the given handle.
     /// \param info Additional info that will be appended to the beginning of the error message.
     database_error(void* handle, short handle_type, const std::string& info = "");
-    const char* what() const NANODBC_NOEXCEPT;
-    const long native() const NANODBC_NOEXCEPT;
-    const std::string state() const NANODBC_NOEXCEPT;
+    const char* what() const noexcept;
+    const long native() const noexcept;
+    const std::string state() const noexcept;
 
 private:
     long native_error;
@@ -404,26 +396,24 @@ public:
     /// Copy constructor.
     transaction(const transaction& rhs);
 
-#ifndef NANODBC_NO_MOVE_CTOR
     /// Move constructor.
-    transaction(transaction&& rhs) NANODBC_NOEXCEPT;
-#endif
+    transaction(transaction&& rhs) noexcept;
 
     /// Assignment.
     transaction& operator=(transaction rhs);
 
     /// Member swap.
-    void swap(transaction& rhs) NANODBC_NOEXCEPT;
+    void swap(transaction& rhs) noexcept;
 
     /// \brief If this transaction has not been committed, will will rollback any modifying ops.
-    ~transaction() NANODBC_NOEXCEPT;
+    ~transaction() noexcept;
 
     /// \brief Commits transaction immediately.
     /// \throws database_error
     void commit();
 
     /// \brief Marks this transaction for rollback.
-    void rollback() NANODBC_NOEXCEPT;
+    void rollback() noexcept;
 
     /// Returns the connection object.
     class connection& connection();
@@ -491,20 +481,18 @@ public:
     /// \brief Copy constructor.
     statement(const statement& rhs);
 
-#ifndef NANODBC_NO_MOVE_CTOR
     /// \brief Move constructor.
-    statement(statement&& rhs) NANODBC_NOEXCEPT;
-#endif
+    statement(statement&& rhs) noexcept;
 
     /// \brief Assignment.
     statement& operator=(statement rhs);
 
     /// \brief Member swap.
-    void swap(statement& rhs) NANODBC_NOEXCEPT;
+    void swap(statement& rhs) noexcept;
 
     /// \brief Closes the statement.
     /// \see close()
-    ~statement() NANODBC_NOEXCEPT;
+    ~statement() noexcept;
 
     /// \brief Creates a statement for the given connection.
     /// \param conn The connection where the statement will be executed.
@@ -731,7 +719,7 @@ public:
     short columns() const;
 
     /// \brief Resets all currently bound parameters.
-    void reset_parameters() NANODBC_NOEXCEPT;
+    void reset_parameters() noexcept;
 
     /// \brief Returns the number of parameters in the statement.
     /// \throws database_error
@@ -1016,16 +1004,14 @@ public:
     /// Copy constructor.
     connection(const connection& rhs);
 
-#ifndef NANODBC_NO_MOVE_CTOR
     /// Move constructor.
-    connection(connection&& rhs) NANODBC_NOEXCEPT;
-#endif
+    connection(connection&& rhs) noexcept;
 
     /// Assignment.
     connection& operator=(connection rhs);
 
     /// Member swap.
-    void swap(connection&) NANODBC_NOEXCEPT;
+    void swap(connection&) noexcept;
 
     /// \brief Create new connection object and immediately connect to the given data source.
     ///
@@ -1054,7 +1040,7 @@ public:
     ///
     /// Will not throw even if disconnecting causes some kind of error and raises an exception.
     /// If you explicitly need to know if disconnect() succeeds, call it directly.
-    ~connection() NANODBC_NOEXCEPT;
+    ~connection() noexcept;
 
     /// \brief Connect to the given data source.
     /// \param dsn The name of the data source.
@@ -1203,34 +1189,32 @@ public:
     result();
 
     /// \brief Free result set.
-    ~result() NANODBC_NOEXCEPT;
+    ~result() noexcept;
 
     /// \brief Copy constructor.
     result(const result& rhs);
 
-#ifndef NANODBC_NO_MOVE_CTOR
     /// \brief Move constructor.
-    result(result&& rhs) NANODBC_NOEXCEPT;
-#endif
+    result(result&& rhs) noexcept;
 
     /// \brief Assignment.
     result& operator=(result rhs);
 
     /// \brief Member swap.
-    void swap(result& rhs) NANODBC_NOEXCEPT;
+    void swap(result& rhs) noexcept;
 
     /// \brief Returns the native ODBC statement handle.
     void* native_statement_handle() const;
 
     /// \brief The rowset size for this result set.
-    long rowset_size() const NANODBC_NOEXCEPT;
+    long rowset_size() const noexcept;
 
     /// \brief Number of affected rows by the request or -1 if the affected rows is not available.
     /// \throws database_error
     long affected_rows() const;
 
     /// \brief Rows in the current rowset or 0 if the number of rows is not available.
-    long rows() const NANODBC_NOEXCEPT;
+    long rows() const noexcept;
 
     /// \brief Returns the number of columns in a result set.
     /// \throws database_error
@@ -1283,7 +1267,7 @@ public:
     unsigned long position() const;
 
     /// \brief Returns true if there are no more results in the current result set.
-    bool at_end() const NANODBC_NOEXCEPT;
+    bool at_end() const noexcept;
 
     /// \brief Gets data from the given column of the current rowset.
     ///

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -14,15 +14,6 @@
 #include <locale>
 #include <sstream>
 
-#if defined(_MSC_VER) && _MSC_VER <= 1800
-// These versions of Visual C++ do not yet support noexcept or override.
-#define NANODBC_NOEXCEPT
-#define NANODBC_OVERRIDE
-#else
-#define NANODBC_NOEXCEPT noexcept
-#define NANODBC_OVERRIDE override
-#endif
-
 #ifdef NANODBC_ENABLE_BOOST
 #include <boost/locale/encoding_utf.hpp>
 #elif defined(__GNUC__) && __GNUC__ < 5
@@ -201,7 +192,7 @@ struct base_test_fixture
             data_path_ = nanodbc::test::convert(get_env("TEST_NANODBC_DATADIR"));
     }
 
-    virtual ~base_test_fixture() NANODBC_NOEXCEPT {}
+    virtual ~base_test_fixture() noexcept {}
 
     // Utilities
 

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -23,9 +23,9 @@ struct sqlite_fixture : public test_case_fixture
         sqlite_cleanup(); // in case prior test exited without proper cleanup
     }
 
-    virtual ~sqlite_fixture() NANODBC_NOEXCEPT { sqlite_cleanup(); }
+    virtual ~sqlite_fixture() noexcept { sqlite_cleanup(); }
 
-    void sqlite_cleanup() NANODBC_NOEXCEPT
+    void sqlite_cleanup() noexcept
     {
         int success = std::remove("nanodbc.db");
         (void)success;


### PR DESCRIPTION
## What does this PR do?

Replace the following with proper C++11 features:

- NANODBC_NO_MOVE_CTOR
- NANODBC_NOEXCEPT
- NANODBC_OVERRIDE

It does not drop or introduce any compiler support.
It just acknowledges current state of C++14 requirement.

## Tasklist

 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed