### PR TITLE
chore: Rename NANODBC_H to NANODBC_NANODBC_H

### DIFF
--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -73,8 +73,8 @@
 /// See http://www.codeguru.com/submission-guidelines.php for details.
 /// </div>
 
-#ifndef NANODBC_H
-#define NANODBC_H
+#ifndef NANODBC_NANODBC_H
+#define NANODBC_NANODBC_H
 
 #include <cstddef>
 #include <functional>


### PR DESCRIPTION
## What does this PR do?

Use `<LIBRARY NAME>_<HEADER NAME>_H` convention
for naming include guards to make things clearer
when new headers arrive.

## Tasklist

 - [x] All CI builds and checks have passed

