### PR TITLE
feat: Add _variant_t-based row-cached result class wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ check_cxx_compiler_flag( "--coverage -O0" CXX_COMPILER_SUPPORTS_COVERAGE )
 include( CMakeDependentOption )
 cmake_dependent_option( NANODBC_FORCE_LIBCXX "Force the use of libc++ (default on if compiler supports it)" ON "CXX_COMPILER_SUPPORTS_LIBCXX" OFF )
 
-
 cmake_dependent_option( NANODBC_BUILD_EXAMPLES "Build examples (default on)" ON "PROJECT_IS_TOP_LEVEL" OFF)
 cmake_dependent_option( NANODBC_GENERATE_INSTALL "Generate install target (default on)" ON "PROJECT_IS_TOP_LEVEL" OFF)
 cmake_dependent_option( NANODBC_BUILD_TESTS "Build tests (default on)" ON "PROJECT_IS_TOP_LEVEL" OFF)
@@ -66,7 +65,6 @@ cmake_dependent_option( NANODBC_FORCE_WARNINGS_AS_ERROR
   "(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24.0) OR CXX_COMPILER_SUPPORTS_WERROR" OFF
 )
 
-
 message( STATUS "nanodbc version: ${NANODBC_VERSION}" )
 
 ########################################
@@ -81,7 +79,13 @@ endif()
 # ==== CMAKE default vars must be set before target creation! ====
 # BUILD_SHARED_LIBS dictates type
 add_library( nanodbc nanodbc/nanodbc.cpp )
-target_sources( nanodbc PUBLIC FILE_SET HEADERS FILES nanodbc/nanodbc.h )
+target_sources(nanodbc
+  PUBLIC FILE_SET HEADERS FILES
+  nanodbc/nanodbc.h
+  $<$<CXX_COMPILER_ID:MSVC>:nanodbc/variant_row_cached_result.h>)
+target_sources(nanodbc
+  PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:nanodbc/variant_row_cached_result.cpp>)
 message( STATUS "nanodbc compile: Global setting: C++${CMAKE_CXX_STANDARD}; nanodbc requires C++14 or greater" )
 
 # nanodbc requires at least C++14, but can use C++17 and beyond

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1596,6 +1596,7 @@ private:
 // clang-format on
 
 class catalog;
+class variant_row_cached_result;
 
 /// \brief A resource for managing result sets from statement execution.
 ///
@@ -1951,6 +1952,9 @@ private:
     class result_impl;
     friend class nanodbc::statement::statement_impl;
     friend class nanodbc::catalog;
+#ifdef _MSC_VER
+    friend class nanodbc::variant_row_cached_result;
+#endif
 
 private:
     std::shared_ptr<result_impl> impl_;

--- a/nanodbc/variant_row_cached_result.cpp
+++ b/nanodbc/variant_row_cached_result.cpp
@@ -1,0 +1,125 @@
+#include <nanodbc/variant_row_cached_result.h>
+
+#ifndef NANODBC_ASSERT
+#include <cassert>
+#define NANODBC_ASSERT(expr) assert(expr)
+#endif
+
+#if defined(_MSC_VER)
+#if defined(_DEBUG)
+#pragma comment(lib, "comsuppwd.lib")
+#else
+#pragma comment(lib, "comsuppw.lib")
+#endif
+#endif
+
+#include <sqlext.h>
+#include <windows.h>
+
+namespace
+{
+static VARIANT const variant_null = {VT_NULL, 0};
+_variant_t const variant_null_value(variant_null);
+} // unnamed namespace
+
+namespace nanodbc
+{
+
+variant_row_cached_result::variant_row_cached_result(nanodbc::result&& result)
+    : nanodbc::result(std::move(result))
+    , row_size_(columns())
+{
+}
+
+variant_row_cached_result::variant_row_cached_result(variant_row_cached_result&& rhs) noexcept
+    : nanodbc::result(std::move(rhs))
+    , row_(std::move(rhs.row_))
+    , row_size_(rhs.row_size_)
+{
+    rhs.row_.clear();
+    rhs.row_size_ = 0;
+}
+
+variant_row_cached_result&
+variant_row_cached_result::operator=(variant_row_cached_result&& rhs) noexcept
+{
+    if (&rhs != this)
+    {
+        nanodbc::result::operator=(std::move(rhs));
+        row_ = std::move(rhs.row_);
+        row_size_ = rhs.row_size_;
+        rhs.row_.clear();
+        rhs.row_size_ = 0;
+    }
+    return *this;
+}
+
+void variant_row_cached_result::swap(variant_row_cached_result& rhs) noexcept
+{
+    result::swap(rhs);
+    using std::swap;
+    swap(row_, rhs.row_);
+    swap(row_size_, rhs.row_size_);
+}
+
+void variant_row_cached_result::clear_row()
+{
+    NANODBC_ASSERT(row_size_ > 0);
+
+    row_.clear();
+    if (row_.capacity() != row_size_)
+        row_.reserve(row_size_);
+
+    NANODBC_ASSERT(row_.capacity() == row_size_);
+}
+
+void variant_row_cached_result::fill_row()
+{
+    NANODBC_ASSERT(row_size_ > 0);
+    // FIXME: There is a mess in drivers support for SQL_ATTR_ROW_NUMBER, so at_end is buggy
+    // if (result::at_end())
+    //     NANODBC_ASSERT(0); // throw programming_error
+
+    if (!row_.empty())
+        return; // Do not allow refilling from the same data source tuple
+
+    if (row_.empty())
+        row_.resize(row_size_);
+
+    for (short column = 0; column < row_size_; column++)
+    {
+        NANODBC_ASSERT(row_[column].vt == VT_EMPTY);
+        row_[column] = result::get<_variant_t>(column, variant_null_value);
+    }
+
+    NANODBC_ASSERT(row_.size() == row_size_);
+}
+
+_variant_t const& variant_row_cached_result::get(short column) const
+{
+    if (column >= row_.size())
+        throw index_range_error(); // row cache empty or column index out of range
+
+    return row_[column];
+}
+
+bool variant_row_cached_result::is_null(short column) const
+{
+    if (column >= row_.size())
+        throw programming_error("row cache empty or column index out of range");
+
+    return row_[column].vt == VT_NULL;
+}
+
+bool variant_row_cached_result::next()
+{
+    clear_row();
+    if (!result::next())
+    {
+        return false;
+    }
+    fill_row();
+    return true;
+}
+
+} // namespace nanodbc

--- a/nanodbc/variant_row_cached_result.h
+++ b/nanodbc/variant_row_cached_result.h
@@ -1,0 +1,72 @@
+#ifndef NANODBC_VARIANT_ROW_CACHED_RESULT_H
+#define NANODBC_VARIANT_ROW_CACHED_RESULT_H
+
+#ifndef _MSC_VER
+#error This file requires _variant_t and only supports Visual C++ on Windows
+#endif
+
+#include <comutil.h> // _variant_t
+#include <nanodbc/nanodbc.h>
+
+namespace nanodbc
+{
+
+class variant_row_cached_result : private result
+{
+public:
+    // Import minimal operations set for necessary usability
+    using result::columns;
+    using result::unbind;
+    using result::operator bool;
+
+    /// \brief Empty result set.
+    variant_row_cached_result() = default;
+
+    /// \brief Converting contructor.
+    variant_row_cached_result(result&& result);
+
+    /// \brief Move constructor.
+    variant_row_cached_result(variant_row_cached_result&& rhs) noexcept;
+
+    /// \brief Move assignment operator.
+    variant_row_cached_result& operator=(variant_row_cached_result&& rhs) noexcept;
+
+    /// Member swap.
+    void swap(variant_row_cached_result& rhs) noexcept;
+
+    /// \brief Gets cached data from the given column of the current rowset.
+    ///
+    /// Columns are numbered from left to right and 0-indexed.
+    _variant_t const& get(short column) const;
+
+    /// \brief Returns true if and only if cached value of the given column is of VT_NULL type.
+    bool is_null(short column) const;
+
+    /// \brief Returns the next result.
+    bool next();
+
+    /// \brief Access to underlying result
+    ///
+    /// For example, in order to access to columns metadata.
+    nanodbc::result& result() { return static_cast<nanodbc::result&>(*this); }
+
+    /// \brief Access to underlying result
+    ///
+    /// For example, in order to access to columns metadata.
+    nanodbc::result const& result() const { return static_cast<nanodbc::result const&>(*this); }
+
+private:
+    /// \brief Clears cache of row values as result::next pre-condition.
+    void clear_row();
+
+    /// \brief Re-fills cache of row values as result::next post-condition.
+    void fill_row();
+
+private:
+    std::vector<_variant_t> row_;
+    std::size_t row_size_{0};
+};
+
+} // namespace nanodbc
+
+#endif

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1166,6 +1166,12 @@ TEST_CASE_METHOD(mssql_fixture, "test_win32_variant_timestamp", "[mssql][variant
     REQUIRE(t0.wSecond <= 60);
     REQUIRE(t0.wMilliseconds <= 100);
 }
+
+TEST_CASE_METHOD(mssql_fixture, "test_win32_variant_row_cached_result", "[mssql][variant][windows]")
+{
+    test_win32_variant_row_cached_result();
+}
+
 #endif // _MSC_VER
 
 TEST_CASE_METHOD(mssql_fixture, "test_while_not_end_iteration", "[mssql][looping]")

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -303,6 +303,11 @@ TEST_CASE_METHOD(
 {
     test_win32_variant_null_literal();
 }
+
+TEST_CASE_METHOD(mysql_fixture, "test_win32_variant_row_cached_result", "[mysql][variant][windows]")
+{
+    test_win32_variant_row_cached_result();
+}
 #endif // _MSC_VER
 
 TEST_CASE_METHOD(mysql_fixture, "test_while_not_end_iteration", "[mysql][looping]")

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -357,6 +357,14 @@ TEST_CASE_METHOD(
 {
     test_win32_variant_null_literal();
 }
+
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_win32_variant_row_cached_result",
+    "[postgresql][variant][windows]")
+{
+    test_win32_variant_row_cached_result();
+}
 #endif // _MSC_VER
 
 TEST_CASE_METHOD(postgresql_fixture, "test_while_not_end_iteration", "[postgresql][looping]")

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -499,6 +499,14 @@ TEST_CASE_METHOD(
 {
     test_win32_variant_null_literal();
 }
+
+TEST_CASE_METHOD(
+    sqlite_fixture,
+    "test_win32_variant_row_cached_result",
+    "[sqlite][variant][windows]")
+{
+    test_win32_variant_row_cached_result();
+}
 #endif // _MSC_VER
 
 TEST_CASE_METHOD(sqlite_fixture, "test_time", "[sqlite][time]")


### PR DESCRIPTION
## What does this PR do?

A simple **Win32**-specific `nanodbc::result` wrapper that fetches row values in single step, accessing columns in order of increasing column number, and caches them as `_variant_t` objects.

This should help avoid out-of-order retrieval issues when
- values are accessed in non-sequential order
- values need to be accessed multiple times from current result

The row-cached result together with the nanodbc feature of **unbinding for out-of-order retrieval of bound and unbound** columns should allow non-sequential and complex schemes of row values access e.g. not uncommon scenario of fetching (unbound)  text or binary data first, then (bound) PK column.

This should help users avoid the `"Invalid Descriptor Index"` error due to known and documented restrictions `SQLGetData`.

Although this is platform or even compiler specific features, I think it will proof very useful, especially to users of SQL Server where ODBC API is the major mean to access data. What do you think @lexicalunit ?

## What are related issues/pull requests?

- https://github.com/nanodbc/nanodbc/pull/328
- https://github.com/nanodbc/nanodbc/pull/236
- https://github.com/nanodbc/nanodbc/issues/228

## Tasklist

 - [x] Add test case(s)
 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed
