### PR TITLE
chore!: Remove deprecated async_complete

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4826,11 +4826,6 @@ result statement::complete_execute(long batch_operations)
     return impl_->complete_execute(batch_operations, *this);
 }
 
-result statement::async_complete(long batch_operations)
-{
-    return impl_->complete_execute(batch_operations, *this);
-}
-
 void statement::enable_async(void* event_handle)
 {
     impl_->enable_async(event_handle);

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -895,11 +895,6 @@ public:
     /// \see async_execute(), async_execute_direct()
     class result complete_execute(long batch_operations = 1);
 
-    /// \brief Completes a previously initiated asynchronous query execution, returning the result.
-    ///
-    /// \deprecated Use complete_execute instead.
-    NANODBC_DEPRECATED class result async_complete(long batch_operations = 1);
-
     /// undocumented - for internal use only (used from result_impl)
     void enable_async(void* event_handle);
 


### PR DESCRIPTION
## What does this PR do?

BREAKING CHANGE: Public  API function complete
has been removed, use complete_execute instead.

It has been deprecated since v2.13.0 released in 2017
see 322591390156e57cd3509a48e5d4180ddca05682

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

