### PR TITLE
fix: Null fallback was ignored for bound columns retrieved as unbound

### DIFF
--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -749,6 +749,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_nullptr_nulls", "[mssql][null]")
     test_nullptr_nulls();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_null_with_bound_columns_unbound", "[mssql][null][unbound]")
+{
+    test_null_with_bound_columns_unbound();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_result_at_end", "[mssql][result]")
 {
     test_result_at_end();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -216,7 +216,12 @@ TEST_CASE_METHOD(mysql_fixture, "test_nullptr_nulls", "[mysql][null]")
     test_nullptr_nulls();
 }
 
-TEST_CASE_METHOD(mysql_fixture, "test_result_at_end", "[mssql][result]")
+TEST_CASE_METHOD(mysql_fixture, "test_null_with_bound_columns_unbound", "[mysql][null][unbound]")
+{
+    test_null_with_bound_columns_unbound();
+}
+
+TEST_CASE_METHOD(mysql_fixture, "test_result_at_end", "[mysql][result][result]")
 {
     test_result_at_end();
 }

--- a/test/odbc_test.cpp
+++ b/test/odbc_test.cpp
@@ -109,12 +109,17 @@ TEST_CASE_METHOD(odbc_fixture, "test_nullptr_nulls", "[odbc][null]")
     test_nullptr_nulls();
 }
 
-TEST_CASE_METHOD(odbc_fixture, "test_result_at_end", "[mssql][result]")
+TEST_CASE_METHOD(mssql_fixture, "test_null_with_bound_columns_unbound", "[odbc][null][unbound]")
+{
+    test_null_with_bound_columns_unbound();
+}
+
+TEST_CASE_METHOD(odbc_fixture, "test_result_at_end", "[odbc][result]")
 {
     test_result_at_end();
 }
 
-TEST_CASE_METHOD(odbc_fixture, "test_result_iterator", "[odbc][iterator]")
+TEST_CASE_METHOD(odbc_fixture, "test_result_iterator", "[odbc][result][iterator]")
 {
     test_result_iterator();
 }

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -146,12 +146,20 @@ TEST_CASE_METHOD(postgresql_fixture, "test_null", "[postgresql][null]")
     test_null();
 }
 
-TEST_CASE_METHOD(postgresql_fixture, "test_result_at_end", "[mssql][result]")
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_null_with_bound_columns_unbound",
+    "[postgresql][null][unbound]")
+{
+    test_null_with_bound_columns_unbound();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "test_result_at_end", "[postgresql][result]")
 {
     test_result_at_end();
 }
 
-TEST_CASE_METHOD(postgresql_fixture, "test_result_iterator", "[postgresql][iterator]")
+TEST_CASE_METHOD(postgresql_fixture, "test_result_iterator", "[postgresql][result][iterator]")
 {
     test_result_iterator();
 }

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -425,12 +425,17 @@ TEST_CASE_METHOD(sqlite_fixture, "test_nullptr_nulls", "[sqlite][null]")
     test_nullptr_nulls();
 }
 
-TEST_CASE_METHOD(sqlite_fixture, "test_result_at_end", "[mssql][result]")
+TEST_CASE_METHOD(sqlite_fixture, "test_null_with_bound_columns_unbound", "[sqlite][null][unbound]")
+{
+    test_null_with_bound_columns_unbound();
+}
+
+TEST_CASE_METHOD(sqlite_fixture, "test_result_at_end", "[sqlite][result]")
 {
     test_result_at_end();
 }
 
-TEST_CASE_METHOD(sqlite_fixture, "test_result_iterator", "[sqlite][iterator]")
+TEST_CASE_METHOD(sqlite_fixture, "test_result_iterator", "[sqlite][result][iterator]")
 {
     test_result_iterator();
 }

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1392,14 +1392,20 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(results.next());
         REQUIRE(results.is_null(0));
         REQUIRE(results.is_null(1));
+        REQUIRE(results.get<int>(0, -1) == -1);
+        REQUIRE(results.get<int>(1, -2) == -2);
 
         REQUIRE(results.next());
         REQUIRE(results.is_null(0));
         REQUIRE(results.is_null(1));
+        REQUIRE(results.get<int>(0, -3) == -3);
+        REQUIRE(results.get<int>(1, -4) == -4);
 
         REQUIRE(results.next());
         REQUIRE(results.is_null(0));
         REQUIRE(results.is_null(1));
+        REQUIRE(results.get<int>(0, -5) == -5);
+        REQUIRE(results.get<int>(1, -6) == -6);
 
         REQUIRE(!results.next());
     }
@@ -1449,6 +1455,39 @@ struct test_case_fixture : public base_test_fixture
 
             REQUIRE(results.get<int>(0) == i);
         }
+    }
+
+    void test_null_with_bound_columns_unbound()
+    {
+        nanodbc::connection conn = connect();
+        create_table(
+            conn,
+            NANODBC_TEXT("test_null_with_bound_columns_unbound"),
+            NANODBC_TEXT("(a int, b float)"));
+
+        nanodbc::statement statement(conn);
+        prepare(
+            statement,
+            NANODBC_TEXT("insert into test_null_with_bound_columns_unbound (a, b) values (?, ?);"));
+        REQUIRE(statement.parameters() == 2);
+        statement.bind_null(0);
+        statement.bind_null(1);
+        execute(statement, 2);
+
+        nanodbc::result results = execute(
+            conn,
+            NANODBC_TEXT("select a, b from test_null_with_bound_columns_unbound order by a;"));
+        results.unbind();
+
+        REQUIRE(results.next());
+
+        REQUIRE(!results.is_null(0)); // false as undetermined until SQLGetData is called
+        REQUIRE(results.get<int>(0, -1) == -1);
+        REQUIRE(results.is_null(0)); // determined
+
+        REQUIRE(!results.is_null(1)); // false as undetermined until SQLGetData is called
+        REQUIRE(results.get<double>(1, 1.23) >= 1.23);
+        REQUIRE(results.is_null(1)); // determined
     }
 
     void test_result_at_end()

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1481,11 +1481,17 @@ struct test_case_fixture : public base_test_fixture
 
         REQUIRE(results.next());
 
-        REQUIRE(!results.is_null(0)); // false as undetermined until SQLGetData is called
+        if (vendor_ == database_vendor::mysql)
+            REQUIRE(results.is_null(0)); // MySQL: Bug or non-standard behaviour? SQLBindCol sets the indicator to SQL_NULL_DATA
+        else
+            REQUIRE(!results.is_null(0)); // false as undetermined until SQLGetData is called
         REQUIRE(results.get<int>(0, -1) == -1);
         REQUIRE(results.is_null(0)); // determined
 
-        REQUIRE(!results.is_null(1)); // false as undetermined until SQLGetData is called
+        if (vendor_ == database_vendor::mysql)
+            REQUIRE(results.is_null(1)); // MySQL: Bug or non-standard behaviour? SQLBindCol sets the indicator to SQL_NULL_DATA
+        else
+            REQUIRE(!results.is_null(1)); // false as undetermined until SQLGetData is called
         REQUIRE(results.get<double>(1, 1.23) >= 1.23);
         REQUIRE(results.is_null(1)); // determined
     }

--- a/test/vertica_test.cpp
+++ b/test/vertica_test.cpp
@@ -124,12 +124,20 @@ TEST_CASE_METHOD(vertica_fixture, "test_null", "[vertica][null]")
     test_null();
 }
 
-TEST_CASE_METHOD(vertica_fixture, "test_result_at_end", "[mssql][result]")
+TEST_CASE_METHOD(
+    vertica_fixture,
+    "test_null_with_bound_columns_unbound",
+    "[vertica][null][unbound]")
+{
+    test_null_with_bound_columns_unbound();
+}
+
+TEST_CASE_METHOD(vertica_fixture, "test_result_at_end", "[vertica][result]")
 {
     test_result_at_end();
 }
 
-TEST_CASE_METHOD(vertica_fixture, "test_result_iterator", "[vertica][iterator]")
+TEST_CASE_METHOD(vertica_fixture, "test_result_iterator", "[vertica][result][iterator]")
 {
     test_result_iterator();
 }


### PR DESCRIPTION
## What does this PR do?

Once `result::unbind` is called for bound columns, null indicator is no longer
set during fetch, but setting it is delayed until `SQLGetData` is called (i.e. via `get<T>` wrapper).

This PR corrects setting the null value fallback.

## What are related issues/pull requests?

- PR #236

## Tasklist

 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed
