### PR TITLE
Make CMAKE_CXX_STANDARD to cache variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ message(STATUS "nanodbc version: ${NANODBC_VERSION}")
 ########################################
 ## require and enable C++0x/11/14
 ########################################
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ standard to use for NANODBC")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 message(STATUS "nanodbc compile: C++${CMAKE_CXX_STANDARD}")


### PR DESCRIPTION
## What does this PR do?
for using c++17 standard, like string_view
cmake -S . -B build -DCMAKE_CXX_STANDARD=17

## What are related issues/pull requests?
[#299  ](https://github.com/nanodbc/nanodbc/pull/299#pullrequestreview-936805997)
