### PR TITLE
Optional binding to support out-of-order retrival of unbound columns with SQLGetData

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3126,13 +3126,6 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         return;
     }
 
-    case SQL_C_GUID:
-    {
-        const char* s = col.pdata_ + rowset_position_ * col.clen_;
-        result.assign(s, s + column_size);
-        return;
-    }
-
     case SQL_C_LONG:
     {
         std::string buffer(column_size + 1, 0); // ensure terminating null

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -686,6 +686,7 @@ public:
         , blob_(false)
         , cbdata_(0)
         , pdata_(0)
+        , bound_(false)
     {
     }
 
@@ -706,6 +707,7 @@ public:
     bool blob_;
     nanodbc::null_type* cbdata_;
     char* pdata_;
+    bool bound_;
 };
 
 // Encapsulates properties of statement parameter.
@@ -2462,6 +2464,19 @@ public:
         return is_null(column);
     }
 
+    bool is_bound(short column) const
+    {
+        throw_if_column_is_out_of_range(column);
+        bound_column& col = bound_columns_[column];
+        return col.bound_;
+    }
+
+    bool is_bound(const string& column_name) const
+    {
+        const short column = this->column(column_name);
+        return is_bound(column);
+    }
+
     short column(const string& column_name) const
     {
         typedef std::map<string, bound_column*>::const_iterator iter;
@@ -2580,6 +2595,46 @@ public:
         return true;
     }
 
+    void unbind()
+    {
+        const short n_columns = columns();
+        if (n_columns < 1)
+            return;
+        for (short i = 0; i < n_columns; ++i)
+            unbind(i);
+    }
+
+    void unbind(short column)
+    {
+        RETCODE rc;
+        throw_if_column_is_out_of_range(column);
+        bound_column& col = bound_columns_[column];
+
+        if (is_bound(column))
+        {
+            NANODBC_CALL_RC(
+                SQLBindCol,
+                rc,
+                stmt_.native_statement_handle(),
+                column + 1,
+                col.ctype_,
+                0,
+                0,
+                col.cbdata_); // Re-use existing cbdata_ buffer
+            if (!success(rc))
+                NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
+            delete[] col.pdata_;
+            col.pdata_ = 0;
+            col.bound_ = false;
+        }
+    }
+
+    void unbind(const string& column_name)
+    {
+        const short column = this->column(column_name);
+        unbind(column);
+    }
+
     template <class T>
     void get_ref(short column, T& result) const
     {
@@ -2655,6 +2710,9 @@ public:
     }
 
 private:
+    template <typename T>
+    T* ensure_pdata(short column) const;
+
     template <class T, typename std::enable_if<!is_string<T>::value, int>::type = 0>
     void get_ref_impl(short column, T& result) const;
 
@@ -2918,6 +2976,7 @@ private:
                     col.cbdata_); // StrLen_or_Ind
                 if (!success(rc))
                     NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
+                col.bound_ = true;
             }
         }
     }
