### PR TITLE
test: Fix test_error with correct SQL State and native code

### DIFF
--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1141,7 +1141,7 @@ struct test_case_fixture : public base_test_fixture
             error_result = {1, "25S03", "ORA-00001"};
             break;
         case database_vendor::postgresql:
-            error_result = {1, "23505", "duplicate key value violates unique constraint"};
+            error_result = {7, "23505", "duplicate key value violates unique constraint"};
             break;
         case database_vendor::sqlite:
             error_result = {19, "HY000", "[SQLite]UNIQUE constraint failed"};

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1140,7 +1140,10 @@ struct test_case_fixture : public base_test_fixture
             error_result = {19, "HY000", "[SQLite]UNIQUE constraint failed"};
             break;
         case database_vendor::sqlserver:
-            error_result = {2627, "23000", "Violation of PRIMARY KEY constraint"};
+            // 01000: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Violation of PRIMARY KEY
+            // constraint 'test_error_pk'. [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The
+            // statement has been terminated.
+            error_result = {3621, "01000", "Violation of PRIMARY KEY constraint"};
             break;
         case database_vendor::vertica:
             // todo validate vertica

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1118,11 +1118,18 @@ struct test_case_fixture : public base_test_fixture
             error = e;
         }
 
-        struct error_result
+        struct error_result_t
         {
             int n = 0;
             std::string s;
             std::string w;
+            error_result_t() = default;
+            error_result_t(int n, std::string s, std::string w)
+                : n(n)
+                , s(s)
+                , w(w)
+            {
+            }
         } error_result;
 
         switch (vendor_)


### PR DESCRIPTION
## What does this PR do?

It seems the `"Violation of PRIMARY KEY constraint"` error is accompanied/concluded with `"The statement has been terminated"` as there is a hierarchy or list of diagnostics collected by the `recent_error` utility function:

https://github.com/nanodbc/nanodbc/blob/946084a9a2a7a34429390c23c56bee2be4a2da6d/nanodbc/nanodbc.cpp#L391-L441

So, all the error messages are collected and concatenated into a single message of `database_error` exception.
But, SQL State and SQL Native Code are stored for the last diagnostics, that is, for "The statement has been terminated".

In future, this could be improved by changing `database_error` to remember queue list of diagnostics.

## What are related issues/pull requests?

- #298

## Tasklist

 - [x] All CI builds and checks have passed -  conditionally

