### PR TITLE
Updates clang-format linter configuration

### DIFF
--- a/.github/workflows/lint-clang-format.yml
+++ b/.github/workflows/lint-clang-format.yml
@@ -11,6 +11,6 @@ jobs:
     - uses: DoozyX/clang-format-lint-action@v0.12
       with:
         source: '.'
-        extensions: 'hpp,cpp'
-        clangFormatVersion: 5
+        extensions: 'h,cpp'
+        clangFormatVersion: 9
         inplace: True

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3929,12 +3929,12 @@ const class connection& transaction::connection() const
     return impl_->connection();
 }
 
-transaction::operator class connection&()
+transaction::operator class connection &()
 {
     return impl_->connection();
 }
 
-transaction::operator const class connection&() const
+transaction::operator const class connection &() const
 {
     return impl_->connection();
 }

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -383,10 +383,10 @@ using is_string = std::integral_constant<
     std::is_same<typename std::decay<T>::type, std::string>::value ||
         std::is_same<typename std::decay<T>::type, wide_string>::value
 #ifdef NANODBC_SUPPORT_STRING_VIEW
-    || std::is_same<typename std::decay<T>::type, std::string_view>::value
-    || std::is_same<typename std::decay<T>::type, wide_string_view>::value
+        || std::is_same<typename std::decay<T>::type, std::string_view>::value ||
+        std::is_same<typename std::decay<T>::type, wide_string_view>::value
 #endif
->;
+    >;
 
 /// \brief A type trait for testing if a type is a character compatible with the current nanodbc
 /// configuration
@@ -461,10 +461,10 @@ public:
     const class connection& connection() const;
 
     /// Returns the connection object.
-    operator class connection&();
+    operator class connection &();
 
     /// Returns the connection object.
-    operator const class connection&() const;
+    operator const class connection &() const;
 
 private:
     class transaction_impl;

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1049,9 +1049,9 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(!driver_name.empty());
         auto const drivers = nanodbc::list_drivers();
         bool found = std::any_of(
-            drivers.cbegin(), drivers.cend(), [&driver_name](nanodbc::driver const& drv) {
-                return driver_name == drv.name;
-            });
+            drivers.cbegin(),
+            drivers.cend(),
+            [&driver_name](nanodbc::driver const& drv) { return driver_name == drv.name; });
         REQUIRE(found);
     }
 
@@ -1063,8 +1063,11 @@ struct test_case_fixture : public base_test_fixture
         // it is registered with the ODBC Driver Manager in the host environment.
         REQUIRE(!driver_name.empty());
         auto const dsns = nanodbc::list_datasources();
-        bool found =
-            std::any_of(dsns.cbegin(), dsns.cend(), [&driver_name](nanodbc::datasource const& dsn) {
+        bool found = std::any_of(
+            dsns.cbegin(),
+            dsns.cend(),
+            [&driver_name](nanodbc::datasource const& dsn)
+            {
                 return dsn.name == nanodbc::test::convert((std::string) "testdsn") &&
                        dsn.driver == driver_name;
             });
@@ -1636,8 +1639,10 @@ struct test_case_fixture : public base_test_fixture
         const std::vector<nanodbc::string> gender_str = {
             NANODBC_TEXT("Male"), NANODBC_TEXT("Male"), NANODBC_TEXT("")};
 
-        const std::vector<nanodbc::string_view> first_name(first_name_str.begin(), first_name_str.end());
-        const std::vector<nanodbc::string_view> last_name(last_name_str.begin(), last_name_str.end());
+        const std::vector<nanodbc::string_view> first_name(
+            first_name_str.begin(), first_name_str.end());
+        const std::vector<nanodbc::string_view> last_name(
+            last_name_str.begin(), last_name_str.end());
         const std::vector<nanodbc::string_view> gender(gender_str.begin(), gender_str.end());
 
         drop_table(connection, NANODBC_TEXT("test_string_view_vector"));
@@ -1649,7 +1654,8 @@ struct test_case_fixture : public base_test_fixture
         nanodbc::statement query(connection);
         prepare(
             query,
-            NANODBC_TEXT("insert into test_string_view_vector(first, last, gender) values(?, ?, ?)"));
+            NANODBC_TEXT(
+                "insert into test_string_view_vector(first, last, gender) values(?, ?, ?)"));
         REQUIRE(query.parameters() == 3);
 
         // Without nulls
@@ -1664,8 +1670,8 @@ struct test_case_fixture : public base_test_fixture
 
         nanodbc::execute(query, 3);
 
-        nanodbc::result results =
-            execute(connection, NANODBC_TEXT("select first,last,gender from test_string_view_vector"));
+        nanodbc::result results = execute(
+            connection, NANODBC_TEXT("select first,last,gender from test_string_view_vector"));
         REQUIRE(results.next());
         REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("Fred"));
         REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("Flintstone"));
@@ -1680,7 +1686,7 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(results.is_null(2));
 #endif //__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
     }
-    
+
     void test_string_vector_null_vector()
     {
         nanodbc::connection connection = connect();
@@ -1893,15 +1899,16 @@ struct test_case_fixture : public base_test_fixture
         std::size_t const batch_size = 9;
         int integers[batch_size] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
         float floats[batch_size] = {1.123f, 2.345f, 3.1f, 4.5f, 5.678f, 6.f, 7.89f, 8.90f, 9.1234f};
-        nanodbc::string::value_type trunc_float[batch_size][6] = {NANODBC_TEXT("1.100"),
-                                                                  NANODBC_TEXT("2.300"),
-                                                                  NANODBC_TEXT("3.100"),
-                                                                  NANODBC_TEXT("4.500"),
-                                                                  NANODBC_TEXT("5.700"),
-                                                                  NANODBC_TEXT("6.000"),
-                                                                  NANODBC_TEXT("7.900"),
-                                                                  NANODBC_TEXT("8.900"),
-                                                                  NANODBC_TEXT("9.100")};
+        nanodbc::string::value_type trunc_float[batch_size][6] = {
+            NANODBC_TEXT("1.100"),
+            NANODBC_TEXT("2.300"),
+            NANODBC_TEXT("3.100"),
+            NANODBC_TEXT("4.500"),
+            NANODBC_TEXT("5.700"),
+            NANODBC_TEXT("6.000"),
+            NANODBC_TEXT("7.900"),
+            NANODBC_TEXT("8.900"),
+            NANODBC_TEXT("9.100")};
         nanodbc::string::value_type strings[batch_size][60] = {
             NANODBC_TEXT("first string"),
             NANODBC_TEXT("second string"),


### PR DESCRIPTION
## What does this PR do?
With respect to https://github.com/nanodbc/nanodbc/pull/272#discussion_r774798427 I think perhaps the `clang-format` linter wasn't running on `nanodbc.h` because it didn't match the extension list. Perviously the extension list was `hpp,cpp`. This MR changes it to `h,cpp`.

I have also ran `find . -iname "*.cpp" -or -iname "*.h" -print0 | xargs clang-format -i -style=file` locally to update the source code. ~~Locally I have version 13 installed, which seems to be supported by [DoozyX/clang-format-lint-action](https://github.com/DoozyX/clang-format-lint-action#clangformatversion), so I also updated the linter configuration to use this version 🤷🏻‍♀️~~ It seems like version 13 of clang-format is not available in CI. I changed it to 9 as that's the default setting for `DoozyX/clang-format-lint-action`.

To verify that this catches tabs in `nanodbc.h` I replaced some leading spaces with a tab to see if it would catch it.

```shell
clang-format -style=file -output-replacements-xml nanodbc/nanodbc.h
<?xml version='1.0'?>
<replacements xml:space='preserve' incomplete_format='false'>
<replacement offset='12923' length='2'>&#10;    </replacement>
</replacements>
```

Seems like it's working now.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed
