### PR TITLE
catalog: Add find_procedures/find_procedure_columns

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4399,32 +4399,32 @@ bool catalog::procedures::next()
     return result_.next();
 }
 
-string catalog::procedures::proc_catalog() const
+string catalog::procedures::procedure_catalog() const
 {
     // PROCEDURE_CAT may be NULL
     return result_.get<string>(0, string());
 }
 
-string catalog::procedures::proc_schema() const
+string catalog::procedures::procedure_schema() const
 {
     // PROCEDURE_SCHEM may be NULL
     return result_.get<string>(1, string());
 }
 
-string catalog::procedures::proc_name() const
+string catalog::procedures::procedure_name() const
 {
     // PROCEDURE_NAME is never NULL
     return result_.get<string>(2);
 }
 
-string catalog::procedures::proc_remarks() const
+string catalog::procedures::procedure_remarks() const
 {
     // Column indicies 3, 4, 5 and "reserved for future use".
     // PROCEDURE_REMARKS column may be NULL
     return result_.get<string>(6, string());
 }
 
-short catalog::procedures::proc_type() const
+short catalog::procedures::procedure_type() const
 {
     // PROCEDURE_TYPE may be NULL
     return result_.get<short>(7, SQL_PT_UNKNOWN);
@@ -4538,19 +4538,19 @@ bool catalog::procedure_columns::next()
     return result_.next();
 }
 
-string catalog::procedure_columns::proc_catalog() const
+string catalog::procedure_columns::procedure_catalog() const
 {
     // TABLE_CAT might be NULL
     return result_.get<string>(0, string());
 }
 
-string catalog::procedure_columns::proc_schema() const
+string catalog::procedure_columns::procedure_schema() const
 {
     // TABLE_SCHEM might be NULL
     return result_.get<string>(1, string());
 }
 
-string catalog::procedure_columns::proc_name() const
+string catalog::procedure_columns::procedure_name() const
 {
     // TABLE_NAME is never NULL
     return result_.get<string>(2);

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4389,6 +4389,47 @@ string catalog::tables::table_remarks() const
     return result_.get<string>(4, string());
 }
 