@@ -2943,11 +3002,11 @@ inline void result::result_impl::get_ref_impl<date>(short column, date& result) 
     switch (col.ctype_)
     {
     case SQL_C_DATE:
-        result = *reinterpret_cast<date*>(col.pdata_ + rowset_position_ * col.clen_);
+        result = *ensure_pdata<date>(column);
         return;
     case SQL_C_TIMESTAMP:
     {
-        timestamp stamp = *reinterpret_cast<timestamp*>(col.pdata_ + rowset_position_ * col.clen_);
+        timestamp stamp = *ensure_pdata<timestamp>(column);
         date d = {stamp.year, stamp.month, stamp.day};
         result = d;
         return;
@@ -2963,11 +3022,11 @@ inline void result::result_impl::get_ref_impl<time>(short column, time& result) 
     switch (col.ctype_)
     {
     case SQL_C_TIME:
-        result = *reinterpret_cast<time*>(col.pdata_ + rowset_position_ * col.clen_);
+        result = *ensure_pdata<time>(column);
         return;
     case SQL_C_TIMESTAMP:
     {
-        timestamp stamp = *reinterpret_cast<timestamp*>(col.pdata_ + rowset_position_ * col.clen_);
+        timestamp stamp = *ensure_pdata<timestamp>(column);
         time t = {stamp.hour, stamp.min, stamp.sec};
         result = t;
         return;
@@ -2984,13 +3043,13 @@ inline void result::result_impl::get_ref_impl<timestamp>(short column, timestamp
     {
     case SQL_C_DATE:
     {
-        date d = *reinterpret_cast<date*>(col.pdata_ + rowset_position_ * col.clen_);
+        date d = *ensure_pdata<date>(column);
         timestamp stamp = {d.year, d.month, d.day, 0, 0, 0, 0};
         result = stamp;
         return;
     }
     case SQL_C_TIMESTAMP:
-        result = *reinterpret_cast<timestamp*>(col.pdata_ + rowset_position_ * col.clen_);
+        result = *ensure_pdata<timestamp>(column);
         return;
     }
     throw type_incompatible_error();
@@ -3007,7 +3066,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
     case SQL_C_CHAR:
     case SQL_C_BINARY:
     {
-        if (col.blob_)
+        if (!is_bound(column))
         {
             // Input is always std::string, while output may be std::string or wide_string
             std::string out;
@@ -3054,7 +3113,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
                 NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
         }
         else
-        {
+        { // bound and not blob
             const char* s = col.pdata_ + rowset_position_ * col.clen_;
             convert(s, result);
         }
@@ -3063,7 +3122,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
 
     case SQL_C_WCHAR:
     {
-        if (col.blob_)
+        if (!is_bound(column))
         {
             // Input is always wide_string, output might be std::string or wide_string.
             // Use a string builder to build the output string.
@@ -3113,8 +3172,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
             ;
         }
         else
-        {
-            // Type is unicode in the database, convert if necessary
+        { // bound and not blob
             SQLWCHAR const* s =
                 reinterpret_cast<SQLWCHAR*>(col.pdata_ + rowset_position_ * col.clen_);
             string::size_type const str_size =
@@ -3129,8 +3187,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
     case SQL_C_LONG:
     {
         std::string buffer(column_size + 1, 0); // ensure terminating null
-        const wide_char_t data =
-            *reinterpret_cast<wide_char_t*>(col.pdata_ + rowset_position_ * col.clen_);
+        const int32_t data = *ensure_pdata<int32_t>(column);
         const int bytes =
             std::snprintf(const_cast<char*>(buffer.data()), column_size + 1, "%d", data);
         if (bytes == -1)
@@ -3143,8 +3200,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
     {
         using namespace std;                    // in case intmax_t is in namespace std
         std::string buffer(column_size + 1, 0); // ensure terminating null
-        const intmax_t data =
-            (intmax_t) * reinterpret_cast<int64_t*>(col.pdata_ + rowset_position_ * col.clen_);
+        const intmax_t data = (intmax_t)*ensure_pdata<int64_t>(column);
         const int bytes =
             std::snprintf(const_cast<char*>(buffer.data()), column_size + 1, "%jd", data);
         if (bytes == -1)
@@ -3156,7 +3212,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
     case SQL_C_FLOAT:
     {
         std::string buffer(column_size + 1, 0); // ensure terminating null
-        const float data = *reinterpret_cast<float*>(col.pdata_ + rowset_position_ * col.clen_);
+        const float data = *ensure_pdata<float>(column);
         const int bytes =
             std::snprintf(const_cast<char*>(buffer.data()), column_size + 1, "%f", data);
         if (bytes == -1)
@@ -3169,7 +3225,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
     {
         const SQLULEN width = column_size + 2; // account for decimal mark and sign
         std::string buffer(width + 1, 0);      // ensure terminating null
-        const double data = *reinterpret_cast<double*>(col.pdata_ + rowset_position_ * col.clen_);
+        const double data = *ensure_pdata<double>(column);
         const int bytes = std::snprintf(
             const_cast<char*>(buffer.data()),
             width + 1,
@@ -3184,7 +3240,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
 
     case SQL_C_DATE:
     {
-        const date d = *reinterpret_cast<date*>(col.pdata_ + rowset_position_ * col.clen_);
+        const date d = *ensure_pdata<date>(column);
         std::tm st = {0};
         st.tm_year = d.year - 1900;
         st.tm_mon = d.month - 1;
@@ -3200,7 +3256,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
 
     case SQL_C_TIME:
     {
-        const time t = *reinterpret_cast<time*>(col.pdata_ + rowset_position_ * col.clen_);
+        const time t = *ensure_pdata<time>(column);
         std::tm st = {0};
         st.tm_hour = t.hour;
         st.tm_min = t.min;
@@ -3216,8 +3272,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
 
     case SQL_C_TIMESTAMP:
     {
-        const timestamp stamp =
-            *reinterpret_cast<timestamp*>(col.pdata_ + rowset_position_ * col.clen_);
+        const timestamp stamp = *ensure_pdata<timestamp>(column);
         std::tm st = {0};
         st.tm_year = stamp.year - 1900;
         st.tm_mon = stamp.month - 1;
@@ -3249,7 +3304,7 @@ inline void result::result_impl::get_ref_impl<std::vector<std::uint8_t>>(
     {
     case SQL_C_BINARY:
     {
-        if (col.blob_)
+        if (!is_bound(column))
         {
             // Input and output is always array of bytes.
             std::vector<std::uint8_t> out;
@@ -3350,14 +3405,13 @@ template <class T, typename std::enable_if<is_character<T>::value, int>::type>
 void result::result_impl::get_ref_from_string_column(short column, T& result) const
 {
     bound_column& col = bound_columns_[column];
-    const char* s = col.pdata_ + rowset_position_ * col.clen_;
     switch (col.ctype_)
     {
     case SQL_C_CHAR:
-        result = static_cast<T>(*static_cast<const char*>(s));
+        result = static_cast<T>(*ensure_pdata<char>(column));
         return;
     case SQL_C_WCHAR:
-        result = static_cast<T>(*reinterpret_cast<const SQLWCHAR*>(s));
+        result = static_cast<T>(*ensure_pdata<wide_char_t>(column));
         return;
     }
     throw type_incompatible_error();
@@ -3374,12 +3428,44 @@ void result::result_impl::get_ref_from_string_column(short column, T& result) co
     result = from_string<T>(str);
 }
 
+template <typename T>
+T* result::result_impl::ensure_pdata(short column) const
+{
+    bound_column& col = bound_columns_[column];
+    SQLLEN ValueLenOrInd;
+    SQLRETURN rc;
+    if (is_bound(column))
+    {
+        return (T*)(col.pdata_ + rowset_position_ * col.clen_);
+    }
+
+    T* buffer = new T;
+    const std::size_t buffer_size = sizeof(T);
+    void* handle = native_statement_handle();
+    NANODBC_CALL_RC(
+        SQLGetData,
+        rc,
+        handle,              // StatementHandle
+        column + 1,          // Col_or_Param_Num
+        sql_ctype<T>::value, // TargetType
+        buffer,              // TargetValuePtr
+        buffer_size,         // BufferLength
+        &ValueLenOrInd);     // StrLen_or_IndPtr
+
+    if (ValueLenOrInd == SQL_NULL_DATA)
+        col.cbdata_[static_cast<size_t>(rowset_position_)] = (SQLINTEGER)SQL_NULL_DATA;
+    if (!success(rc))
+        NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
+    NANODBC_ASSERT(ValueLenOrInd == (SQLLEN)buffer_size);
+
+    return buffer;
+}
+
 template <class T, typename std::enable_if<!is_string<T>::value, int>::type>
 void result::result_impl::get_ref_impl(short column, T& result) const
 {
     bound_column& col = bound_columns_[column];
     using namespace std; // if int64_t is in std namespace (in c++11)
-    const char* s = col.pdata_ + rowset_position_ * col.clen_;
     switch (col.ctype_)
     {
     case SQL_C_CHAR:
@@ -3387,31 +3473,31 @@ void result::result_impl::get_ref_impl(short column, T& result) const
         get_ref_from_string_column(column, result);
         return;
     case SQL_C_SSHORT:
-        result = (T) * (short*)(s);
+        result = (T) * (ensure_pdata<short>(column));
         return;
     case SQL_C_USHORT:
-        result = (T) * (unsigned short*)(s);
+        result = (T) * (ensure_pdata<unsigned short>(column));
         return;
     case SQL_C_LONG:
-        result = (T) * (int32_t*)(s);
+        result = (T) * (ensure_pdata<int32_t>(column));
         return;
     case SQL_C_SLONG:
-        result = (T) * (int32_t*)(s);
+        result = (T) * (ensure_pdata<int32_t>(column));
         return;
     case SQL_C_ULONG:
-        result = (T) * (uint32_t*)(s);
+        result = (T) * (ensure_pdata<uint32_t>(column));
         return;
     case SQL_C_FLOAT:
-        result = (T) * (float*)(s);
+        result = (T) * (ensure_pdata<float>(column));
         return;
     case SQL_C_DOUBLE:
-        result = (T) * (double*)(s);
+        result = (T) * (ensure_pdata<double>(column));
         return;
     case SQL_C_SBIGINT:
-        result = (T) * (int64_t*)(s);
+        result = (T) * (ensure_pdata<int64_t>(column));
         return;
     case SQL_C_UBIGINT:
-        result = (T) * (uint64_t*)(s);
+        result = (T) * (ensure_pdata<uint64_t>(column));
         return;
     }
     throw type_incompatible_error();
@@ -4843,6 +4929,16 @@ bool result::is_null(const string& column_name) const
     return impl_->is_null(column_name);
 }
 
+bool result::is_bound(short column) const
+{
+    return impl_->is_bound(column);
+}
+
+bool result::is_bound(const string& column_name) const
+{
+    return impl_->is_bound(column_name);
+}
+
 short result::column(const string& column_name) const
 {
     return impl_->column(column_name);
@@ -4906,6 +5002,21 @@ int result::column_c_datatype(const string& column_name) const
 bool result::next_result()
 {
     return impl_->next_result();
+}
+
+void result::unbind()
+{
+    impl_->unbind();
+}
+
+void result::unbind(short column)
+{
+    impl_->unbind(column);
+}
+
+void result::unbind(const string& column_name)
+{
+    impl_->unbind(column_name);
 }
 
 template <class T>

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1323,6 +1323,36 @@ public:
     /// \brief Returns true if there are no more results in the current result set.
     bool at_end() const noexcept;
 
+    /// \brief Unbind data buffers for all columns in the result set.
+    ///
+    /// Wraps unbind(short column)
+    /// \throws index_range_error, database_error
+    void unbind();
+
+    /// \brief Unbind data buffers for specific columns in the result set.
+    ///
+    /// Wraps unbind(short column)
+    ///
+    /// \param column_name string Name of column we wish to unbind.
+    /// \throws index_range_error, database_error
+    void unbind(const string& column_name);
+
+    /// \brief Unbind data buffers for specific columns in the result set.
+    ///
+    /// When a result is constructed, in order to optimize data retrieval,
+    /// we automatically try to bind buffers, except for columns that contain
+    /// long/blob data types.  This method gives the caller the option to unbind
+    /// a specific buffer.  Subsequently, during calls to get(), if there is no
+    /// bound data buffer, we will attempt to retrieve the data using a call
+    /// SQLGetData; this is similar to the route taken for columns hosting long
+    /// or bloby data types.  This is suboptimal from efficiency perspective,
+    /// however may be necessary of the driver we are communicating with does
+    /// not support out-of-order retrieval of long data.
+    ///
+    /// \param column short Zero-based index of column we wish to unbind.
+    /// \throws index_range_error, database_error
+    void unbind(short column);
+
     /// \brief Gets data from the given column of the current rowset.
     ///
     /// Columns are numbered from left to right and 0-indexed.
@@ -1420,6 +1450,26 @@ public:
     /// \param column_name column's name.
     /// \throws database_error, index_range_error
     bool is_null(const string& column_name) const;
+
+    /// \brief Returns true if we have bound a buffer to the given column.
+    ///
+    /// Generically, nanodbc will greedily bind buffers to columns in the result
+    /// set.  However, we have also given the user the ability to unbind buffers
+    /// via unbind() forcing nanodbc to retrieve data via SQLGetData.  This
+    /// method returns true if there is a buffer bound to the column.
+    ///
+    /// Columns are numbered from left to right and 0-indexed.
+    /// \param column short position.
+    /// \throws index_range_error
+    bool is_bound(short column) const;
+
+    /// \brief Returns true if we have bound a buffer to the given column.
+    ///
+    /// See is_bound(short column) for details.
+    /// \see is_bound()
+    /// \param column_name column's name.
+    /// \throws index_range_error
+    bool is_bound(const string& column_name) const;
 
     /// \brief Returns the column number of the specified column name.
     ///

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -456,6 +456,34 @@ TEST_CASE_METHOD(
         REQUIRE(results.get<nanodbc::string>(2) == NANODBC_TEXT("this is varchar max"));
         REQUIRE(results.get<nanodbc::string>(3) == NANODBC_TEXT("this is text"));
     }
+
+    // Unbind all columns
+    {
+        nanodbc::result results = nanodbc::execute(
+            connection,
+            NANODBC_TEXT("select c1, c2, c3, c4 from test_blob_retrieve_out_of_order;"));
+        results.unbind();
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 1);
+        REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("this is varchar max"));
+        REQUIRE(results.get<int>(2) == 11);
+        REQUIRE(results.get<nanodbc::string>(3) == NANODBC_TEXT("this is text"));
+    }
+
+    // Unbind offending column only
+    {
+        nanodbc::result results = nanodbc::execute(
+            connection,
+            NANODBC_TEXT("select c1, c2, c3, c4 from test_blob_retrieve_out_of_order;"));
+        REQUIRE(results.is_bound(0));
+        REQUIRE(results.is_bound(2));
+        results.unbind(2);
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 1);
+        REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("this is varchar max"));
+        REQUIRE(results.get<int>(2) == 11);
+        REQUIRE(results.get<nanodbc::string>(3) == NANODBC_TEXT("this is text"));
+    }
 }
 
 TEST_CASE_METHOD(mssql_fixture, "test_catalog_list_catalogs", "[mssql][catalog][catalogs]")


### PR DESCRIPTION
This is a rebase of https://github.com/nanodbc/nanodbc/pull/236 on top of master.  In addition, I squashed fixup/code-review commits into one (for a total of two).

Below is the text of the original PR.

-------------------------------------------------------------------------------------------------------------
Hi @mloskot @lexicalunit 

This is a candidate solution to the problem documented in https://github.com/nanodbc/nanodbc/issues/228

The general idea is:

* We give the caller the option to unbind one or more of the buffers that are bound during the `auto_bind` step.
* Make it seam-less to retrieve data for these columns (that would have had a buffer bound previously) via a fall-back to `SQLGetData`.

Some notes on the design choices:
* The name `ensure_pdata` definitely needs help.  Also open to suggestion on guarding the template with `enable_if` - within the current design this is not intended to be called with a string-like result buffer.
* I tried, as much as possible, to not augment the existing code-path (where the caller is fine with buffers being automatically bound when the result is constructed).  There might be, for example, opportunities for `ensure_pdata` to be more expansive and used more broadly at other locations where `SQLGetData` is currently called.  In this iteration I tried to touch as little as possible.
* There might be an opportunity to make the `auto_bind` conditional, rather than the current flow where buffers are automatically bound, and then the user has the option to `unbind`.  However this required touching and churning through many constructors and method declarations, since there are quite a few places where a result is instantiated internally and returned to the caller.

I have still run through the styling script - will do that as well.

Looking forward to getting your feedback.