### PR TITLE
BugFix: Last character of SQLSTATE error code is not copied to nanodbc::database_error::state()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:17.04
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+
 # NOTE: install apt-utils since it is Priority: important, should really be installed otherwise
 #       'debconf: delaying package configuration, since apt-utils is not installed'
 RUN apt-get -qy update && apt-get -qy install --no-upgrade --no-install-recommends \
@@ -35,6 +37,7 @@ RUN apt-get -qy update && apt-get -qy install --no-upgrade --no-install-recommen
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update
 RUN ACCEPT_EULA=Y apt-get -qy install --no-upgrade --no-install-recommends \
         msodbcsql \
         mssql-tools

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3743,9 +3743,7 @@ connection::connection(const string& connection_string, long timeout)
 {
 }
 
-connection::~connection() noexcept
-{
-}
+connection::~connection() noexcept {}
 
 void connection::allocate()
 {
@@ -3909,9 +3907,7 @@ void transaction::swap(transaction& rhs) noexcept
     swap(impl_, rhs.impl_);
 }
 
-transaction::~transaction() noexcept
-{
-}
+transaction::~transaction() noexcept {}
 
 void transaction::commit()
 {
@@ -3933,12 +3929,12 @@ const class connection& transaction::connection() const
     return impl_->connection();
 }
 
-transaction::operator class connection&()
+transaction::operator class connection &()
 {
     return impl_->connection();
 }
 
-transaction::operator const class connection&() const
+transaction::operator const class connection &() const
 {
     return impl_->connection();
 }
@@ -3997,9 +3993,7 @@ void statement::swap(statement& rhs) noexcept
     swap(impl_, rhs.impl_);
 }
 
-statement::~statement() noexcept
-{
-}
+statement::~statement() noexcept {}
 
 void statement::open(class connection& conn)
 {
@@ -5047,9 +5041,7 @@ result::result()
 {
 }
 
-result::~result() noexcept
-{
-}
+result::~result() noexcept {}
 
 result::result(statement stmt, long rowset_size)
     : impl_(new result_impl(stmt, rowset_size))

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -408,14 +408,14 @@ recent_error(SQLHANDLE handle, SQLSMALLINT handle_type, long& native, std::strin
     } while (rc != SQL_NO_DATA);
 
     convert(std::move(result), rvalue);
-    if (size(sql_state) > 0)
+
+    auto stateSize = size(sql_state);
+    if (stateSize > 0)
     {
-        state.clear();
-        state.reserve(size(sql_state) - 1);
-        for (std::size_t idx = 0; idx != size(sql_state) - 1; ++idx)
-        {
-            state.push_back(static_cast<char>(sql_state[idx]));
-        }
+        state.resize(stateSize);
+        std::transform(sql_state, sql_state + stateSize, std::begin(state), [](NANODBC_SQLCHAR c) {
+            return static_cast<char>(c);
+        });
     }
 
     native = native_error;
@@ -3743,7 +3743,9 @@ connection::connection(const string& connection_string, long timeout)
 {
 }
 
-connection::~connection() noexcept {}
+connection::~connection() noexcept
+{
+}
 
 void connection::allocate()
 {
@@ -3907,7 +3909,9 @@ void transaction::swap(transaction& rhs) noexcept
     swap(impl_, rhs.impl_);
 }
 
-transaction::~transaction() noexcept {}
+transaction::~transaction() noexcept
+{
+}
 
 void transaction::commit()
 {
@@ -3929,12 +3933,12 @@ const class connection& transaction::connection() const
     return impl_->connection();
 }
 
-transaction::operator class connection &()
+transaction::operator class connection&()
 {
     return impl_->connection();
 }
 
-transaction::operator const class connection &() const
+transaction::operator const class connection&() const
 {
     return impl_->connection();
 }
@@ -3993,7 +3997,9 @@ void statement::swap(statement& rhs) noexcept
     swap(impl_, rhs.impl_);
 }
 