+catalog::procedures::procedures(result& find_result)
+    : result_(find_result)
+{
+}
+
+bool catalog::procedures::next()
+{
+    return result_.next();
+}
+
+string catalog::procedures::proc_catalog() const
+{
+    // PROCEDURE_CAT may be NULL
+    return result_.get<string>(0, string());
+}
+
+string catalog::procedures::proc_schema() const
+{
+    // PROCEDURE_SCHEM may be NULL
+    return result_.get<string>(1, string());
+}
+
+string catalog::procedures::proc_name() const
+{
+    // PROCEDURE_NAME is never NULL
+    return result_.get<string>(2);
+}
+
+string catalog::procedures::proc_remarks() const
+{
+    // Column indicies 3, 4, 5 and "reserved for future use".
+    // PROCEDURE_REMARKS column may be NULL
+    return result_.get<string>(6, string());
+}
+
+short catalog::procedures::proc_type() const
+{
+    // PROCEDURE_TYPE may be NULL
+    return result_.get<short>(7, SQL_PT_UNKNOWN);
+}
+
 catalog::table_privileges::table_privileges(result& find_result)
     : result_(find_result)
 {
@@ -4485,6 +4526,130 @@ string catalog::primary_keys::primary_key_name() const
 {
     // PK_NAME might be NULL
     return result_.get<string>(5);
+}
+
+catalog::procedure_columns::procedure_columns(result& find_result)
+    : result_(find_result)
+{
+}
+
+bool catalog::procedure_columns::next()
+{
+    return result_.next();
+}
+
+string catalog::procedure_columns::proc_catalog() const
+{
+    // TABLE_CAT might be NULL
+    return result_.get<string>(0, string());
+}
+
+string catalog::procedure_columns::proc_schema() const
+{
+    // TABLE_SCHEM might be NULL
+    return result_.get<string>(1, string());
+}
+
+string catalog::procedure_columns::proc_name() const
+{
+    // TABLE_NAME is never NULL
+    return result_.get<string>(2);
+}
+
+string catalog::procedure_columns::column_name() const
+{
+    // COLUMN_NAME is never NULL
+    return result_.get<string>(3);
+}
+
+short catalog::procedure_columns::column_type() const
+{
+    // DATA_TYPE is never NULL
+    return result_.get<short>(4);
+}
+
+short catalog::procedure_columns::data_type() const
+{
+    // DATA_TYPE is never NULL
+    return result_.get<short>(5);
+}
+
+string catalog::procedure_columns::type_name() const
+{
+    // TYPE_NAME is never NULL
+    return result_.get<string>(6);
+}
+
+long catalog::procedure_columns::column_size() const
+{
+    // COLUMN_SIZE, might be NULL
+    return result_.get<long>(7, 0);
+}
+
+long catalog::procedure_columns::buffer_length() const
+{
+    // BUFFER_LENGTH
+    return result_.get<long>(8);
+}
+
+short catalog::procedure_columns::decimal_digits() const
+{
+    // DECIMAL_DIGITS might be NULL
+    return result_.get<short>(9, 0);
+}
+
+short catalog::procedure_columns::numeric_precision_radix() const
+{
+    // NUM_PREC_RADIX might be NULL
+    return result_.get<short>(10, 0);
+}
+
+short catalog::procedure_columns::nullable() const
+{
+    // NULLABLE is never NULL
+    return result_.get<short>(11);
+}
+
+string catalog::procedure_columns::remarks() const
+{
+    // REMARKS might be NULL
+    return result_.get<string>(12, string());
+}
+
+string catalog::procedure_columns::column_default() const
+{
+    // COLUMN_DEF might be NULL, if no default value is specified
+    return result_.get<string>(13, string());
+}
+
+short catalog::procedure_columns::sql_data_type() const
+{
+    // SQL_DATA_TYPE is never NULL
+    return result_.get<short>(14);
+}
+
+short catalog::procedure_columns::sql_datetime_subtype() const
+{
+    // SQL_DATETIME_SUB might be NULL
+    return result_.get<short>(15, 0);
+}
+
+long catalog::procedure_columns::char_octet_length() const
+{
+    // CHAR_OCTET_LENGTH might be NULL
+    return result_.get<long>(16, 0);
+}
+
+long catalog::procedure_columns::ordinal_position() const
+{
+    // ORDINAL_POSITION is never NULL
+    return result_.get<long>(17);
+}
+
+string catalog::procedure_columns::is_nullable() const
+{
+    // IS_NULLABLE might be NULL.
+    return result_.get<string>(18, string());
 }
 
 catalog::columns::columns(result& find_result)
@@ -4642,6 +4807,62 @@ catalog::tables catalog::find_tables(
 
     result find_result(stmt, 1);
     return catalog::tables(find_result);
+}
+
+catalog::procedures
+catalog::find_procedures(const string& procedure, const string& schema, const string& catalog)
+{
+    // Passing a null pointer to a search pattern argument does not
+    // constrain the search for that argument; that is, a null pointer and
+    // the search pattern % (any characters) are equivalent.
+    // However, a zero-length search pattern - that is, a valid pointer to
+    // a string of length zero - matches only the empty string ("").
+    // See https://msdn.microsoft.com/en-us/library/ms710171.aspx
+
+    statement stmt(conn_);
+    RETCODE rc;
+    NANODBC_CALL_RC(
+        NANODBC_FUNC(SQLProcedures),
+        rc,
+        stmt.native_statement_handle(),
+        (NANODBC_SQLCHAR*)(catalog.empty() ? nullptr : catalog.c_str()),
+        (catalog.empty() ? 0 : SQL_NTS),
+        (NANODBC_SQLCHAR*)(schema.empty() ? nullptr : schema.c_str()),
+        (schema.empty() ? 0 : SQL_NTS),
+        (NANODBC_SQLCHAR*)(procedure.empty() ? nullptr : procedure.c_str()),
+        (procedure.empty() ? 0 : SQL_NTS));
+    if (!success(rc))
+        NANODBC_THROW_DATABASE_ERROR(stmt.native_statement_handle(), SQL_HANDLE_STMT);
+
+    result find_result(stmt, 1);
+    return catalog::procedures(find_result);
+}
+
+catalog::procedure_columns catalog::find_procedure_columns(
+    const string& column,
+    const string& procedure,
+    const string& schema,
+    const string& catalog)
+{
+    statement stmt(conn_);
+    RETCODE rc;
+    NANODBC_CALL_RC(
+        NANODBC_FUNC(SQLProcedureColumns),
+        rc,
+        stmt.native_statement_handle(),
+        (NANODBC_SQLCHAR*)(catalog.empty() ? nullptr : catalog.c_str()),
+        (catalog.empty() ? 0 : SQL_NTS),
+        (NANODBC_SQLCHAR*)(schema.empty() ? nullptr : schema.c_str()),
+        (schema.empty() ? 0 : SQL_NTS),
+        (NANODBC_SQLCHAR*)(procedure.empty() ? nullptr : procedure.c_str()),
+        (procedure.empty() ? 0 : SQL_NTS),
+        (NANODBC_SQLCHAR*)(column.empty() ? nullptr : column.c_str()),
+        (column.empty() ? 0 : SQL_NTS));
+    if (!success(rc))
+        NANODBC_THROW_DATABASE_ERROR(stmt.native_statement_handle(), SQL_HANDLE_STMT);
+
+    result find_result(stmt, 1);
+    return catalog::procedure_columns(find_result);
 }
 
 catalog::table_privileges

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1769,6 +1769,64 @@ public:
         result result_;
     };
 
