### PR TITLE
Add support for SQL_WLONGVARCHAR data type

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2834,6 +2834,11 @@ private:
                 col.blob_ = true;
                 col.clen_ = 0;
                 break;
+            case SQL_WLONGVARCHAR:
+                col.ctype_ = sql_ctype<wide_string>::value;
+                col.blob_ = true;
+                col.clen_ = 0;
+                break;
             case SQL_BINARY:
             case SQL_VARBINARY:
             case SQL_LONGVARBINARY:

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -521,8 +521,7 @@ TEST_CASE_METHOD(mssql_fixture, "test_string_with_ntext", "[mssql][string][ntext
 {
     nanodbc::connection connection = connect();
     drop_table(connection, NANODBC_TEXT("test_string_with_ntext"));
-    execute(
-        connection, NANODBC_TEXT("create table test_string_with_ntext (s ntext);"));
+    execute(connection, NANODBC_TEXT("create table test_string_with_ntext (s ntext);"));
     execute(
         connection,
         NANODBC_TEXT("insert into test_string_with_ntext(s) ")
@@ -541,8 +540,7 @@ TEST_CASE_METHOD(mssql_fixture, "test_string_with_text", "[mssql][string][text]"
 {
     nanodbc::connection connection = connect();
     drop_table(connection, NANODBC_TEXT("test_string_with_text"));
-    execute(
-        connection, NANODBC_TEXT("create table test_string_with_text (s text);"));
+    execute(connection, NANODBC_TEXT("create table test_string_with_text (s text);"));
     execute(
         connection,
         NANODBC_TEXT("insert into test_string_with_text(s) ")

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -517,6 +517,46 @@ TEST_CASE_METHOD(mssql_fixture, "test_string_with_varchar_max", "[mssql][string]
     test_string_with_varchar_max();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_string_with_ntext", "[mssql][string][ntext]")
+{
+    nanodbc::connection connection = connect();
+    drop_table(connection, NANODBC_TEXT("test_string_with_ntext"));
+    execute(
+        connection, NANODBC_TEXT("create table test_string_with_ntext (s ntext);"));
+    execute(
+        connection,
+        NANODBC_TEXT("insert into test_string_with_ntext(s) ")
+            NANODBC_TEXT("values (REPLICATE(CAST(\'a\' AS nvarchar(MAX)), 15000))"));
+
+    nanodbc::result results =
+        execute(connection, NANODBC_TEXT("select s from test_string_with_ntext;"));
+    REQUIRE(results.next());
+
+    nanodbc::string select;
+    results.get_ref(0, select);
+    REQUIRE(select.size() == 15000);
+}
+
+TEST_CASE_METHOD(mssql_fixture, "test_string_with_text", "[mssql][string][text]")
+{
+    nanodbc::connection connection = connect();
+    drop_table(connection, NANODBC_TEXT("test_string_with_text"));
+    execute(
+        connection, NANODBC_TEXT("create table test_string_with_text (s text);"));
+    execute(
+        connection,
+        NANODBC_TEXT("insert into test_string_with_text(s) ")
+            NANODBC_TEXT("values (REPLICATE(CAST(\'a\' AS varchar(MAX)), 15000))"));
+
+    nanodbc::result results =
+        execute(connection, NANODBC_TEXT("select s from test_string_with_text;"));
+    REQUIRE(results.next());
+
+    nanodbc::string select;
+    results.get_ref(0, select);
+    REQUIRE(select.size() == 15000);
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_string_vector", "[mssql][string]")
 {
     test_string_vector();


### PR DESCRIPTION
## What does this PR do?

SQL Server, for example, reports
- `NTEXT` as `SQL_WLONGVARCHAR`
- `TEXT` as `SQL_LONGVARCHAR`

Formerly, [SQL_WLONGVARCHAR(-10)](https://github.com/Microsoft/ODBC-Specification/blob/master/Windows/inc/sqlucode.h) column was only recognised by accident due to defined non-standard `SQL_NVARCHAR(-10)` constant but the implementation was broken:
- `SQLDescribeCol` returns the column size of 1073741824 characters
- The column was not recognised as large variable-length object
- The column was also incorrectly recognised as `SQLCHAR`-based data
- Binding would attempt to pre-allocate large buffer of size
  `sizeof(SQLCHAR) * 1073741824`

Removal of the non-standard `SQL_NVARCHAR` proposed in #210 - a requirement of this changeset.

## What are related issues/pull requests?

- Blocked by #210 

## Tasklist

 - [x] Add test case(s)
 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed
         - Travis failures are not related to this change, but to Ubuntu package repositories setup, e.g. https://travis-ci.org/nanodbc/nanodbc/builds/502526541
