### PR TITLE
Take fix from r-dbi to allow correct retrieval of datetimeoffset

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2895,7 +2895,6 @@ private:
                 break;
             case SQL_TIMESTAMP:
             case SQL_TYPE_TIMESTAMP:
-            case SQL_SS_TIMESTAMPOFFSET:
                 col.ctype_ = SQL_C_TIMESTAMP;
                 col.clen_ = sizeof(timestamp);
                 break;
@@ -2911,6 +2910,7 @@ private:
                 break;
             case SQL_WCHAR:
             case SQL_WVARCHAR:
+            case SQL_SS_TIMESTAMPOFFSET:
             case SQL_SS_XML:
                 col.ctype_ = sql_ctype<wide_string>::value;
                 col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLWCHAR);

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -152,8 +152,7 @@ TEST_CASE_METHOD(mssql_fixture, "test_multi_statement_insert_select", "[mssql]")
     // Type of IDENTITY(seed,increment) return value is NUMERIC(38,0)
     // and the function may generate negative values too.
     auto const sid = r.get<nanodbc::string>(0);
-    auto const nid = std::stoll(sid);
-    REQUIRE(nid == 1);
+    REQUIRE(NANODBC_TEXT("1") == sid);
 }
 
 TEST_CASE_METHOD(mssql_fixture, "test_blob", "[mssql][blob][binary][varbinary]")

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -879,19 +879,17 @@ TEST_CASE_METHOD(mssql_fixture, "test_datetimeoffset", "[mssql][datetime]")
         REQUIRE(result.column_datatype_name(0) == NANODBC_TEXT("datetimeoffset"));
 
         REQUIRE(result.next());
-        auto t = result.get<nanodbc::timestamp>(0);
-        REQUIRE(t.year == 2006);
-        REQUIRE(t.month == 12);
-        REQUIRE(t.day == 30);
-        // Currently, nanodbc binds SQL_SS_TIMESTAMPOFFSET as SQL_C_TIMESTAMP,
-        // not as SQL_C_SS_TIMESTAMPOFFSET.
-        // This seems to cause the DBMS or the driver to convert the time to local time
-        // based on time zone
-        // REQUIRE(t.hour == 13); // or 21 (GMT) or 22 (CET) or other client local time
-        REQUIRE(t.hour > 0);
-        REQUIRE(t.min == 45);
-        REQUIRE(t.sec == 12);
-        REQUIRE(t.fract > 0);
+        auto t = result.get<nanodbc::string>(0);
+		// the result is this NANODBC_TEXT("2006-12-30 13:45:12.3450000 -08:00");
+        REQUIRE(t.size() >= 27); // frac of seconds is server and system dependend
+        REQUIRE(t.substr(0, 23) == NANODBC_TEXT("2006-12-30 13:45:12.345"));
+		auto it = t.rbegin();
+		REQUIRE(*it++ == '0');
+		REQUIRE(*it++ == '0');
+		REQUIRE(*it++ == ':');
+		REQUIRE(*it++ == '8');
+		REQUIRE(*it++ == '0');
+		REQUIRE(*it++ == '-');
         ;
     }
 }


### PR DESCRIPTION
This PR will change the API behaviour of datetimeoffset.
It is no longer possible to get those columns via the timestamp class.
Since the timestamp class has no notion of UTC offset, allowing the datetimeoffset as a unparsed strings seems more reasonable.
