### PR TITLE
auto_bind: Handle SQL_SS_XML

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2780,6 +2780,7 @@ private:
                 {
                 case SQL_VARCHAR:
                 case SQL_WVARCHAR:
+                case SQL_SS_XML:
                 {
                     // Divide in half, due to sqlsize being 32-bit in Win32 (and 64-bit in x64)
                     // sqlsize = std::numeric_limits<int32_t>::max() / 2 - 1;
@@ -2851,6 +2852,7 @@ private:
                 break;
             case SQL_WCHAR:
             case SQL_WVARCHAR:
+            case SQL_SS_XML:
                 col.ctype_ = sql_ctype<wide_string>::value;
                 col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLWCHAR);
                 if (is_blob)

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -158,6 +158,24 @@ TEST_CASE_METHOD(mssql_fixture, "test_blob", "[mssql][blob][binary][varbinary]")
     }
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_xml", "[mssql][xml]")
+{
+    auto connection = connect();
+    {
+        create_table(connection, NANODBC_TEXT("test_xml"), NANODBC_TEXT("(data XML)"));
+        nanodbc::statement stmt(connection);
+        prepare(stmt, NANODBC_TEXT("INSERT INTO test_xml (data) VALUES (?)"));
+
+        std::vector<nanodbc::string> s = {NANODBC_TEXT("myxmldata")};
+        stmt.bind_strings(0, s);
+        execute(stmt);
+        nanodbc::result results =
+            nanodbc::execute(connection, NANODBC_TEXT("SELECT data FROM test_xml;"));
+        REQUIRE(results.next());
+        REQUIRE(results.get<nanodbc::string>(0) == s[0]);
+    }
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_large_blob", "[mssql][blob][binary][varbinary]")
 {
     std::vector<std::uint8_t> blob;


### PR DESCRIPTION
Hi @mloskot @lexicalunit 

This patch adds functionality for handling "XML" columns in SQL SERVER result sets.

From what I gather in the [docs](https://docs.microsoft.com/en-us/sql/relational-databases/native-client/features/using-xml-data-types?redirectedfrom=MSDN&view=sql-server-ver15) the recommended handling is to bind the buffers either as binary or wchar, to avoid any server side conversions.  I tried binary first: the Microsoft's driver prepended what looked like a BOM; i got something garbled back with FreeTDS (granted I didn't try too hard to figure out what's going on there).

Binding the buffer as WCHAR seems to work just fine with both drivers.