### PR TITLE
test: Test unbinding vs access in order of increasing column number

### DIFF
--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -527,7 +527,8 @@ TEST_CASE_METHOD(
         NANODBC_TEXT("insert into test_blob_retrieve_out_of_order values "
                      "(1, 'this is varchar max', 11, 'this is text');"));
 
-    // Out of order
+    // Query bound and unbound interleaved.
+    // Access in order of increasing column number.
     {
         nanodbc::result results = nanodbc::execute(
             connection,
@@ -539,7 +540,8 @@ TEST_CASE_METHOD(
             results.get<nanodbc::string>(1), Catch::Contains("Invalid Descriptor Index"));
     }
 
-    // Bound first, then unbound
+    // Query bound first, then unbound.
+    // Access in order of increasing column number.
     {
         nanodbc::result results = nanodbc::execute(
             connection,
@@ -552,7 +554,37 @@ TEST_CASE_METHOD(
         REQUIRE(results.get<nanodbc::string>(3) == NANODBC_TEXT("this is text"));
     }
 
-    // Unbind all columns
+    // Query bound first, then unbound.
+    // Access bound NOT in order and unbound in order of increasing column number.
+    {
+        nanodbc::result results = nanodbc::execute(
+            connection,
+            NANODBC_TEXT("select c1_bound, c3_bound, c2_unbound, c4_unbound from "
+                         "test_blob_retrieve_out_of_order;"));
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 1);
+        REQUIRE(results.get<nanodbc::string>(2) == NANODBC_TEXT("this is varchar max"));
+        REQUIRE(results.get<int>(1) == 11); // no error "Invalid Descriptor Index"
+        REQUIRE(results.get<nanodbc::string>(3) == NANODBC_TEXT("this is text"));
+    }
+    // Query bound first, then unbound.
+    // Access bound in order and unbound NOT in order of increasing column number.
+    {
+        nanodbc::result results = nanodbc::execute(
+            connection,
+            NANODBC_TEXT("select c1_bound, c3_bound, c2_unbound, c4_unbound from "
+                         "test_blob_retrieve_out_of_order;"));
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 1);
+        REQUIRE(results.get<int>(1) == 11);
+        REQUIRE(results.get<nanodbc::string>(3) == NANODBC_TEXT("this is text"));
+        REQUIRE_THROWS_WITH(
+            results.get<nanodbc::string>(2), Catch::Contains("Invalid Descriptor Index"));
+    }
+
+    // Query bound and unbound interleaved.
+    // Unbind all columns.
+    // Access in order of increasing column number.
     {
         nanodbc::result results = nanodbc::execute(
             connection,
@@ -565,8 +597,22 @@ TEST_CASE_METHOD(
         REQUIRE(results.get<int>(2) == 11);
         REQUIRE(results.get<nanodbc::string>(3) == NANODBC_TEXT("this is text"));
     }
+    // Query bound and unbound interleaved.
+    // Unbind all columns.
+    // Access NOT in order of increasing column number.
+    {
+        nanodbc::result results = nanodbc::execute(
+            connection,
+            NANODBC_TEXT("select c1_bound, c2_unbound, c3_bound, c4_unbound from "
+                         "test_blob_retrieve_out_of_order;"));
+        results.unbind();
+        REQUIRE(results.next());
+        REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("this is varchar max"));
+        REQUIRE_THROWS_WITH(results.get<int>(0), Catch::Contains("Invalid Descriptor Index"));
+    }
 
-    // Unbind offending column only
+    // Query bound and unbound interleaved.
+    // Unbind offending column only, and access in order of increasing column number.
     {
         nanodbc::result results = nanodbc::execute(
             connection,
@@ -575,6 +621,20 @@ TEST_CASE_METHOD(
         REQUIRE(results.is_bound(0));
         REQUIRE(results.is_bound(2));
         results.unbind(2); // make c3_bound an unbound column
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 1);
+        REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("this is varchar max"));
+        REQUIRE(results.get<int>(2) == 11);
+        REQUIRE(results.get<nanodbc::string>(3) == NANODBC_TEXT("this is text"));
+    }
+
+    // Unbind all columns, and access NOT in order of increasing column number
+    {
+        nanodbc::result results = nanodbc::execute(
+            connection,
+            NANODBC_TEXT("select c1_bound, c2_unbound, c3_bound, c4_unbound from "
+                         "test_blob_retrieve_out_of_order;"));
+        results.unbind();
         REQUIRE(results.next());
         REQUIRE(results.get<int>(0) == 1);
         REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("this is varchar max"));

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1273,10 +1273,16 @@ TEST_CASE_METHOD(
     stmt.prepare(NANODBC_TEXT("{ CALL tvp_test(?, ?, ?) }"));
 
     std::vector<std::string_view> p1_col2_view;
-    for (auto& p : p1_col2_) { p1_col2_view.emplace_back(p); }
+    for (auto& p : p1_col2_)
+    {
+        p1_col2_view.emplace_back(p);
+    }
 
     std::vector<nanodbc::wide_string_view> p1_col3_view;
-    for (auto& p : p1_col3_) { p1_col3_view.emplace_back(p); }
+    for (auto& p : p1_col3_)
+    {
+        p1_col3_view.emplace_back(p);
+    }
 
     // bind param 0
     stmt.bind(0, &p0_);


### PR DESCRIPTION
## What does this PR do?

This is to illustrate that unbinding only helps to work around some cases of out-of-order access, namely, when  query interleaves bound and unbound columns, but access is still performed in order of increasing column number.

Unbinding does not avoid the limitation of `SQLGetData` which requires access in order of increasing column number.

The limitation could be worked around with `result` class **adapter caching values of all columns at once** to ensure access in order of increasing column number.

## What are related issues/pull requests?

Related to issue #228 and enhancement PR #236

## Tasklist

 - [x] All CI builds and checks have passed