-statement::~statement() noexcept {}
+statement::~statement() noexcept
+{
+}
 
 void statement::open(class connection& conn)
 {
@@ -5041,7 +5047,9 @@ result::result()
 {
 }
 
-result::~result() noexcept {}
+result::~result() noexcept
+{
+}
 
 result::result(statement stmt, long rowset_size)
     : impl_(new result_impl(stmt, rowset_size))

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -409,11 +409,11 @@ recent_error(SQLHANDLE handle, SQLSMALLINT handle_type, long& native, std::strin
 
     convert(std::move(result), rvalue);
 
-    auto stateSize = size(sql_state);
-    if (stateSize > 0)
+    auto state_size = size(sql_state);
+    if (state_size > 0)
     {
-        state.resize(stateSize);
-        std::transform(sql_state, sql_state + stateSize, std::begin(state), [](NANODBC_SQLCHAR c) {
+        state.resize(state_size);
+        std::transform(sql_state, sql_state + state_size, std::begin(state), [](NANODBC_SQLCHAR c) {
             return static_cast<char>(c);
         });
     }

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -39,18 +39,18 @@ struct test_case_fixture : public base_test_fixture
 
     template <typename Functor>
     void check_database_error_state(
-        Functor operationThrowsDatabaseError,
-        const std::string& expectedState)
+        Functor operation_throws_database_error,
+        const std::string& expected_state)
     {
         bool database_error_thrown = false;
         try
         {
-            operationThrowsDatabaseError();
+            operation_throws_database_error();
         }
         catch (const nanodbc::database_error& err)
         {
             database_error_thrown = true;
-            REQUIRE(expectedState == err.state());
+            REQUIRE(expected_state == err.state());
         }
         catch (...)
         {

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -328,8 +328,7 @@ struct test_case_fixture : public base_test_fixture
                     NANODBC_TEXT("c2 float NULL,") + NANODBC_TEXT("c3 decimal(9, 3),") +
                     NANODBC_TEXT("c4 date,") // seems more portable than datetime (SQL Server),
                                              // timestamp (PostgreSQL, MySQL)
-                    +
-                    NANODBC_TEXT("c5 varchar(60) DEFAULT \'sample value\',") +
+                    + NANODBC_TEXT("c5 varchar(60) DEFAULT \'sample value\',") +
                     NANODBC_TEXT("c6 varchar(120),") + NANODBC_TEXT("c7 ") + text_type_name +
                     NANODBC_TEXT(",") + NANODBC_TEXT("c8 ") + binary_type_name +
                     NANODBC_TEXT(");"));
@@ -1082,20 +1081,17 @@ struct test_case_fixture : public base_test_fixture
     void test_datasources()
     {
         auto const dsns = nanodbc::list_datasources();
-        bool test_dsn_found = std::any_of(
-            dsns.cbegin(),
-            dsns.cend(),
-            [](nanodbc::datasource const& dsn)
-            { return dsn.name == nanodbc::test::convert("testdsn"); });
+        bool test_dsn_found =
+            std::any_of(dsns.cbegin(), dsns.cend(), [](nanodbc::datasource const& dsn) {
+                return dsn.name == nanodbc::test::convert("testdsn");
+            });
         if (test_dsn_found)
         {
             auto const driver_name = connection_string_parameter(NANODBC_TEXT("DRIVER"));
             REQUIRE(!driver_name.empty());
 
             bool found = std::any_of(
-                dsns.cbegin(),
-                dsns.cend(),
-                [&driver_name](nanodbc::datasource const& dsn) {
+                dsns.cbegin(), dsns.cend(), [&driver_name](nanodbc::datasource const& dsn) {
                     return dsn.name == nanodbc::test::convert("testdsn") &&
                            dsn.driver == driver_name;
                 });
@@ -1932,15 +1928,16 @@ struct test_case_fixture : public base_test_fixture
         std::size_t const batch_size = 9;
         int integers[batch_size] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
         float floats[batch_size] = {1.123f, 2.345f, 3.1f, 4.5f, 5.678f, 6.f, 7.89f, 8.90f, 9.1234f};
-        nanodbc::string::value_type trunc_float[batch_size][6] = {NANODBC_TEXT("1.100"),
-                                                                  NANODBC_TEXT("2.300"),
-                                                                  NANODBC_TEXT("3.100"),
-                                                                  NANODBC_TEXT("4.500"),
-                                                                  NANODBC_TEXT("5.700"),
-                                                                  NANODBC_TEXT("6.000"),
-                                                                  NANODBC_TEXT("7.900"),
-                                                                  NANODBC_TEXT("8.900"),
-                                                                  NANODBC_TEXT("9.100")};
+        nanodbc::string::value_type trunc_float[batch_size][6] = {
+            NANODBC_TEXT("1.100"),
+            NANODBC_TEXT("2.300"),
+            NANODBC_TEXT("3.100"),
+            NANODBC_TEXT("4.500"),
+            NANODBC_TEXT("5.700"),
+            NANODBC_TEXT("6.000"),
+            NANODBC_TEXT("7.900"),
+            NANODBC_TEXT("8.900"),
+            NANODBC_TEXT("9.100")};
         nanodbc::string::value_type strings[batch_size][60] = {
             NANODBC_TEXT("first string"),
             NANODBC_TEXT("second string"),


### PR DESCRIPTION
## What does this PR do?

1. Bugfix: Last character of ODBC state was not copied to nanodbc::database_error exception, so nanodbc::database_error::state returned only with the first four character of the SQLSTATE.

2. Fix Docker build: docker build failed with the following error:

        **Reading package lists...
        W: The repository 'http://archive.ubuntu.com/ubuntu zesty Release' does not have a Release file.
        W: The repository 'http://archive.ubuntu.com/ubuntu zesty-updates Release' does not have a Release file.
        W: The repository 'http://security.ubuntu.com/ubuntu zesty-security Release' does not have a Release file.
        W: The repository 'http://archive.ubuntu.com/ubuntu zesty-backports Release' does not have a Release file.
        E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty/universe/source/Sources  404  Not Found [IP: 185.125.190.36 80]
        E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty-updates/universe/source/Sources  404  Not Found [IP: 185.125.190.36 80]
        E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/zesty-security/universe/source/Sources  404  Not Found [IP: 91.189.91.38 80]
        E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty-backports/main/binary-amd64/Packages  404  Not Found [IP: 185.125.190.36 80]
        E: Some index files failed to download. They have been ignored, or old ones used instead.
        The command '/bin/bash -o pipefail -c apt-get -qy update && apt-get -qy install --no-upgrade --no-install-recommends         apt-transport-https         apt-utils         curl         software-properties-common         && apt-get clean         && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100**
      
      Solution:
      https://askubuntu.com/questions/999856/apt-get-update-fails-when-updating-from-17-04-to-17-10-after-eol-none-of-the-mi