### PR TITLE
fix: Bug that on batch fetching string columns cannot be retrieved

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3305,7 +3305,8 @@ public:
 
     bool next(void* event_handle = nullptr)
     {
-        if (rows() && ++rowset_position_ < rowset_size_){
+        if (rows() && ++rowset_position_ < rowset_size_)
+        {
             set_current_position();
             return rowset_position_ < rows();
         }
@@ -3342,7 +3343,7 @@ public:
 
     bool prior()
     {
-        if( rows() && --rowset_position_ >= 0 )
+        if (rows() && --rowset_position_ >= 0)
         {
             set_current_position();
             return true;
@@ -4004,12 +4005,18 @@ private:
 
     void set_current_position()
     {
-        if( rowset_position_ < rowset_size_ )
+        if (rowset_position_ < rowset_size_)
         {
             RETCODE rc;
-            NANODBC_CALL_RC( SQLSetPos, rc, stmt_.native_statement_handle(), rowset_position_ + 1, SQL_POSITION, SQL_LOCK_NO_CHANGE );
-            if( !success( rc ) )
-                NANODBC_THROW_DATABASE_ERROR( stmt_.native_statement_handle(), SQL_HANDLE_STMT );
+            NANODBC_CALL_RC(
+                SQLSetPos,
+                rc,
+                stmt_.native_statement_handle(),
+                rowset_position_ + 1,
+                SQL_POSITION,
+                SQL_LOCK_NO_CHANGE);
+            if (!success(rc))
+                NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
         }
     }
 

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3305,8 +3305,10 @@ public:
 
     bool next(void* event_handle = nullptr)
     {
-        if (rows() && ++rowset_position_ < rowset_size_)
+        if (rows() && ++rowset_position_ < rowset_size_){
+            set_current_position();
             return rowset_position_ < rows();
+        }
         rowset_position_ = 0;
         return fetch(0, SQL_FETCH_NEXT, event_handle);
     }
@@ -3340,8 +3342,11 @@ public:
 
     bool prior()
     {
-        if (rows() && --rowset_position_ >= 0)
+        if( rows() && --rowset_position_ >= 0 )
+        {
+            set_current_position();
             return true;
+        }
         rowset_position_ = 0;
         return fetch(0, SQL_FETCH_PRIOR);
     }
@@ -3995,6 +4000,17 @@ private:
         delete[] column.pdata_;
         column.pdata_ = nullptr;
         column.bound_ = false;
+    }
+
+    void set_current_position()
+    {
+        if( rowset_position_ < rowset_size_ )
+        {
+            RETCODE rc;
+            NANODBC_CALL_RC( SQLSetPos, rc, stmt_.native_statement_handle(), rowset_position_ + 1, SQL_POSITION, SQL_LOCK_NO_CHANGE );
+            if( !success( rc ) )
+                NANODBC_THROW_DATABASE_ERROR( stmt_.native_statement_handle(), SQL_HANDLE_STMT );
+        }
     }
 
 private:


### PR DESCRIPTION
## What does this PR do?
Fix a bug that on batch fetching string columns cannot be retrieved.
With a multi-row cursor SQLSetPos must be called before calling SQLGetData.

This bug happens on the following situation.
```c++
auto results= nanodbc::execute(conn, L"SELECT * FROM blahblah", 3);
while(results.next)
{
    auto i = result.get<std::wstring>( 0 );
}
```