### PR TITLE
ensure_pdata: Return unique_ptr so as to not leak resources

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3436,6 +3436,8 @@ std::unique_ptr<T, std::function<void(T*)>> result::result_impl::ensure_pdata(sh
     SQLRETURN rc;
     if (is_bound(column))
     {
+        // Return a unique_ptr with a no-op deleter as this memory allocation
+        // is managed (allocated and released) elsewhere.
         return std::unique_ptr<T, std::function<void(T*)>>(
             (T*)(col.pdata_ + rowset_position_ * col.clen_), [](T* ptr) {});
     }
@@ -3459,6 +3461,9 @@ std::unique_ptr<T, std::function<void(T*)>> result::result_impl::ensure_pdata(sh
         NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
     NANODBC_ASSERT(ValueLenOrInd == (SQLLEN)buffer_size);
 
+    // Return a traditional unique_ptr since we just allocated this buffer, and
+    // we most certainly want this memory returned to the heap when the result
+    // goes out of scope.
     return std::unique_ptr<T>(buffer);
 }
 


### PR DESCRIPTION
Hi @mloskot @lexicalunit 

Fixing here a memory leak I introduced with `ensure_pdata`.

I may be guilty of over-thinking the solution here; any feedback is appreciated.  It seemed to me that, given that we are allocating memory in the function, returning a smart rather than raw pointer is preferable.  But then, I was struggling with the two code-paths - one where we are just re-casting the `pdata_` pointer, and the other where we are returning a pointer to a new allocation.  In the former case, where there is another part of the code-base that is responsible for managing that memory allocation, I ended up returning a `unique_ptr` with a trivial deleter.

Happy to post the valgrind stats, but the leak is pretty obvious.


