### PR TITLE
Remove non-standard constant SQL_NVARCHAR

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -89,10 +89,6 @@
 #define SQL_SS_UDT (-151) // from sqlncli.h
 #endif
 
-#ifndef SQL_NVARCHAR
-#define SQL_NVARCHAR (-10)
-#endif
-
 // SQL_SS_LENGTH_UNLIMITED is used to describe the max length of
 // VARCHAR(max), VARBINARY(max), NVARCHAR(max), and XML columns
 #ifndef SQL_SS_LENGTH_UNLIMITED
@@ -2810,7 +2806,6 @@ private:
                 break;
             case SQL_CHAR:
             case SQL_VARCHAR:
-            case SQL_NVARCHAR:
                 col.ctype_ = sql_ctype<std::string>::value;
                 col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLCHAR);
                 if (is_blob)


### PR DESCRIPTION
## What does this PR do?

Clear use of the non-standard type constant:

- It is NOT a standard type defined in the ODBC Specification
- It was defined locally as `SQL_NVARCHAR(-10)`
- The same identifier value is reserved used by the ODBC standard
  for `SQL_WLONGVARCHAR(-10)`
- https://github.com/Microsoft/ODBC-Specification/blob/master/Windows/inc/sqlucode.h

It seems to be a vendor-specific type defined by systems like
- [HDBSQL and JDBC](http://hsqldb.org/doc/guide/guide.html)
- [OpenLink Virtuoso](http://docs.openlinksw.com/virtuoso/utf8notes4odbc/)
- [Open Database Transport Protocol](http://odbtp.sourceforge.net/)

## What are related issues/pull requests?

- Blocking #211

## Tasklist

 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed
       - Allow AppVeyor failure due to SQLite driver download issues
