### PR TITLE
[AppVeyor] Switch to MinGW 6.3.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -109,9 +109,9 @@ install:
   - ps: |
       if ($env:G -Match "MinGW") {
         if ($env:P -Match "x86-32") {
-          $env:Path += ";C:\MinGW\bin"
+          $env:Path += ";C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin"
         } else {
-          $env:Path += ";C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin"
+          $env:Path += ";C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin"
         }
         g++ --version
       }


### PR DESCRIPTION
## What does this PR do?

It seems we have been using incorrect MinGW for x64-32 build, that is dwarf instead of seh. The former does not support Windows 64-bit apps as per https://sourceforge.net/p/mingw-w64/wiki2/Exception%20Handling/

## Tasklist

 - [x] All CI builds and checks have passed

## Environment

* OS and Compiler: Windows, MinGW-w64 (GCC 6.3.0)
