### PR TITLE
Do not set SQL_LOGIN_TIMEOUT when timeout == 0

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -953,12 +953,18 @@ public:
         allocate_dbc_handle(dbc_, env_);
 
         RETCODE rc;
-        if (timeout != 0) {
+        if (timeout != 0)
+        {
             // Avoid to set the timeout to 0 (no timeout).
             // This is a workaround for the Oracle ODBC Driver (11.1), as this
             // operation is not supported by the Driver.
             NANODBC_CALL_RC(
-                SQLSetConnectAttr, rc, dbc_, SQL_LOGIN_TIMEOUT, (SQLPOINTER)(std::intptr_t)timeout, 0);
+                SQLSetConnectAttr,
+                rc,
+                dbc_,
+                SQL_LOGIN_TIMEOUT,
+                (SQLPOINTER)(std::intptr_t)timeout,
+                0);
             if (!success(rc))
                 NANODBC_THROW_DATABASE_ERROR(dbc_, SQL_HANDLE_DBC);
         }
@@ -996,12 +1002,18 @@ public:
         allocate_dbc_handle(dbc_, env_);
 
         RETCODE rc;
-        if (timeout != 0) {
+        if (timeout != 0)
+        {
             // Avoid to set the timeout to 0 (no timeout).
             // This is a workaround for the Oracle ODBC Driver (11.1), as this
             // operation is not supported by the Driver.
             NANODBC_CALL_RC(
-                SQLSetConnectAttr, rc, dbc_, SQL_LOGIN_TIMEOUT, (SQLPOINTER)(std::intptr_t)timeout, 0);
+                SQLSetConnectAttr,
+                rc,
+                dbc_,
+                SQL_LOGIN_TIMEOUT,
+                (SQLPOINTER)(std::intptr_t)timeout,
+                0);
             if (!success(rc))
                 NANODBC_THROW_DATABASE_ERROR(dbc_, SQL_HANDLE_DBC);
         }

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -953,10 +953,15 @@ public:
         allocate_dbc_handle(dbc_, env_);
 
         RETCODE rc;
-        NANODBC_CALL_RC(
-            SQLSetConnectAttr, rc, dbc_, SQL_LOGIN_TIMEOUT, (SQLPOINTER)(std::intptr_t)timeout, 0);
-        if (!success(rc))
-            NANODBC_THROW_DATABASE_ERROR(dbc_, SQL_HANDLE_DBC);
+        if (timeout != 0) {
+            // Avoid to set the timeout to 0 (no timeout).
+            // This is a workaround for the Oracle ODBC Driver (11.1), as this
+            // operation is not supported by the Driver.
+            NANODBC_CALL_RC(
+                SQLSetConnectAttr, rc, dbc_, SQL_LOGIN_TIMEOUT, (SQLPOINTER)(std::intptr_t)timeout, 0);
+            if (!success(rc))
+                NANODBC_THROW_DATABASE_ERROR(dbc_, SQL_HANDLE_DBC);
+        }
 
 #if !defined(NANODBC_DISABLE_ASYNC) && defined(SQL_ATTR_ASYNC_DBC_EVENT)
         if (event_handle != nullptr)
@@ -991,10 +996,15 @@ public:
         allocate_dbc_handle(dbc_, env_);
 
         RETCODE rc;
-        NANODBC_CALL_RC(
-            SQLSetConnectAttr, rc, dbc_, SQL_LOGIN_TIMEOUT, (SQLPOINTER)(std::intptr_t)timeout, 0);
-        if (!success(rc))
-            NANODBC_THROW_DATABASE_ERROR(dbc_, SQL_HANDLE_DBC);
+        if (timeout != 0) {
+            // Avoid to set the timeout to 0 (no timeout).
+            // This is a workaround for the Oracle ODBC Driver (11.1), as this
+            // operation is not supported by the Driver.
+            NANODBC_CALL_RC(
+                SQLSetConnectAttr, rc, dbc_, SQL_LOGIN_TIMEOUT, (SQLPOINTER)(std::intptr_t)timeout, 0);
+            if (!success(rc))
+                NANODBC_THROW_DATABASE_ERROR(dbc_, SQL_HANDLE_DBC);
+        }
 
 #if !defined(NANODBC_DISABLE_ASYNC) && defined(SQL_ATTR_ASYNC_DBC_EVENT)
         if (event_handle != nullptr)


### PR DESCRIPTION
This allows to use the Oracle ODBC Driver 11.1 as SQL_LOGIN_TIMEOUT  is not supported by the driver.
More info: https://github.com/nanodbc/nanodbc/issues/190