+    /// \brief Result set for a list of procedures in the data source.
+    class procedures
+    {
+    public:
+        bool next();                 ///< Move to the next result in the result set.
+        string proc_catalog() const; ///< Fetch procedure catalog.
+        string proc_schema() const;  ///< Fetch procedure schema.
+        string proc_name() const;    ///< Fetch procedure name.
+        string proc_remarks() const; ///< Fetch procedure remarks.
+        short proc_type() const;     ///< Fetch procedure type.
+
+    private:
+        friend class nanodbc::catalog;
+        procedures(result& find_result);
+        result result_;
+    };
+
+    /// \brief Result set for a list of procedures in the data source.
+    class procedure_columns
+    {
+    public:
+        bool next();                           ///< Move to the next result in the result set.
+        string proc_catalog() const;           ///< Fetch table catalog.
+        string proc_schema() const;            ///< Fetch table schema.
+        string proc_name() const;              ///< Fetch table name.
+        string column_name() const;            ///< Fetch column name.
+        short column_type() const;             ///< Fetch column type.
+        short data_type() const;               ///< Fetch column data type.
+        string type_name() const;              ///< Fetch column type name.
+        long column_size() const;              ///< Fetch column size.
+        long buffer_length() const;            ///< Fetch buffer length.
+        short decimal_digits() const;          ///< Fetch decimal digits.
+        short numeric_precision_radix() const; ///< Fetch numeric precission.
+        short nullable() const;                ///< True iff column is nullable.
+        string remarks() const;                ///< Fetch column remarks.
+        string column_default() const;         ///< Fetch column's default.
+        short sql_data_type() const;           ///< Fetch column's SQL data type.
+        short sql_datetime_subtype() const;    ///< Fetch datetime subtype of column.
+        long char_octet_length() const;        ///< Fetch char octet length.
+
+        /// \brief Ordinal position of the column in the table.
+        /// The first column in the table is number 1.
+        /// Returns ORDINAL_POSITION column value in result set returned by SQLColumns.
+        long ordinal_position() const;
+
+        /// \brief Fetch column is-nullable information.
+        ///
+        /// \note MSDN: This column returns a zero-length string if nullability is unknown.
+        ///       ISO rules are followed to determine nullability.
+        ///       An ISO SQL-compliant DBMS cannot return an empty string.
+        string is_nullable() const;
+
+    private:
+        friend class nanodbc::catalog;
+        procedure_columns(result& find_result);
+        result result_;
+    };
+
     /// \brief Creates catalog operating on database accessible through the specified connection.
     explicit catalog(connection& conn);
 
@@ -1830,6 +1888,37 @@ public:
     /// Empty string argument is equivalent to passing the search pattern '%'.
     catalog::primary_keys find_primary_keys(
         const string& table,
+        const string& schema = string(),
+        const string& catalog = string());
+
+    /// \brief Creates result set with catalog, schema, procedure, and procedure types.
+    ///
+    /// Procedure information is obtained by executing `SQLProcedures` function within
+    /// scope of the connected database accessible with the specified connection.
+    /// Since this function is implemented in terms of the `SQLProcedures`s, it returns
+    /// result set ordered by PROCEDURE_CAT, PROCEDUORE_SCHEM, and PROCEDURE_NAME.
+    ///
+    /// All arguments are treated as the Pattern Value Arguments.
+    /// Empty string argument is equivalent to passing the search pattern '%'.
+
+    catalog::procedures find_procedures(
+        const string& procedure = string(),
+        const string& schema = string(),
+        const string& catalog = string());
+
+    /// \brief Creates result set with columns in one or more procedures.
+    ///
+    /// Columns information is obtained by executing `SQLProcedureColumns` function within
+    /// scope of the connected database accessible with the specified connection.
+    /// Since this function is implemented in terms of the `SQLProcedureColumns`, it returns
+    /// result set ordered by PROCEDURE_CAT, PROCEDURE_SCHEM, PROCEDURE_NAME, and
+    /// COLUMN_TYPE.
+    ///
+    /// All arguments are treated as the Pattern Value Arguments.
+    /// Empty string argument is equivalent to passing the search pattern '%'.
+    catalog::procedure_columns find_procedure_columns(
+        const string& column = string(),
+        const string& procedure = string(),
         const string& schema = string(),
         const string& catalog = string());
 

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1773,12 +1773,12 @@ public:
     class procedures
     {
     public:
-        bool next();                 ///< Move to the next result in the result set.
-        string proc_catalog() const; ///< Fetch procedure catalog.
-        string proc_schema() const;  ///< Fetch procedure schema.
-        string proc_name() const;    ///< Fetch procedure name.
-        string proc_remarks() const; ///< Fetch procedure remarks.
-        short proc_type() const;     ///< Fetch procedure type.
+        bool next();                      ///< Move to the next result in the result set.
+        string procedure_catalog() const; ///< Fetch procedure catalog.
+        string procedure_schema() const;  ///< Fetch procedure schema.
+        string procedure_name() const;    ///< Fetch procedure name.
+        string procedure_remarks() const; ///< Fetch procedure remarks.
+        short procedure_type() const;     ///< Fetch procedure type.
 
     private:
         friend class nanodbc::catalog;
@@ -1791,9 +1791,9 @@ public:
     {
     public:
         bool next();                           ///< Move to the next result in the result set.
-        string proc_catalog() const;           ///< Fetch table catalog.
-        string proc_schema() const;            ///< Fetch table schema.
-        string proc_name() const;              ///< Fetch table name.
+        string procedure_catalog() const;      ///< Fetch procedure catalog.
+        string procedure_schema() const;       ///< Fetch procedure schema.
+        string procedure_name() const;         ///< Fetch procedure name.
         string column_name() const;            ///< Fetch column name.
         short column_type() const;             ///< Fetch column type.
         short data_type() const;               ///< Fetch column data type.

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -540,6 +540,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_catalog_tables", "[mssql][catalog][tables]
     test_catalog_tables();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_catalog_procedure_columns", "[mssql][catalog][procedure_columns]")
+{
+    test_catalog_procedure_columns();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_catalog_table_privileges", "[mssql][catalog][tables]")
 {
     test_catalog_table_privileges();

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -540,7 +540,10 @@ TEST_CASE_METHOD(mssql_fixture, "test_catalog_tables", "[mssql][catalog][tables]
     test_catalog_tables();
 }
 
-TEST_CASE_METHOD(mssql_fixture, "test_catalog_procedure_columns", "[mssql][catalog][procedure_columns]")
+TEST_CASE_METHOD(
+    mssql_fixture,
+    "test_catalog_procedure_columns",
+    "[mssql][catalog][procedure_columns]")
 {
     test_catalog_procedure_columns();
 }

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -582,7 +582,7 @@ struct test_case_fixture : public base_test_fixture
             while (procedures.next())
             {
                 // This values (procedure name) must not be NULL (returned as empty string)
-                REQUIRE(!procedures.proc_name().empty());
+                REQUIRE(!procedures.procedure_name().empty());
                 count++;
             }
             REQUIRE(count > 0);
@@ -616,7 +616,7 @@ struct test_case_fixture : public base_test_fixture
                 while (procedures.next())
                 {
                     // Can not expect name to be exactly the same.
-                    if (procedures.proc_name().find(procedure_name) != std::string::npos)
+                    if (procedures.procedure_name().find(procedure_name) != std::string::npos)
                     {
                         // Unclear whether we can form reliable expectations around the procedure
                         // type
@@ -632,7 +632,7 @@ struct test_case_fixture : public base_test_fixture
                 nanodbc::catalog::procedures procedures = catalog.find_procedures(procedure_name);
                 // expect single record with the wanted procedure
                 REQUIRE(procedures.next());
-                REQUIRE(procedures.proc_name().find(procedure_name) != std::string::npos);
+                REQUIRE(procedures.procedure_name().find(procedure_name) != std::string::npos);
                 // expect no more records
                 REQUIRE(!procedures.next());
             }

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -570,6 +570,111 @@ struct test_case_fixture : public base_test_fixture
         }
     }
 
+    void test_catalog_procedure_columns()
+    {
+        nanodbc::connection connection = connect();
+        nanodbc::catalog catalog(connection);
+
+        // Check we can iterate over any procedures
+        {
+            nanodbc::catalog::procedures procedures = catalog.find_procedures();
+            long count = 0;
+            while (procedures.next())
+            {
+                // This values (procedure name) must not be NULL (returned as empty string)
+                REQUIRE(!procedures.proc_name().empty());
+                count++;
+            }
+            REQUIRE(count > 0);
+        }
+
+        nanodbc::string const procedure_name(NANODBC_TEXT("test_catalog_procedure"));
+
+        // Find a procedure with known name
+        {
+            try
+            {
+                nanodbc::result results =
+                    execute(connection, NANODBC_TEXT("DROP PROCEDURE " + procedure_name));
+            }
+            catch (...)
+            {
+            }
+            execute(
+                connection,
+                NANODBC_TEXT(
+                    "CREATE PROCEDURE " + procedure_name +
+                    " @arg_varchar VARCHAR(10), @arg_int INT "
+                    "AS "
+                    "BEGIN "
+                    "        SELECT @arg_varchar AS A, @arg_int AS B, GETDATE() AS C "
+                    "END;"));
+
+            // Use brute-force look-up
+            {
+                nanodbc::catalog::procedures procedures = catalog.find_procedures();
+                bool found = false;
+                while (procedures.next())
+                {
+                    // Can not expect name to be exactly the same.
+                    if (procedures.proc_name().find(procedure_name) != std::string::npos)
+                    {
+                        // Unclear whether we can form reliable expectations around the procedure
+                        // type
+                        found = true;
+                        break;
+                    }
+                }
+                REQUIRE(found);
+            }
+
+            // Use SQLProcedures pattern search capabilities
+            {
+                nanodbc::catalog::procedures procedures = catalog.find_procedures(procedure_name);
+                // expect single record with the wanted procedure
+                REQUIRE(procedures.next());
+                REQUIRE(procedures.proc_name().find(procedure_name) != std::string::npos);
+                // expect no more records
+                REQUIRE(!procedures.next());
+            }
+        }
+        // Now over to find_procedure_columns
+        {
+            // Check we can iterate over any columns
+            {
+                nanodbc::catalog::procedure_columns columns = catalog.find_procedure_columns();
+                long count = 0;
+                while (columns.next())
+                {
+                    // These values must not be NULL (returned as empty string)
+                    REQUIRE(!columns.column_name().empty());
+                    count++;
+                }
+                REQUIRE(count > 0);
+            }
+            // Find a procedure with known name and verify its known columns
+            {
+                nanodbc::catalog::procedure_columns columns =
+                    catalog.find_procedure_columns(NANODBC_TEXT("%"), procedure_name);
+                long count = 0;
+                while (columns.next())
+                {
+                    // Verify that the expected columns make an appearance
+                    // as well as column_type is as expected.
+                    // All of the remaining attribtues are shared with the SQLColumns
+                    // API call and are tested there
+                    if (columns.column_name().find("arg_int") != std::string::npos ||
+                        columns.column_name().find("arg_varchar") != std::string::npos)
+                    {
+                        REQUIRE(columns.column_type() == SQL_PARAM_INPUT);
+                        count++;
+                    }
+                }
+                REQUIRE(count == 2);
+            }
+        }
+    }
+
     void test_catalog_tables()
     {
         nanodbc::connection connection = connect();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -602,13 +602,12 @@ struct test_case_fixture : public base_test_fixture
             }
             execute(
                 connection,
-                NANODBC_TEXT(
-                    "CREATE PROCEDURE " + procedure_name +
-                    " @arg_varchar VARCHAR(10), @arg_int INT "
-                    "AS "
-                    "BEGIN "
-                    "        SELECT @arg_varchar AS A, @arg_int AS B, GETDATE() AS C "
-                    "END;"));
+                NANODBC_TEXT("CREATE PROCEDURE " + procedure_name) +
+                    NANODBC_TEXT(" @arg_varchar VARCHAR(10), @arg_int INT "
+                                 "AS "
+                                 "BEGIN "
+                                 "        SELECT @arg_varchar AS A, @arg_int AS B, GETDATE() AS C "
+                                 "END;"));
 
             // Use brute-force look-up
             {
@@ -663,8 +662,9 @@ struct test_case_fixture : public base_test_fixture
                     // as well as column_type is as expected.
                     // All of the remaining attribtues are shared with the SQLColumns
                     // API call and are tested there
-                    if (columns.column_name().find("arg_int") != std::string::npos ||
-                        columns.column_name().find("arg_varchar") != std::string::npos)
+                    if (columns.column_name().find(NANODBC_TEXT("arg_int")) != std::string::npos ||
+                        columns.column_name().find(NANODBC_TEXT("arg_varchar")) !=
+                            std::string::npos)
                     {
                         REQUIRE(columns.column_type() == SQL_PARAM_INPUT);
                         count++;


### PR DESCRIPTION
Hi @lexicalunit @mloskot 

This is an implementation of the [SQLProcedures](https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlprocedures-function?view=sql-server-ver15) and [SQLProcedureColumns](https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlprocedurecolumns-function?view=sql-server-ver15) function calls.

This PR adds:

Methods:
* `catalog::find_procedures`: Implementation of `SQLProcedures`, similar to `find_tables`.
* `catalog::find_procedure_columns`: Implementation of `SQLProcedureColumns`, similar to `find_columns`. 

Classes:
* `catalog::procedures`: Result set from `find_procedures`; similar to `catalog::tables`.
* `catalog::procedure_columns`: Result set from `find_columns`; similar to `catalog::columns`.

Looking forward to hearing your feedback.

Thanks