### PR TITLE
Remove non-ascii character from source

### DIFF
--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1281,7 +1281,7 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(results.next());
 
         // NOTE: Parentheses around REQIURE() expressions are to silence error:
-        //       suggest parentheses around comparison in operand of ‘==’ [-Werror=parentheses]
+        //       suggest parentheses around comparison in operand of '==' [-Werror=parentheses]
         T ref;
         p = 0;
         results.get_ref(p, ref);


### PR DESCRIPTION
## What does this PR do?
Remove non-ascii character from source
Remove C4819 warning on Visual Studio 2019
