### PR TITLE
Resolve narrowing from wchar_t -> char warning in VS 2017 updates

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -410,8 +410,13 @@ recent_error(SQLHANDLE handle, SQLSMALLINT handle_type, long& native, std::strin
     } while (rc != SQL_NO_DATA);
 
     convert(std::move(result), rvalue);
-    if (size(sql_state) > 0)
-        state = std::string(&sql_state[0], &sql_state[size(sql_state) - 1]);
+    if (size(sql_state) > 0) {
+        state.clear();
+        for (int idx = 0; idx != size(sql_state) - 1; ++idx) {
+            state.push_back(static_cast<char>(sql_state[idx]));
+        }
+    }
+
     native = native_error;
     std::string status = state;
     status += ": ";


### PR DESCRIPTION
## What does this PR do?

Fixes compiler warning in recent VS 2017 updates

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* DBMS name/version:
* ODBC connection string:
* OS and Compiler:
