### PR TITLE
Add missing include

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <ctime>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <type_traits>
 


### PR DESCRIPTION
## What does this PR do?
Fixes compilation under macOS using Homebrew's vanilla GCC.