### PR TITLE
Unicode fix for column_datatype_name.

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2542,13 +2542,13 @@ public:
         SQLSMALLINT len = 0; // total number of bytes
         RETCODE rc;
         NANODBC_CALL_RC(
-            SQLColAttribute,
+            NANODBC_FUNC(SQLColAttribute),
             rc,
             stmt_.native_statement_handle(),
             column + 1,
             SQL_DESC_TYPE_NAME,
             type_name,
-            sizeof(type_name) / sizeof(NANODBC_SQLCHAR),
+            sizeof(type_name),
             &len,
             nullptr);
         if (!success(rc))


### PR DESCRIPTION
There was a missing NANODBC_FUNC around the call to SQLColAttribute,
also the wrong unit was used for the BufferLength sent to
SQLColAttribute (should be in bytes, not in characters).

## What does this PR do?
Fixes a Unicode issue in column_datatype_name

## What are related issues/pull requests?
#262

## Tasklist

 - [x] Review
 - [x] All CI builds and checks have passed

## Environment

* DBMS name/version: MS SQL Server
* ODBC connection string: Driver={ODBC Driver 17 for SQL Server};Server=tcp:xxx.database.windows.net,1433;Database=xxx;Uid=xxx;Pwd=xxx;Encrypt=yes;TrustServerCertificate=no;Connection Timeout=30;
* OS and Compiler: Debian Buster, gcc 7.5.0
