### PR TITLE
Install path for cmake are wrong on linux/unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,11 @@ if(NOT NANODBC_DISABLE_INSTALL)
   install(FILES nanodbc/nanodbc.h DESTINATION include/nanodbc)
   # Make project importable from the install directory
   ## Generate and install *-config.cmake exporting targets from install tree.
-  install(EXPORT ${NANODBC_CONFIG} DESTINATION cmake)
+  if (WIN32 AND NOT MINGW)
+    install(EXPORT ${NANODBC_CONFIG} DESTINATION "cmake")
+  else()
+    install(EXPORT ${NANODBC_CONFIG} DESTINATION "lib/cmake/nanodbc")
+  endif()
   # Make project importable from the build directory
   ## Generate file *-config.cmake exporting targets from build tree.
   export(TARGETS nanodbc FILE ${NANODBC_CONFIG}.cmake)


### PR DESCRIPTION
## What does this PR do?

This PR fixes the install path for the cmake package config on linux/unix systems according to the cmake definition.

## What are related issues/pull requests?

- #240 

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* DBMS name/version:
* ODBC connection string:
* OS and Compiler:
