### PR TITLE
Fixes column_size type inconsistency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 message(STATUS "nanodbc compile: C++${CMAKE_CXX_STANDARD}")
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wnarrowing -Werror")
   include(CheckCXXCompilerFlag)
 
   if (NANODBC_ENABLE_COVERAGE)

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2500,7 +2500,7 @@ public:
         return static_cast<long>(col.sqlsize_);
     }
 
-    int column_size(const string& column_name) const
+    long column_size(const string& column_name) const
     {
         const short column = this->column(column_name);
         return column_size(column);

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -260,7 +260,7 @@ struct base_test_fixture
         }
     }
 
-    void check_data_type_size(nanodbc::string const& name, int column_size, short radix = -1)
+    void check_data_type_size(nanodbc::string const& name, long column_size, short radix = -1)
     {
         if (name == NANODBC_TEXT("float"))
         {


### PR DESCRIPTION
This PR fixes the `column_size` type inconsistency. The header file even declares both `column_size` functions as returning long. The implementation should match that.

This caused problems when using nanodbc in projects with narrowing warnings.

As I figured the project probably wants narrowing warnings on (in order to prevent accidental narrowings like these in the future and ensure higher code quality), I've added the respective flag to CMakeLists.txt.