### PR TITLE
fix: SQLSTATE truncation (#267)

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -411,8 +411,8 @@ recent_error(SQLHANDLE handle, SQLSMALLINT handle_type, long& native, std::strin
     if (size(sql_state) > 0)
     {
         state.clear();
-        state.reserve(size(sql_state) - 1);
-        for (std::size_t idx = 0; idx != size(sql_state) - 1; ++idx)
+        state.reserve(size(sql_state));
+        for (std::size_t idx = 0; idx != size(sql_state); ++idx)
         {
             state.push_back(static_cast<char>(sql_state[idx]));
         }

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -577,6 +577,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_decimal_conversion", "[mssql][decimal][con
     test_decimal_conversion();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_error", "[mssql][error]")
+{
+    test_error();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_exception", "[mssql][exception]")
 {
     test_exception();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -173,6 +173,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_decimal_conversion", "[mysql][decimal][con
     test_decimal_conversion();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_error", "[mysql][error]")
+{
+    test_error();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_exception", "[mysql][exception]")
 {
     test_exception();

--- a/test/odbc_test.cpp
+++ b/test/odbc_test.cpp
@@ -69,6 +69,11 @@ TEST_CASE_METHOD(odbc_fixture, "test_decimal_conversion", "[odbc][decimal][conve
     test_decimal_conversion();
 }
 
+TEST_CASE_METHOD(odbc_fixture, "test_error", "[odbc][error]")
+{
+    test_error();
+}
+
 TEST_CASE_METHOD(odbc_fixture, "test_exception", "[odbc][exception]")
 {
     test_exception();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -108,6 +108,11 @@ TEST_CASE_METHOD(postgresql_fixture, "test_decimal_conversion", "[postgresql][de
     test_decimal_conversion();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "test_error", "[postgresql][error]")
+{
+    test_error();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_exception", "[postgresql][exception]")
 {
     test_exception();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -254,6 +254,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_decimal_conversion", "[sqlite][decimal][c
     REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("-1.333"));
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_error", "[sqlite][error]")
+{
+    test_error();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_exception", "[sqlite][exception]")
 {
     test_exception();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1104,10 +1104,7 @@ struct test_case_fixture : public base_test_fixture
         execute(connection, create_table_sql);
 
         nanodbc::statement statement(connection);
-        const int i = 0;
-        prepare(statement, NANODBC_TEXT("insert into test_error (i) values (?);"));
-        REQUIRE(statement.parameters() == 1);
-        statement.bind(0, &i, 1, nullptr, nanodbc::statement::PARAM_IN);
+        prepare(statement, NANODBC_TEXT("insert into test_error (i) values (0);"));
         execute(statement);
 
         nanodbc::database_error error = nanodbc::database_error(nullptr, 0);

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1079,6 +1079,86 @@ struct test_case_fixture : public base_test_fixture
         }
     }
 
+    void test_error()
+    {
+        nanodbc::connection connection = connect();
+
+        drop_table(connection, NANODBC_TEXT("test_error"));
+        nanodbc::string create_table_sql = NANODBC_TEXT("create table test_error (i int not null");
+        if (vendor_ == database_vendor::mysql)
+        {
+            create_table_sql =
+                create_table_sql + NANODBC_TEXT(", constraint test_error_pk primary key (i)");
+        }
+        else
+        {
+            create_table_sql =
+                create_table_sql + NANODBC_TEXT(" constraint test_error_pk primary key");
+        }
+        if (vendor_ == database_vendor::vertica)
+        {
+            create_table_sql = create_table_sql + NANODBC_TEXT(" enabled");
+        }
+        create_table_sql = create_table_sql + NANODBC_TEXT(");");
+
+        execute(connection, create_table_sql);
+
+        nanodbc::statement statement(connection);
+        const int i = 0;
+        prepare(statement, NANODBC_TEXT("insert into test_error (i) values (?);"));
+        REQUIRE(statement.parameters() == 1);
+        statement.bind(0, &i, 1, nullptr, nanodbc::statement::PARAM_IN);
+        execute(statement);
+
+        nanodbc::database_error error = nanodbc::database_error(nullptr, 0);
+
+        try
+        {
+            statement.execute();
+        }
+        catch (const nanodbc::database_error& e)
+        {
+            error = e;
+        }
+
+        struct error_result
+        {
+            int n = 0;
+            std::string s;
+            std::string w;
+        } error_result;
+
+        switch (vendor_)
+        {
+        case database_vendor::mysql:
+            error_result = {1062, "23000", "Duplicate entry"};
+            break;
+        case database_vendor::oracle:
+            error_result = {1, "25S03", "ORA-00001"};
+            break;
+        case database_vendor::postgresql:
+            error_result = {1, "23505", "duplicate key value violates unique constraint"};
+            break;
+        case database_vendor::sqlite:
+            error_result = {19, "HY000", "[SQLite]UNIQUE constraint failed"};
+            break;
+        case database_vendor::sqlserver:
+            error_result = {2627, "23000", "Violation of PRIMARY KEY constraint"};
+            break;
+        case database_vendor::vertica:
+            // todo validate vertica
+            //  https://www.vertica.com/docs/11.1.x/HTML/Content/Authoring/ErrorCodes/SqlState-23505.htm
+            error_result = {6745, "23505", "Duplicate key values"};
+            break;
+        default:
+            FAIL("Database vendor is unknown.");
+        }
+
+        REQUIRE(error.native() == error_result.n);
+        REQUIRE_THAT(error.state(), Catch::Matches(error_result.s));
+        REQUIRE_THAT(error.what(), Catch::Contains(error_result.w));
+    }
+
     void test_exception()
     {
         nanodbc::connection connection = connect();

--- a/test/vertica_test.cpp
+++ b/test/vertica_test.cpp
@@ -86,6 +86,11 @@ TEST_CASE_METHOD(vertica_fixture, "test_decimal_conversion", "[vertica][decimal]
     test_decimal_conversion();
 }
 
+TEST_CASE_METHOD(vertica_fixture, "test_error", "[vertica][error]")
+{
+    test_error();
+}
+
 TEST_CASE_METHOD(vertica_fixture, "test_exception", "[vertica][exception]")
 {
     test_exception();


### PR DESCRIPTION
## What does this PR do?

Fixes SQLSTATE truncation in nanodbc.

## What are related issues/pull requests?

#267 #297

## Environment

DB platforms tested:

* Microsoft SQL Server 2017 (14.00.1000)
* MySQL 8.0.13
* Oracle 11.2.0.2.0
* PostgreSQL 12.1
* SQLite 3.25.1
* Vertica has not been tested
