### PR TITLE
ci: Tweak GHA analyse.yml workflow

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -29,7 +29,7 @@ jobs:
           # Ruleset file that will determine what checks will be run
           ruleset: CppCoreCheckRules.ruleset
           # Paths to ignore analysis of CMake targets and includes
-          #ignoredPaths: ${{ github.workspace }}/test/catch;
+          ignoredPaths: ${{ github.workspace }}/test/catch
 
       # Upload SARIF file to GitHub Code Scanning Alerts
       - name: Upload SARIF to GitHub

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -29,7 +29,7 @@ jobs:
           # Ruleset file that will determine what checks will be run
           ruleset: CppCoreCheckRules.ruleset
           # Paths to ignore analysis of CMake targets and includes
-          ignoredPaths: ${{ github.workspace }}/test/catch;
+          #ignoredPaths: ${{ github.workspace }}/test/catch;
 
       # Upload SARIF file to GitHub Code Scanning Alerts
       - name: Upload SARIF to GitHub

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,5 +1,5 @@
-# GHA workflow to run MSVC Code Analysis + GitHub Code Scanning Alerts
-name: "analyse"
+# GHA workflow to run MSVC with C++ Core Guidelines checkers + GitHub Code Scanning Alerts
+name: "CppCoreCheck"
 
 on: [push, pull_request]
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,5 +1,5 @@
 # GHA workflow to build documentation and deploy with website in gh-pages branch
-name: "documentation"
+name: "Documentation"
 
 on: [push, pull_request]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 # GHA workflow to check well-formedness of sources, docs and auxiliary files
-name: "lint"
+name: "Lint"
 
 on: [push, pull_request]
 


### PR DESCRIPTION
## What does this PR do?

Variety of tweaks to the static analysis workflow

Why setting `ignoredPaths: ${{ github.workspace }}/test/catch;` leads to:

```
Analyze
Error: No C/C++ files were found in the project that could be analyzed.
```

Looks like removing the trailing `;` fixes the problem.
