### PR TITLE
fix: Do not restrict number of digits for SQL_C_DOUBLE

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3230,8 +3230,9 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         const int bytes = std::snprintf(
             const_cast<char*>(buffer.data()),
             width + 1,
-            "%.*lf",    // restrict the number of digits
-            col.scale_, // number of digits after the decimal point
+            "%f", // do not restrict the number of digits, because for floating-point
+                  // columns the scale is undefined - number of digits to the right
+                  // of the decimal point is not fixed
             data);
         if (bytes == -1)
             throw type_incompatible_error();


### PR DESCRIPTION
## What does this PR do?

Since, scale value returned by `DescribeCol` is always zero for `SQL_FLOAT` and `SQL_DOUBLE`, retrieving float-point value via `get<string>` led to truncation of decimal digits.

From https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/decimal-digits
>  For approximate floating-point number columns or parameters,
>  the scale is undefined because the number of digits to the right
>  of the decimal point is not fixed.

## What are related issues/pull requests?

Fix related to discussion in #288

## Tasklist

 - [x] Add test case(s)
 - [x] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
