### PR TITLE
Add public macro NANODBC_THROW_NO_SOURCE_LOCATION

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -482,9 +482,14 @@ const std::string database_error::state() const noexcept
 
 // Throwing exceptions using NANODBC_THROW_DATABASE_ERROR enables file name
 // and line numbers to be inserted into the error message. Useful for debugging.
+#ifdef NANODBC_THROW_NO_SOURCE_LOCATION
+#define NANODBC_THROW_DATABASE_ERROR(handle, handle_type)                                          \
+    throw nanodbc::database_error(handle, handle_type, "ODBC database error: ") /**/
+#else
 #define NANODBC_THROW_DATABASE_ERROR(handle, handle_type)                                          \
     throw nanodbc::database_error(                                                                 \
         handle, handle_type, __FILE__ ":" NANODBC_STRINGIZE(__LINE__) ": ") /**/
+#endif
 
 // clang-format off
 // 8888888b.           888             d8b 888

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -113,11 +113,18 @@ namespace nanodbc
 // clang-format on
 
 /// \addtogroup macros Macros
-/// \brief Macros that nanodbc uses, can be overriden by users.
+/// \brief Configuration and utility macros that nanodbc uses, can be overriden by users.
 ///
 /// @{
-
 #ifdef DOXYGEN
+
+/// \def NANODBC_THROW_NO_SOURCE_LOCATION
+/// \brief Configures \c nanodbc::database_error message
+///
+/// If defined, removes source file name and line number from \c nanodbc::database_error message
+/// By default, nanodbc includes source location of exception in the error message.
+#define NANODBC_THROW_NO_SOURCE_LOCATION 1
+
 /// \def NANODBC_ASSERT(expression)
 /// \brief Assertion.
 ///
@@ -133,8 +140,8 @@ namespace nanodbc
 /// #endif
 /// \endcode
 #define NANODBC_ASSERT(expression) assert(expression)
-#endif
 
+#endif
 /// @}
 
 // You must explicitly request Unicode support by defining NANODBC_ENABLE_UNICODE at compile time.


### PR DESCRIPTION
## What does this PR do?

User can defined `NANODBC_THROW_NO_SOURCE_LOCATION` to remove
source location from exception messages.

## What are related issues/pull requests?

Closes #183

## Tasklist

 - [x] Review (accepted via https://github.com/nanodbc/nanodbc/issues/183#issuecomment-403063015)
 - [x] All CI builds and checks have passed
