### PR TITLE
Report SQL_HANDLE_DBC error if statement::open fails to allocate handle

### DIFF
--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -722,6 +722,15 @@ TEST_CASE_METHOD(mssql_fixture, "test_datetimeoffset", "[mssql][datetime]")
     }
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_statement_with_empty_connection", "[mssql][statement]")
+{
+    nanodbc::connection c;
+    c.allocate();
+    nanodbc::statement s;
+    REQUIRE_THROWS_AS(s.open(c), nanodbc::database_error);
+    REQUIRE_THROWS_WITH(s.open(c), Catch::Contains("Connection"));
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_transaction", "[mssql][transaction]")
 {
     test_transaction();


### PR DESCRIPTION
## What does this PR do?

`statement::open` attempts to capture a meaningful error from `SQL_HANDLE_DBC`, if called with non-open or empty connection (see #177).

Avoid access violation when copying `sql_state` when recent_error is called for handle without any present error state.

Note, `size(SQLCHAR array[N])` template overload returns strlen-like length, not `N`. If called with null-only or uninitialized `sql_state`, it returns invalid or overflown value, leading to access errors.

## What are related issues/pull requests?

#177 

## Tasklist

 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed
