### PR TITLE
Add describe_parameters function as alternative to SQLDescribeParam

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2048,9 +2048,8 @@ public:
         const std::vector<short>& scale)
     {
 
-        NANODBC_ASSERT(idx.size() == type.size());
-        NANODBC_ASSERT(idx.size() == size.size());
-        NANODBC_ASSERT(idx.size() == scale.size());
+        if (idx.size() != type.size() || idx.size() != size.size() || idx.size() != scale.size())
+            throw programming_error("parameter description arrays are of different size");
 
         for (std::size_t i = 0; i < idx.size(); ++i)
         {

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2041,7 +2041,7 @@ public:
             NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
     }
 
-    void set_param_descr(
+    void describe_parameters(
         const std::vector<short>& idx,
         const std::vector<short>& type,
         const std::vector<unsigned long>& size,
@@ -4202,13 +4202,13 @@ void statement::bind_null(short param_index, std::size_t batch_size)
     impl_->bind_null(param_index, batch_size);
 }
 
-void statement::set_param_descr(
+void statement::describe_parameters(
     const std::vector<short>& idx,
     const std::vector<short>& type,
     const std::vector<unsigned long>& size,
     const std::vector<short>& scale)
 {
-    impl_->set_param_descr(idx, type, size, scale);
+    impl_->describe_parameters(idx, type, size, scale);
 }
 
 } // namespace nanodbc

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1746,7 +1746,8 @@ public:
         return cols;
     }
 
-    void reset_parameters() noexcept {
+    void reset_parameters() noexcept
+    {
         param_descr_data_.clear();
         NANODBC_CALL(SQLFreeStmt, stmt_, SQL_RESET_PARAMS);
     }
@@ -2051,14 +2052,14 @@ public:
         NANODBC_ASSERT(idx.size() == size.size());
         NANODBC_ASSERT(idx.size() == scale.size());
 
-        for (std::size_t i = 0; i < idx.size(); ++i) {
+        for (std::size_t i = 0; i < idx.size(); ++i)
+        {
             param_descr_data_[idx[i]].type_ = static_cast<SQLSMALLINT>(type[i]);
             param_descr_data_[idx[i]].size_ = static_cast<SQLULEN>(size[i]);
             param_descr_data_[idx[i]].scale_ = static_cast<SQLSMALLINT>(scale[i]);
             param_descr_data_[idx[i]].index_ = static_cast<SQLUSMALLINT>(i);
             param_descr_data_[idx[i]].iotype_ = PARAM_IN; // not used
         }
-
     }
 
     // comparator for null sentry values

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1746,7 +1746,10 @@ public:
         return cols;
     }
 
-    void reset_parameters() noexcept { NANODBC_CALL(SQLFreeStmt, stmt_, SQL_RESET_PARAMS); }
+    void reset_parameters() noexcept {
+        param_descr_data_.clear();
+        NANODBC_CALL(SQLFreeStmt, stmt_, SQL_RESET_PARAMS);
+    }
 
     short parameters() const
     {
@@ -1825,19 +1828,28 @@ public:
         disable_async();
 #endif
 
-        RETCODE rc;
-        SQLSMALLINT nullable; // unused
-        NANODBC_CALL_RC(
-            SQLDescribeParam,
-            rc,
-            stmt_,
-            param_index + 1,
-            &param.type_,
-            &param.size_,
-            &param.scale_,
-            &nullable);
-        if (!success(rc))
-            NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
+        if (!param_descr_data_.count(param_index))
+        {
+            RETCODE rc;
+            SQLSMALLINT nullable; // unused
+            NANODBC_CALL_RC(
+                SQLDescribeParam,
+                rc,
+                stmt_,
+                param_index + 1,
+                &param.type_,
+                &param.size_,
+                &param.scale_,
+                &nullable);
+            if (!success(rc))
+                NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
+        }
+        else
+        {
+            param.type_ = param_descr_data_[param_index].type_;
+            param.size_ = param_descr_data_[param_index].size_;
+            param.scale_ = param_descr_data_[param_index].scale_;
+        }
 
         param.index_ = param_index;
         param.iotype_ = param_type_from_direction(direction);
@@ -2028,6 +2040,27 @@ public:
             NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
     }
 
+    void set_param_descr(
+        const std::vector<short>& idx,
+        const std::vector<short>& type,
+        const std::vector<unsigned long>& size,
+        const std::vector<short>& scale)
+    {
+
+        NANODBC_ASSERT(idx.size() == type.size());
+        NANODBC_ASSERT(idx.size() == size.size());
+        NANODBC_ASSERT(idx.size() == scale.size());
+
+        for (std::size_t i = 0; i < idx.size(); ++i) {
+            param_descr_data_[idx[i]].type_ = static_cast<SQLSMALLINT>(type[i]);
+            param_descr_data_[idx[i]].size_ = static_cast<SQLULEN>(size[i]);
+            param_descr_data_[idx[i]].scale_ = static_cast<SQLSMALLINT>(scale[i]);
+            param_descr_data_[idx[i]].index_ = static_cast<SQLUSMALLINT>(i);
+            param_descr_data_[idx[i]].iotype_ = PARAM_IN; // not used
+        }
+
+    }
+
     // comparator for null sentry values
     template <class T>
     bool equals(const T& lhs, const T& rhs)
@@ -2046,6 +2079,7 @@ private:
     std::map<short, std::vector<wide_string::value_type>> wide_string_data_;
     std::map<short, std::vector<std::string::value_type>> string_data_;
     std::map<short, std::vector<uint8_t>> binary_data_;
+    std::map<short, bound_parameter> param_descr_data_;
 
 #if defined(NANODBC_DO_ASYNC_IMPL)
     bool async_;                 // true if statement is currently in SQL_STILL_EXECUTING mode
@@ -4165,6 +4199,15 @@ void statement::bind_strings(
 void statement::bind_null(short param_index, std::size_t batch_size)
 {
     impl_->bind_null(param_index, batch_size);
+}
+
+void statement::set_param_descr(
+    const std::vector<short>& idx,
+    const std::vector<short>& type,
+    const std::vector<unsigned long>& size,
+    const std::vector<short>& scale)
+{
+    impl_->set_param_descr(idx, type, size, scale);
 }
 
 } // namespace nanodbc

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -994,6 +994,7 @@ public:
     /// \param type Vector of (short integer) types.
     /// \param size Vector of (unsigned long) sizes.
     /// \param scale Vector of (short integer) decimal precision / scale.
+    /// \throws programming_error
     void describe_parameters(
         const std::vector<short>& idx,
         const std::vector<short>& type,

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1000,7 +1000,6 @@ public:
         const std::vector<unsigned long>& size,
         const std::vector<short>& scale);
 
-
     /// @}
 private:
     typedef std::function<bool(std::size_t)> null_predicate_type;

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -994,7 +994,7 @@ public:
     /// \param type Vector of (short integer) types.
     /// \param size Vector of (unsigned long) sizes.
     /// \param scale Vector of (short integer) decimal precision / scale.
-    void set_param_descr(
+    void describe_parameters(
         const std::vector<short>& idx,
         const std::vector<short>& type,
         const std::vector<unsigned long>& size,

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -978,6 +978,30 @@ public:
 
     /// @}
 
+    /// \brief Sets descriptions for parameters in the prepared statement.
+    ///
+    /// If your prepared SQL query has any parameter markers, ? (question  mark)
+    /// placeholders this is how you can describe the SQL type, size and scale
+    /// for some or all of the parameters, prior to binding any data to the
+    /// parameters.  Calling this method is optional: if a parameter is not
+    /// described using a call to this method, then during a bind an attempt is
+    /// made to identify it using a call to the ODBC SQLDescribeParam API handle.
+    /// Once set, description is re-used for possibly repeated binds
+    /// execution and only cleared when the statement is cleared / destroyed.
+    /// Parameter markers are numbered using Zero-based index from left to right.
+    ///
+    /// \param idx Vector of zero-based indices of parameters we are describing.
+    /// \param type Vector of (short integer) types.
+    /// \param size Vector of (unsigned long) sizes.
+    /// \param scale Vector of (short integer) decimal precision / scale.
+    void set_param_descr(
+        const std::vector<short>& idx,
+        const std::vector<short>& type,
+        const std::vector<unsigned long>& size,
+        const std::vector<short>& scale);
+
+
+    /// @}
 private:
     typedef std::function<bool(std::size_t)> null_predicate_type;
 

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -114,6 +114,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_batch_insert_mixed", "[mssql][batch]")
     test_batch_insert_mixed();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_batch_insert_param_type_set", "[mssql][batch][param_type]")
+{
+    test_batch_insert_param_type_set();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_blob", "[mssql][blob][binary][varbinary]")
 {
     nanodbc::connection connection = connect();

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -114,9 +114,12 @@ TEST_CASE_METHOD(mssql_fixture, "test_batch_insert_mixed", "[mssql][batch]")
     test_batch_insert_mixed();
 }
 
-TEST_CASE_METHOD(mssql_fixture, "test_batch_insert_param_type_set", "[mssql][batch][param_type]")
+TEST_CASE_METHOD(
+    mssql_fixture,
+    "test_batch_insert_describe_param",
+    "[mssql][batch][describe_param]")
 {
-    test_batch_insert_param_type_set();
+    test_batch_insert_describe_param();
 }
 
 TEST_CASE_METHOD(mssql_fixture, "test_blob", "[mssql][blob][binary][varbinary]")

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1711,7 +1711,8 @@ struct test_case_fixture : public base_test_fixture
         std::size_t const batch_size = 9;
         int integers[batch_size] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
         float floats[batch_size] = {1.123f, 2.345f, 3.1f, 4.5f, 5.678f, 6.f, 7.89f, 8.90f, 9.1234f};
-        std::string trunc_float[batch_size] = {"1.100", "2.300", "3.100", "4.500", "5.700", "6.000", "7.900", "8.900", "9.100"};
+        std::string trunc_float[batch_size] = {
+            "1.100", "2.300", "3.100", "4.500", "5.700", "6.000", "7.900", "8.900", "9.100"};
         nanodbc::string::value_type strings[batch_size][60] = {
             NANODBC_TEXT("first string"),
             NANODBC_TEXT("second string"),
@@ -1728,7 +1729,8 @@ struct test_case_fixture : public base_test_fixture
             conn,
             NANODBC_TEXT("test_batch_insert_param_type"),
             NANODBC_TEXT("(i int, s varchar(60), f float, d decimal(9, 3))"));
-        nanodbc::string insert(NANODBC_TEXT("insert into test_batch_insert_param_type (i, s, f, d) values(?, ?, ?, ?)"));
+        nanodbc::string insert(NANODBC_TEXT(
+            "insert into test_batch_insert_param_type (i, s, f, d) values(?, ?, ?, ?)"));
         nanodbc::statement stmt(conn);
         prepare(stmt, insert);
 
@@ -1738,7 +1740,7 @@ struct test_case_fixture : public base_test_fixture
         std::vector<short> idx{1, 3};
         std::vector<short> type{12, 3};
         std::vector<unsigned long> size{60, 9};
-        std::vector<short> scale{0, 1}; //round to one decimal
+        std::vector<short> scale{0, 1}; // round to one decimal
         stmt.set_param_descr(idx, type, size, scale);
 
         stmt.bind(0, integers, batch_size);
@@ -1755,8 +1757,7 @@ struct test_case_fixture : public base_test_fixture
             {
                 REQUIRE(result.get<int>(0) == integers[i]);
                 REQUIRE(
-                    result.get<float>(1) ==
-                    floats[i]); // exact test might fail, switch to Approx
+                    result.get<float>(1) == floats[i]); // exact test might fail, switch to Approx
                 REQUIRE(result.get<nanodbc::string>(2) == strings[i]);
                 REQUIRE(result.get<nanodbc::string>(3) == NANODBC_TEXT(trunc_float[i]));
                 ++i;

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1759,7 +1759,7 @@ struct test_case_fixture : public base_test_fixture
                 REQUIRE(
                     result.get<float>(1) == floats[i]); // exact test might fail, switch to Approx
                 REQUIRE(result.get<nanodbc::string>(2) == strings[i]);
-                REQUIRE(result.get<nanodbc::string>(3) == NANODBC_TEXT(trunc_float[i]));
+                REQUIRE(result.get<nanodbc::string>(3) == trunc_float[i]);
                 ++i;
             }
             REQUIRE(i == batch_size);

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1711,8 +1711,15 @@ struct test_case_fixture : public base_test_fixture
         std::size_t const batch_size = 9;
         int integers[batch_size] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
         float floats[batch_size] = {1.123f, 2.345f, 3.1f, 4.5f, 5.678f, 6.f, 7.89f, 8.90f, 9.1234f};
-        std::string trunc_float[batch_size] = {
-            "1.100", "2.300", "3.100", "4.500", "5.700", "6.000", "7.900", "8.900", "9.100"};
+        nanodbc::string::value_type trunc_float[batch_size][6] = {NANODBC_TEXT("1.100"),
+                                                                  NANODBC_TEXT("2.300"),
+                                                                  NANODBC_TEXT("3.100"),
+                                                                  NANODBC_TEXT("4.500"),
+                                                                  NANODBC_TEXT("5.700"),
+                                                                  NANODBC_TEXT("6.000"),
+                                                                  NANODBC_TEXT("7.900"),
+                                                                  NANODBC_TEXT("8.900"),
+                                                                  NANODBC_TEXT("9.100")};
         nanodbc::string::value_type strings[batch_size][60] = {
             NANODBC_TEXT("first string"),
             NANODBC_TEXT("second string"),

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1706,7 +1706,7 @@ struct test_case_fixture : public base_test_fixture
         }
     }
 
-    void test_batch_insert_param_type_set()
+    void test_batch_insert_describe_param()
     {
         std::size_t const batch_size = 9;
         int integers[batch_size] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -1748,7 +1748,7 @@ struct test_case_fixture : public base_test_fixture
         std::vector<short> type{12, 3};
         std::vector<unsigned long> size{60, 9};
         std::vector<short> scale{0, 1}; // round to one decimal
-        stmt.set_param_descr(idx, type, size, scale);
+        stmt.describe_parameters(idx, type, size, scale);
 
         stmt.bind(0, integers, batch_size);
         stmt.bind_strings(1, strings);


### PR DESCRIPTION
Hi:

The idea here is to offer the user an alternative to needing/having to call `SQLDescribeParam` when binding data to a parameter(s) in a statement.

Motivation is:

- Compatibility with drivers that have not implemented `SQLDescribeParam` - in particular FreeTDS, see: https://github.com/nanodbc/nanodbc/issues/15 (@jimhester)
- Performance enhancement as a nice by-product due to fewer round-trips to the server

Initially went down the route of adding parameter(s) / expanding the `statement::bind_*` method, but that approach resulted in more code churn.  
 
Excited to hear your feedback.
