### PR TITLE
Add accessor to fields of implementation row descriptor (IRD)

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -5779,6 +5779,13 @@ auto implementation_row_descriptor::base_table_name(short column) const -> strin
     return sql_col_attribute(*this, column, SQL_DESC_BASE_TABLE_NAME);
 }
 
+auto implementation_row_descriptor::catalog_name(short column) const -> string
+{
+    throw_if_column_is_out_of_range(column);
+    constexpr auto fid = NANODBC_DESC_FIELD_IDENTIFIER(SQL_DESC_CATALOG_NAME, SQL_COLUMN_QUALIFIER_NAME);
+    return sql_col_attribute(*this, column, fid);
+}
+
 auto implementation_row_descriptor::column_count() const -> short
 {
     constexpr auto fid = NANODBC_DESC_FIELD_IDENTIFIER(SQL_DESC_COUNT, SQL_COLUMN_COUNT);
@@ -5790,6 +5797,13 @@ auto implementation_row_descriptor::column_name(short column) const -> string
 {
     throw_if_column_is_out_of_range(column);
     constexpr auto fid = NANODBC_DESC_FIELD_IDENTIFIER(SQL_DESC_NAME, SQL_COLUMN_NAME);
+    return sql_col_attribute(*this, column, fid);
+}
+
+auto implementation_row_descriptor::schema_name(short column) const -> string
+{
+    throw_if_column_is_out_of_range(column);
+    constexpr auto fid = NANODBC_DESC_FIELD_IDENTIFIER(SQL_DESC_SCHEMA_NAME, SQL_COLUMN_OWNER_NAME);
     return sql_col_attribute(*this, column, fid);
 }
 

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -5793,6 +5793,13 @@ auto implementation_row_descriptor::column_count() const -> short
     return static_cast<short>(value);
 }
 
+auto implementation_row_descriptor::column_label(short column) const -> string
+{
+    throw_if_column_is_out_of_range(column);
+    constexpr auto fid = NANODBC_DESC_FIELD_IDENTIFIER(SQL_DESC_NAME, SQL_DESC_LABEL);
+    return sql_col_attribute(*this, column, fid);
+}
+
 auto implementation_row_descriptor::column_name(short column) const -> string
 {
     throw_if_column_is_out_of_range(column);

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -5759,6 +5759,14 @@ void implementation_row_descriptor::throw_if_column_is_out_of_range(short column
         throw index_range_error();
 }
 
+auto implementation_row_descriptor::auto_unique_value(short column) const -> bool
+{
+    throw_if_column_is_out_of_range(column);
+    constexpr auto fid = NANODBC_DESC_FIELD_IDENTIFIER(SQL_DESC_AUTO_UNIQUE_VALUE, SQL_COLUMN_AUTO_INCREMENT);
+    auto const value = sql_col_attribute(*this, column, fid);
+    return value == SQL_TRUE;
+}
+
 auto implementation_row_descriptor::base_column_name(short column) const -> string
 {
     throw_if_column_is_out_of_range(column);

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -5800,6 +5800,22 @@ auto implementation_row_descriptor::column_name(short column) const -> string
     return sql_col_attribute(*this, column, fid);
 }
 
+auto implementation_row_descriptor::column_named(short column) const -> bool
+{
+    throw_if_column_is_out_of_range(column);
+#if (NANODBC_ODBC_VERSION >= SQL_OV_ODBC3)
+    auto const value = sql_col_attribute(*this, column, SQL_DESC_UNNAMED);
+    if (value == SQL_NAMED)
+        return true;
+    else if (value == SQL_UNNAMED)
+        return false;
+    else
+        throw std::out_of_range("SQL_DESC_UNNAMED value unknown");
+#else
+    return false; // value undetermined
+#endif
+}
+
 auto implementation_row_descriptor::schema_name(short column) const -> string
 {
     throw_if_column_is_out_of_range(column);

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -5668,7 +5668,7 @@ namespace nanodbc
 implementation_row_descriptor::sql_get_descr_field::sql_get_descr_field(
     implementation_row_descriptor const& ird,
     short record,
-    std::uint16_t field_identifier)
+    std::uint16_t field_identifier) noexcept
     : ird_(ird)
     , record_(record)
     , field_identifier_(field_identifier)
@@ -5796,7 +5796,7 @@ auto implementation_row_descriptor::alloc_type() const -> short
     return static_cast<short>(value);
 }
 
-short implementation_row_descriptor::count() const
+short implementation_row_descriptor::count() const noexcept
 {
     return descriptor_records_count_;
 }

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -5731,14 +5731,16 @@ implementation_row_descriptor::sql_get_descr_field::operator string() const
         static_cast<SQLUSMALLINT>(record_ + 1),
         field_identifier_,
         value,
-        sizeof(value),
+        sizeof(value) / sizeof(NANODBC_SQLCHAR),
         &len);
     if (!success(rc))
         NANODBC_THROW_DATABASE_ERROR(ird_.statement_handle_, SQL_HANDLE_STMT);
 
     NANODBC_ASSERT(len % sizeof(NANODBC_SQLCHAR) == 0);
     len = len / sizeof(NANODBC_SQLCHAR);
-    return {value, value + len};
+
+    NANODBC_ASSERT(len <= std::char_traits<NANODBC_SQLCHAR>::length(value));
+    return {&value[0], &value[len]};
 }
 
 implementation_row_descriptor::implementation_row_descriptor(result const& result)

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -5792,7 +5792,7 @@ void implementation_row_descriptor::throw_if_record_is_out_of_range(short record
 
 auto implementation_row_descriptor::alloc_type() const -> short
 {
-    std::int64_t const value = sql_get_descr_field(*this,0, SQL_DESC_ALLOC_TYPE);
+    std::int64_t const value = sql_get_descr_field(*this, 0, SQL_DESC_ALLOC_TYPE);
     return static_cast<short>(value);
 }
 

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -2048,6 +2048,64 @@ inline result_iterator end(result& /*r*/)
 }
 
 // clang-format off
+// 8888888b.                                     d8b          888
+// 888  "Y88b                                    Y8P          888
+// 888    888                                                 888
+// 888    888  .d88b.  .d8888b   .d8888b 888d888 888 88888b.  888888 .d88b.  888d888 .d8888b
+// 888    888 d8P  Y8b 88K      d88P"    888P"   888 888 "88b 888   d88""88b 888P"   88K
+// 888    888 88888888 "Y8888b. 888      888     888 888  888 888   888  888 888     "Y8888b.
+// 888  .d88P Y8b.          X88 Y88b.    888     888 888 d88P Y88b. Y88..88P 888          X88
+// 8888888P"   "Y8888   88888P'  "Y8888P 888     888 88888P"   "Y888 "Y88P"  888      88888P'
+//                                                   888
+//                                                   888
+//                                                   888
+// MARK: Descriptors -
+// clang-format on
+
+/// Provides access to metadata in the Implementation Row Descriptor (IRD)
+/// implicitly allocated for a prepared or executed statement.
+///
+/// The IRD contains information about the columns in a result set,
+/// such as their SQL data types, lengths, and nullability.
+class implementation_row_descriptor
+{
+public:
+    implementation_row_descriptor(result const& result);
+    implementation_row_descriptor(statement const& statement);
+
+    auto base_column_name(short column) const -> string;
+
+    auto base_table_name(short column) const -> string;
+
+    auto column_count() const -> short;
+
+    auto column_name(short column) const -> string;
+
+    auto columns() const -> short;
+
+    auto table_name(short column) const -> string;
+
+private:
+
+    struct sql_col_attribute
+    {
+        sql_col_attribute(implementation_row_descriptor const& ird, short column, std::uint16_t field_identifier);
+        operator std::int64_t() const;
+        operator string() const;
+
+        implementation_row_descriptor const& ird_;
+        short column_;
+        std::uint16_t field_identifier_;
+    };
+    friend sql_col_attribute;
+
+    void throw_if_column_is_out_of_range(short column) const;
+
+    void* statement_handle_{nullptr};
+    short statement_columns_size_{0};
+};
+
+// clang-format off
 //
 //  .d8888b.           888             888
 // d88P  Y88b          888             888

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -2083,6 +2083,8 @@ public:
 
     auto column_count() const -> short;
 
+    auto column_label(short column) const -> string;
+
     auto column_name(short column) const -> string;
 
     auto column_named(short column) const -> bool;

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -2073,46 +2073,88 @@ public:
     implementation_row_descriptor(result const& result);
     implementation_row_descriptor(statement const& statement);
 
-    auto auto_unique_value(short column) const -> bool;
+    // Descriptor header fields accessors
 
-    auto base_column_name(short column) const -> string;
+    auto alloc_type() const -> short;
 
-    auto base_table_name(short column) const -> string;
+    auto count() const -> short;
 
-    auto catalog_name(short column) const -> string;
+    // Descriptor record fields (records) accessors
 
-    auto column_count() const -> short;
+    auto auto_unique_value(short record) const -> bool;
 
-    auto column_label(short column) const -> string;
+    auto base_column_name(short record) const -> string;
 
-    auto column_name(short column) const -> string;
+    auto base_table_name(short record) const -> string;
 
-    auto column_named(short column) const -> bool;
+    auto case_sensitive(short record) const -> bool;
 
-    auto columns() const -> short;
+    auto catalog_name(short record) const -> string;
 
-    auto schema_name(short column) const -> string;
+    auto concise_type(short record) const -> short;
 
-    auto table_name(short column) const -> string;
+    auto display_size(short record) const -> std::int64_t;
+
+    auto fixed_prec_scale(short record) const -> short;
+
+    auto label(short record) const -> string;
+
+    auto length(short record) const -> std::uint64_t;
+
+    auto local_type_name(short record) const -> string;
+
+    auto name(short record) const -> string;
+
+    auto nullable(short record) const -> short;
+
+    auto num_prec_radix(short record) const -> short;
+
+    auto octet_length(short record) const -> std::int64_t;
+
+    auto precision(short record) const -> short;
+
+    auto rowver(short record) const -> short;
+
+    auto scale(short record) const -> short;
+
+    auto schema_name(short record) const -> string;
+
+    auto searchable(short record) const -> short;
+
+    auto table_name(short record) const -> string;
+
+    auto type(short record) const -> short;
+
+    auto type_name(short record) const -> string;
+
+    auto unnamed(short record) const -> bool;
+
+    auto unsigned_(short record) const -> bool;
+
+    auto updatable(short record) const -> short;
 
 private:
 
-    struct sql_col_attribute
+    struct sql_get_descr_field
     {
-        sql_col_attribute(implementation_row_descriptor const& ird, short column, std::uint16_t field_identifier);
+        sql_get_descr_field(implementation_row_descriptor const& ird, short record, std::uint16_t field_identifier);
         operator std::int64_t() const;
+        operator std::uint64_t() const;
         operator string() const;
 
         implementation_row_descriptor const& ird_;
-        short column_;
+        short record_;
         std::uint16_t field_identifier_;
     };
-    friend sql_col_attribute;
+    friend sql_get_descr_field;
 
-    void throw_if_column_is_out_of_range(short column) const;
+    void initialize_descriptor();
+    void throw_if_record_is_out_of_range(short record) const;
 
     void* statement_handle_{nullptr};
-    short statement_columns_size_{0};
+    short statement_columns_count_{0};
+    void* descriptor_handle_{nullptr};
+    short descriptor_records_count_{0};
 };
 
 // clang-format off

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -2070,7 +2070,6 @@ inline result_iterator end(result& /*r*/)
 class implementation_row_descriptor
 {
 public:
-
     /// Initializes IRD access from statement of executed result set.
     implementation_row_descriptor(result const& result);
 
@@ -2177,15 +2176,18 @@ public:
 
     /// Value of the `SQL_DESC_UPDATABLE` field.
     ///
-    /// \return Possible return values are `SQL_ATTR_READ_ONLY`, `SQL_ATTR_WRITE` or `SQL_ATTR_READWRITE_UNKNOWN`.
+    /// \return Possible return values are `SQL_ATTR_READ_ONLY`, `SQL_ATTR_WRITE` or
+    /// `SQL_ATTR_READWRITE_UNKNOWN`.
     auto updatable(short record) const -> short;
 
 private:
-
     // Convenience wrapper for SQLGetDescrField accesor.
     struct sql_get_descr_field
     {
-        sql_get_descr_field(implementation_row_descriptor const& ird, short record, std::uint16_t field_identifier);
+        sql_get_descr_field(
+            implementation_row_descriptor const& ird,
+            short record,
+            std::uint16_t field_identifier);
         operator std::int64_t() const;
         operator std::uint64_t() const;
         operator string() const;

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -2090,7 +2090,7 @@ public:
     auto alloc_type() const -> short;
 
     /// Value of the header field `SQL_DESC_COUNT`.
-    auto count() const -> short;
+    auto count() const noexcept -> short;
 
     // Descriptor record fields (records) accessors
 
@@ -2187,7 +2187,7 @@ private:
         sql_get_descr_field(
             implementation_row_descriptor const& ird,
             short record,
-            std::uint16_t field_identifier);
+            std::uint16_t field_identifier) noexcept;
         operator std::int64_t() const;
         operator std::uint64_t() const;
         operator string() const;

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -2079,11 +2079,15 @@ public:
 
     auto base_table_name(short column) const -> string;
 
+    auto catalog_name(short column) const -> string;
+
     auto column_count() const -> short;
 
     auto column_name(short column) const -> string;
 
     auto columns() const -> short;
+
+    auto schema_name(short column) const -> string;
 
     auto table_name(short column) const -> string;
 

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -2070,71 +2070,119 @@ inline result_iterator end(result& /*r*/)
 class implementation_row_descriptor
 {
 public:
+
+    /// Initializes IRD access from statement of executed result set.
     implementation_row_descriptor(result const& result);
+
+    /// Initializes IRD access from prepared or executed statement.
+    ///
+    /// For performance reasons, an application should ensure the statement
+    /// is executed before accessing any of the IRD fields.
+    /// Accessing (i.e. calls to SQLGetDescRec) the descriptor fields of
+    /// prepared only statement causes a roundtrip to SQL Server.
+    ///
+    /// \note Some fields of the descriptor are available on result set
+    /// retrieved from statements that generate server cursors or
+    /// on executed SQL Server `SELECT` statements containing a `FOR BROWSE`
+    /// clause (database-specific).
     implementation_row_descriptor(statement const& statement);
 
-    // Descriptor header fields accessors
-
+    /// Value of the header field `SQL_DESC_ALLOC_AUTO`.
     auto alloc_type() const -> short;
 
+    /// Value of the header field `SQL_DESC_COUNT`.
     auto count() const -> short;
 
     // Descriptor record fields (records) accessors
 
+    /// Boolean based on value of the `SQL_DESC_AUTO_UNIQUE_VALUE` field.
     auto auto_unique_value(short record) const -> bool;
 
+    /// Value of the `SQL_DESC_BASE_COLUMN_NAME` field.
     auto base_column_name(short record) const -> string;
 
+    /// Value of the `SQL_DESC_BASE_TABLE_NAME` field.
     auto base_table_name(short record) const -> string;
 
+    /// Boolean based on value of the `SQL_DESC_CASE_SENSITIVE` field.
     auto case_sensitive(short record) const -> bool;
 
+    /// Value of the `SQL_DESC_CATALOG_NAME` field.
     auto catalog_name(short record) const -> string;
 
+    /// Value of the `SQL_DESC_CONCISE_TYPE` field.
     auto concise_type(short record) const -> short;
 
+    /// Value of the `SQL_DESC_DISPLAY_SIZE` field.
     auto display_size(short record) const -> std::int64_t;
 
+    /// Value of the `SQL_DESC_FIXED_PREC_SCALE` field.
     auto fixed_prec_scale(short record) const -> short;
 
+    /// Value of the `SQL_DESC_LABEL` field.
     auto label(short record) const -> string;
 
+    /// Value of the `SQL_DESC_LENGTH` field.
     auto length(short record) const -> std::uint64_t;
 
+    /// Value of the `SQL_DESC_LOCAL_TYPE_NAME` field.
     auto local_type_name(short record) const -> string;
 
+    /// Value of the `SQL_DESC_NAME` field.
     auto name(short record) const -> string;
 
+    /// Value of the `SQL_DESC_NULLABLE` field.
+    ///
+    /// \return Possible return values are `SQL_NULLABLE`, `SQL_NO_NULLS` or `SQL_NULLABLE_UNKNOWN`.
     auto nullable(short record) const -> short;
 
+    /// Value of the `SQL_DESC_NUM_PREC_RADIX` field.
     auto num_prec_radix(short record) const -> short;
 
+    /// Value of the `SQL_DESC_OCTET_LENGTH` field.
     auto octet_length(short record) const -> std::int64_t;
 
+    /// Value of the `SQL_DESC_PRECISION` field.
     auto precision(short record) const -> short;
 
+    /// Value of the `SQL_DESC_ROWVER` field.
     auto rowver(short record) const -> short;
 
+    /// Value of the `SQL_DESC_SCALE` field.
     auto scale(short record) const -> short;
 
+    /// Value of the `SQL_DESC_SCHEMA_NAME` field.
     auto schema_name(short record) const -> string;
 
+    /// Value of the `SQL_DESC_SEARCHABLE` field.
+    ///
+    /// \return Possible return values are `SQL_PRED_NONE`, `SQL_PRED_CHAR`, `SQL_PRED_BASIC` or
+    /// `SQL_PRED_SEARCHABLE`.
     auto searchable(short record) const -> short;
 
+    /// Value of the `SQL_DESC_TABLE_NAME` field.
     auto table_name(short record) const -> string;
 
+    /// Value of the `SQL_DESC_TYPE` field.
     auto type(short record) const -> short;
 
+    /// Value of the `SQL_DESC_TYPE_NAME` field.
     auto type_name(short record) const -> string;
 
+    /// Boolean based on value of the `SQL_DESC_UNNAMED` field.
     auto unnamed(short record) const -> bool;
 
+    ///  Boolean based on value of the `SQL_DESC_UNSIGNED` field.
     auto unsigned_(short record) const -> bool;
 
+    /// Value of the `SQL_DESC_UPDATABLE` field.
+    ///
+    /// \return Possible return values are `SQL_ATTR_READ_ONLY`, `SQL_ATTR_WRITE` or `SQL_ATTR_READWRITE_UNKNOWN`.
     auto updatable(short record) const -> short;
 
 private:
 
+    // Convenience wrapper for SQLGetDescrField accesor.
     struct sql_get_descr_field
     {
         sql_get_descr_field(implementation_row_descriptor const& ird, short record, std::uint16_t field_identifier);

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -2085,6 +2085,8 @@ public:
 
     auto column_name(short column) const -> string;
 
+    auto column_named(short column) const -> bool;
+
     auto columns() const -> short;
 
     auto schema_name(short column) const -> string;

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -2073,6 +2073,8 @@ public:
     implementation_row_descriptor(result const& result);
     implementation_row_descriptor(statement const& statement);
 
+    auto auto_unique_value(short column) const -> bool;
+
     auto base_column_name(short column) const -> string;
 
     auto base_table_name(short column) const -> string;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,8 @@
 # nanodbc tests build configuration
 find_package(ODBC REQUIRED)
+if(DEFINED ENV{CI})
+  add_compile_definitions(NANODBC_TEST_CI=1)
+endif()
 add_compile_definitions( "$<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>" )
 
 # Prepare "Catch" library for other executables

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -788,10 +788,20 @@ TEST_CASE_METHOD(mssql_fixture, "test_execute_multiple", "[mssql][execute]")
     test_execute_multiple();
 }
 
+// FIXME(mloskot): Strange behaviour of SQLGetDescField on Linux with SQL Server, see
+// https://github.com/nanodbc/nanodbc/pull/342#issuecomment-2077942587
+#if defined(NANODBC_TEST_CI) && defined(CATCH_PLATFORM_LINUX)
+#define NANODBC_TESTS_SKIP_IRD 1
+#else
+#define NANODBC_TEST_SKIP_IRD_DUE_STRANGE_FAILURES_ON_LINUX 0
+#endif
+
+#if defined(NANODBC_TEST_SKIP_IRD_DUE_STRANGE_FAILURES_ON_LINUX)
 TEST_CASE_METHOD(mssql_fixture, "test_implementation_row_descriptor", "[mssql][descriptor][ird]")
 {
     test_implementation_row_descriptor();
 }
+#endif // defined(NANODBC_TEST_SKIP_IRD_DUE_STRANGE_FAILURES_ON_LINUX)
 
 TEST_CASE_METHOD(
     mssql_fixture,
@@ -815,6 +825,7 @@ name varchar(60)
     REQUIRE(!ird.auto_unique_value(1));
 }
 
+#if defined(NANODBC_TEST_SKIP_IRD_DUE_STRANGE_FAILURES_ON_LINUX)
 TEST_CASE_METHOD(
     mssql_fixture,
     "test_implementation_row_descriptor_with_expressions",
@@ -942,6 +953,7 @@ PRIMARY KEY(t2_fid)
     REQUIRE(ird.type_name(i) == NANODBC_TEXT("int"));
     REQUIRE(ird.local_type_name(i) == NANODBC_TEXT("int"));
 }
+#endif // defined(NANODBC_TEST_SKIP_IRD_DUE_STRANGE_FAILURES_ON_LINUX)
 
 TEST_CASE_METHOD(mssql_fixture, "test_integral", "[mssql][integral]")
 {

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -793,6 +793,28 @@ TEST_CASE_METHOD(mssql_fixture, "test_implementation_row_descriptor", "[mssql][d
     test_implementation_row_descriptor();
 }
 
+TEST_CASE_METHOD(
+    mssql_fixture,
+    "test_implementation_row_descriptor_auto_unique_value",
+    "[mssql][descriptor][ird]")
+{
+    auto c = connect();
+
+    create_table(
+        c, NANODBC_TEXT("test_implementation_row_descriptor_auto_unique_value"), NANODBC_TEXT(R"(
+fid int IDENTITY(1,1) PRIMARY KEY,
+name varchar(60)
+)"));
+
+    auto const sql =
+        NANODBC_TEXT("SELECT fid, name FROM test_implementation_row_descriptor_auto_unique_value");
+    nanodbc::statement s(c, sql);
+    nanodbc::implementation_row_descriptor ird(s);
+    REQUIRE(ird.columns() == 2);
+    REQUIRE(ird.auto_unique_value(0));
+    REQUIRE(!ird.auto_unique_value(1));
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_integral", "[mssql][integral]")
 {
     test_integral<mssql_fixture>();

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -810,7 +810,7 @@ name varchar(60)
         NANODBC_TEXT("SELECT fid, name FROM test_implementation_row_descriptor_auto_unique_value");
     nanodbc::statement s(c, sql);
     nanodbc::implementation_row_descriptor ird(s);
-    REQUIRE(ird.columns() == 2);
+    REQUIRE(ird.count() == 2);
     REQUIRE(ird.auto_unique_value(0));
     REQUIRE(!ird.auto_unique_value(1));
 }

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -788,6 +788,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_execute_multiple", "[mssql][execute]")
     test_execute_multiple();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_implementation_row_descriptor", "[mssql][descriptor][ird]")
+{
+    test_implementation_row_descriptor();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_integral", "[mssql][integral]")
 {
     test_integral<mssql_fixture>();

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -795,6 +795,14 @@ TEST_CASE_METHOD(mssql_fixture, "test_implementation_row_descriptor", "[mssql][d
 
 TEST_CASE_METHOD(
     mssql_fixture,
+    "test_implementation_row_descriptor_with_expressions",
+    "[mssql][descriptor][ird]")
+{
+    test_implementation_row_descriptor_with_expressions();
+}
+
+TEST_CASE_METHOD(
+    mssql_fixture,
     "test_implementation_row_descriptor_auto_unique_value",
     "[mssql][descriptor][ird]")
 {

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -215,6 +215,7 @@ TEST_CASE_METHOD(mysql_fixture, "test_execute_multiple", "[mysql][execute]")
     test_execute_multiple();
 }
 
+#if 0 // FIXME: MySQL driver always reports Zero for SQL_DESC_COUNT
 TEST_CASE_METHOD(mysql_fixture, "test_implementation_row_descriptor", "[mysql][descriptor][ird]")
 {
     test_implementation_row_descriptor();
@@ -250,6 +251,7 @@ PRIMARY KEY(fid)
     REQUIRE(ird.auto_unique_value(0));
     REQUIRE(!ird.auto_unique_value(1));
 }
+#endif
 
 TEST_CASE_METHOD(mysql_fixture, "test_integral", "[mysql][integral]")
 {

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -220,6 +220,28 @@ TEST_CASE_METHOD(mysql_fixture, "test_implementation_row_descriptor", "[mysql][d
     test_implementation_row_descriptor();
 }
 
+TEST_CASE_METHOD(
+    mysql_fixture,
+    "test_implementation_row_descriptor_auto_unique_value",
+    "[mysql][descriptor][ird]")
+{
+    auto c = connect();
+
+    create_table(
+        c, NANODBC_TEXT("test_implementation_row_descriptor_auto_unique_value"), NANODBC_TEXT(R"(
+fid int NOT NULL AUTO_INCREMENT,
+name varchar(60),
+PRIMARY KEY(fid)
+)"));
+
+    auto const sql = NANODBC_TEXT("SELECT fid, name FROM test_implementation_row_descriptor_auto_unique_value");
+    nanodbc::statement s(c, sql);
+    nanodbc::implementation_row_descriptor ird(s);
+    REQUIRE(ird.columns() == 2);
+    REQUIRE(ird.auto_unique_value(0));
+    REQUIRE(!ird.auto_unique_value(1));
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_integral", "[mysql][integral]")
 {
     test_integral<mysql_fixture>();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -237,7 +237,7 @@ PRIMARY KEY(fid)
     auto const sql = NANODBC_TEXT("SELECT fid, name FROM test_implementation_row_descriptor_auto_unique_value");
     nanodbc::statement s(c, sql);
     nanodbc::implementation_row_descriptor ird(s);
-    REQUIRE(ird.columns() == 2);
+    REQUIRE(ird.count() == 2);
     REQUIRE(ird.auto_unique_value(0));
     REQUIRE(!ird.auto_unique_value(1));
 }

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -215,6 +215,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_execute_multiple", "[mysql][execute]")
     test_execute_multiple();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_implementation_row_descriptor", "[mysql][descriptor][ird]")
+{
+    test_implementation_row_descriptor();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_integral", "[mysql][integral]")
 {
     test_integral<mysql_fixture>();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -222,6 +222,14 @@ TEST_CASE_METHOD(mysql_fixture, "test_implementation_row_descriptor", "[mysql][d
 
 TEST_CASE_METHOD(
     mysql_fixture,
+    "test_implementation_row_descriptor_with_expressions",
+    "[mysql][descriptor][ird]")
+{
+    test_implementation_row_descriptor_with_expressions();
+}
+
+TEST_CASE_METHOD(
+    mysql_fixture,
     "test_implementation_row_descriptor_auto_unique_value",
     "[mysql][descriptor][ird]")
 {

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -234,7 +234,8 @@ name varchar(60),
 PRIMARY KEY(fid)
 )"));
 
-    auto const sql = NANODBC_TEXT("SELECT fid, name FROM test_implementation_row_descriptor_auto_unique_value");
+    auto const sql =
+        NANODBC_TEXT("SELECT fid, name FROM test_implementation_row_descriptor_auto_unique_value");
     nanodbc::statement s(c, sql);
     nanodbc::implementation_row_descriptor ird(s);
     REQUIRE(ird.count() == 2);

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -155,7 +155,10 @@ TEST_CASE_METHOD(postgresql_fixture, "test_execute_multiple", "[postgresql][exec
     test_execute_multiple();
 }
 
-TEST_CASE_METHOD(postgresql_fixture, "test_implementation_row_descriptor", "[postgresql][descriptor][ird]")
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_implementation_row_descriptor",
+    "[postgresql][descriptor][ird]")
 {
     test_implementation_row_descriptor();
 }

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -177,7 +177,7 @@ name varchar(60)
         NANODBC_TEXT("SELECT fid, name FROM test_implementation_row_descriptor_auto_unique_value");
     nanodbc::statement s(c, sql);
     nanodbc::implementation_row_descriptor ird(s);
-    REQUIRE(ird.columns() == 2);
+    REQUIRE(ird.count() == 2);
     REQUIRE(ird.auto_unique_value(0));
     REQUIRE(!ird.auto_unique_value(1));
 }

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -155,6 +155,11 @@ TEST_CASE_METHOD(postgresql_fixture, "test_execute_multiple", "[postgresql][exec
     test_execute_multiple();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "test_implementation_row_descriptor", "[postgresql][descriptor][ird]")
+{
+    test_implementation_row_descriptor();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_integral", "[postgresql][integral]")
 {
     test_integral<postgresql_fixture>();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -160,6 +160,28 @@ TEST_CASE_METHOD(postgresql_fixture, "test_implementation_row_descriptor", "[pos
     test_implementation_row_descriptor();
 }
 
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_implementation_row_descriptor_auto_unique_value",
+    "[postgresql][descriptor][ird]")
+{
+    auto c = connect();
+
+    create_table(
+        c, NANODBC_TEXT("test_implementation_row_descriptor_auto_unique_value"), NANODBC_TEXT(R"(
+fid serial PRIMARY KEY,
+name varchar(60)
+)"));
+
+    auto const sql =
+        NANODBC_TEXT("SELECT fid, name FROM test_implementation_row_descriptor_auto_unique_value");
+    nanodbc::statement s(c, sql);
+    nanodbc::implementation_row_descriptor ird(s);
+    REQUIRE(ird.columns() == 2);
+    REQUIRE(ird.auto_unique_value(0));
+    REQUIRE(!ird.auto_unique_value(1));
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_integral", "[postgresql][integral]")
 {
     test_integral<postgresql_fixture>();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -165,6 +165,14 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     postgresql_fixture,
+    "test_implementation_row_descriptor_with_expressions",
+    "[postgresql][descriptor][ird]")
+{
+    test_implementation_row_descriptor_with_expressions();
+}
+
+TEST_CASE_METHOD(
+    postgresql_fixture,
     "test_implementation_row_descriptor_auto_unique_value",
     "[postgresql][descriptor][ird]")
 {

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -293,6 +293,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_execute_multiple", "[sqlite][execute]")
     test_execute_multiple();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_implementation_row_descriptor", "[sqlite][descriptor][ird]")
+{
+    test_implementation_row_descriptor();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_integral", "[sqlite][integral]")
 {
     test_integral<sqlite_fixture>();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -293,10 +293,21 @@ TEST_CASE_METHOD(sqlite_fixture, "test_execute_multiple", "[sqlite][execute]")
     test_execute_multiple();
 }
 
+// SQLite ODBC driver does not support SQL_ATTR_IMP_ROW_DESC
+// and SQLGetStmtAttr invocation returns dummy handle,
+// see
+// https://github.com/softace/sqliteodbc/blob/9049782382ae15f753e8321de34c1568eafadbf7/sqlite3odbc.c#L9195
+#if 0
 TEST_CASE_METHOD(sqlite_fixture, "test_implementation_row_descriptor", "[sqlite][descriptor][ird]")
 {
     test_implementation_row_descriptor();
 }
+
+TEST_CASE_METHOD(sqlite_fixture, "test_implementation_row_descriptor_with_expressions", "[sqlite][descriptor][ird]")
+{
+    test_implementation_row_descriptor_with_expressions();
+}
+#endif
 
 TEST_CASE_METHOD(sqlite_fixture, "test_integral", "[sqlite][integral]")
 {

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1479,7 +1479,8 @@ PRIMARY KEY(t2_fid)
             {
                 REQUIRE(ird.base_column_name(2) == NANODBC_TEXT("2 * 3"));
                 REQUIRE(ird.name(2) == NANODBC_TEXT("2 * 3"));
-                REQUIRE_THROWS_WITH(!ird.unnamed(2), Catch::Contains("unsupported column attribute"));
+                REQUIRE_THROWS_WITH(
+                    !ird.unnamed(2), Catch::Contains("unsupported column attribute"));
             }
             else
             {

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1483,6 +1483,7 @@ PRIMARY KEY(t2_fid)
             NANODBC_TEXT("v_t1_t2"),
             NANODBC_TEXT("SELECT t1.*, t2.* FROM t1 INNER JOIN t2 ON t1.t1_fid1 = t2.t2_fid"),
             true);
+
         // view
         {
             nanodbc::string sql = NANODBC_TEXT("SELECT t1_fid1 AS fid1, t1_fid2 AS fid2, t2_fid AS "
@@ -2615,8 +2616,8 @@ PRIMARY KEY(t2_fid)
             NANODBC_TEXT("create table ") + table_name + NANODBC_TEXT("(") +
                 NANODBC_TEXT("c0 int NULL,") + NANODBC_TEXT("c1 smallint NULL,") +
                 NANODBC_TEXT("c2 float NULL,") + NANODBC_TEXT("c3 decimal(9, 3) NULL,") +
-                NANODBC_TEXT("c4 date NULL,") + // seems more portable than datetime (SQL Server),
-                                                // timestamp (PostgreSQL, MySQL)
+                NANODBC_TEXT("c4 date NULL,") + // seems more portable than datetime (SQL
+                                                // Server), timestamp (PostgreSQL, MySQL)
                 NANODBC_TEXT("c5 varchar(60) NULL,") + NANODBC_TEXT("c6 varchar(120) NULL,") +
                 NANODBC_TEXT("c7 ") + text_type_name + NANODBC_TEXT(" NULL,") +
                 NANODBC_TEXT("c8 ") + binary_type_name + NANODBC_TEXT(" NULL);"));
@@ -2772,8 +2773,8 @@ PRIMARY KEY(t2_fid)
 
         nanodbc::variant_row_cached_result rs = execute(
             cn,
-            NANODBC_TEXT(
-                "select i0,s1,f2,s3,d4,b5,dt6,s7,t8 from test_win32_variant_row_cached_result;"));
+            NANODBC_TEXT("select i0,s1,f2,s3,d4,b5,dt6,s7,t8 from "
+                         "test_win32_variant_row_cached_result;"));
         rs.unbind(); // allow interleaved bound and unbound columns access
         short row_count = 0;
         while (rs.next())

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1403,95 +1403,6 @@ PRIMARY KEY(t2_fid)
         execute(c, NANODBC_TEXT("INSERT INTO t2(t2_fid,age) VALUES (2,41)"));
         execute(c, NANODBC_TEXT("INSERT INTO t2(t2_fid,age) VALUES (3,60)"));
 
-        // expression
-        {
-            nanodbc::string sql = NANODBC_TEXT("SELECT 'test' AS name, 2 + 3 AS age, 2 * 3");
-            if (vendor_ == database_vendor::sqlserver)
-                sql +=
-                    NANODBC_TEXT(" FOR BROWSE"); // attributes like table name available only for
-                                                 // SELECT statements containing FOR BROWSE clause
-
-            nanodbc::statement s(c, sql);
-            nanodbc::implementation_row_descriptor ird(s);
-            REQUIRE(ird.count() == 3);
-            REQUIRE(ird.count() == ird.count());
-            for (short i = 0; i < ird.count(); i++)
-            {
-                if (vendor_ == database_vendor::mysql)
-                {
-                    REQUIRE(ird.catalog_name(i) != NANODBC_TEXT(""));
-                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
-                }
-                else if (vendor_ == database_vendor::postgresql)
-                {
-                    REQUIRE(ird.catalog_name(i) == NANODBC_TEXT(""));
-                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
-                }
-                else if (vendor_ == database_vendor::sqlite)
-                {
-                    REQUIRE(ird.catalog_name(i) == NANODBC_TEXT(""));
-                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
-                }
-                else if (vendor_ == database_vendor::sqlserver)
-                {
-                    REQUIRE(ird.catalog_name(i) == NANODBC_TEXT(""));
-                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
-                }
-                else
-                {
-                    REQUIRE(ird.schema_name(i) != NANODBC_TEXT(""));
-                    REQUIRE(ird.schema_name(i) != NANODBC_TEXT(""));
-                }
-            }
-            // name
-            REQUIRE(!ird.auto_unique_value(0));
-            if (vendor_ == database_vendor::sqlite || vendor_ == database_vendor::postgresql)
-                REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("name"));
-            else
-                REQUIRE(ird.base_column_name(0) == NANODBC_TEXT(""));
-            REQUIRE(ird.name(0) == NANODBC_TEXT("name"));
-            REQUIRE(ird.base_table_name(0) == NANODBC_TEXT(""));
-            REQUIRE(ird.table_name(0) == NANODBC_TEXT(""));
-            // age
-            REQUIRE(!ird.auto_unique_value(1));
-            if (vendor_ == database_vendor::sqlite || vendor_ == database_vendor::postgresql)
-                REQUIRE(ird.base_column_name(1) == NANODBC_TEXT("age"));
-            else
-                REQUIRE(ird.base_column_name(1) == NANODBC_TEXT(""));
-            REQUIRE(ird.name(1) == NANODBC_TEXT("age"));
-            REQUIRE(ird.base_table_name(1) == NANODBC_TEXT(""));
-            REQUIRE(ird.table_name(1) == NANODBC_TEXT(""));
-            // 2 * 3
-            REQUIRE(!ird.auto_unique_value(2));
-            if (vendor_ == database_vendor::mysql)
-            {
-                REQUIRE(ird.base_column_name(2) == NANODBC_TEXT(""));
-                REQUIRE(ird.name(2) == NANODBC_TEXT("2 * 3"));
-                REQUIRE(!ird.unnamed(2));
-            }
-            else if (vendor_ == database_vendor::postgresql)
-            {
-                REQUIRE(ird.base_column_name(2) == NANODBC_TEXT("?column?"));
-                REQUIRE(ird.name(2) == NANODBC_TEXT("?column?"));
-                REQUIRE(!ird.unnamed(2));
-            }
-            else if (vendor_ == database_vendor::sqlite)
-            {
-                REQUIRE(ird.base_column_name(2) == NANODBC_TEXT("2 * 3"));
-                REQUIRE(ird.name(2) == NANODBC_TEXT("2 * 3"));
-                REQUIRE_THROWS_WITH(
-                    !ird.unnamed(2), Catch::Contains("unsupported column attribute"));
-            }
-            else
-            {
-                REQUIRE(ird.base_column_name(2) == NANODBC_TEXT(""));
-                REQUIRE(ird.name(2) == NANODBC_TEXT(""));
-                REQUIRE(ird.unnamed(2));
-            }
-            REQUIRE(ird.base_table_name(2) == NANODBC_TEXT(""));
-            REQUIRE(ird.table_name(2) == NANODBC_TEXT(""));
-        }
-
         // table
         {
             nanodbc::string sql =
@@ -1601,6 +1512,94 @@ PRIMARY KEY(t2_fid)
                 REQUIRE(ird.table_name(0) == NANODBC_TEXT("t1"));
             }
         }
+    }
+
+    void test_implementation_row_descriptor_with_expressions()
+    {
+        auto c = connect();
+        nanodbc::string sql = NANODBC_TEXT("SELECT 'test' AS name, 2 + 3 AS age, 2 * 3");
+        if (vendor_ == database_vendor::sqlserver)
+            sql += NANODBC_TEXT(" FOR BROWSE"); // attributes like table name available only for
+                                                // SELECT statements containing FOR BROWSE clause
+
+        nanodbc::statement s(c, sql);
+        nanodbc::implementation_row_descriptor ird(s);
+        REQUIRE(ird.count() == 3);
+        REQUIRE(ird.count() == ird.count());
+        for (short i = 0; i < ird.count(); i++)
+        {
+            if (vendor_ == database_vendor::mysql)
+            {
+                REQUIRE(ird.catalog_name(i) != NANODBC_TEXT(""));
+                REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
+            }
+            else if (vendor_ == database_vendor::postgresql)
+            {
+                REQUIRE(ird.catalog_name(i) == NANODBC_TEXT(""));
+                REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
+            }
+            else if (vendor_ == database_vendor::sqlite)
+            {
+                REQUIRE(ird.catalog_name(i) == NANODBC_TEXT(""));
+                REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
+            }
+            else if (vendor_ == database_vendor::sqlserver)
+            {
+                REQUIRE(ird.catalog_name(i) == NANODBC_TEXT(""));
+                REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
+            }
+            else
+            {
+                REQUIRE(ird.schema_name(i) != NANODBC_TEXT(""));
+                REQUIRE(ird.schema_name(i) != NANODBC_TEXT(""));
+            }
+        }
+        // name
+        REQUIRE(!ird.auto_unique_value(0));
+        if (vendor_ == database_vendor::sqlite || vendor_ == database_vendor::postgresql)
+            REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("name"));
+        else
+            REQUIRE(ird.base_column_name(0) == NANODBC_TEXT(""));
+        REQUIRE(ird.name(0) == NANODBC_TEXT("name"));
+        REQUIRE(ird.base_table_name(0) == NANODBC_TEXT(""));
+        REQUIRE(ird.table_name(0) == NANODBC_TEXT(""));
+        // age
+        REQUIRE(!ird.auto_unique_value(1));
+        if (vendor_ == database_vendor::sqlite || vendor_ == database_vendor::postgresql)
+            REQUIRE(ird.base_column_name(1) == NANODBC_TEXT("age"));
+        else
+            REQUIRE(ird.base_column_name(1) == NANODBC_TEXT(""));
+        REQUIRE(ird.name(1) == NANODBC_TEXT("age"));
+        REQUIRE(ird.base_table_name(1) == NANODBC_TEXT(""));
+        REQUIRE(ird.table_name(1) == NANODBC_TEXT(""));
+        // 2 * 3
+        REQUIRE(!ird.auto_unique_value(2));
+        if (vendor_ == database_vendor::mysql)
+        {
+            REQUIRE(ird.base_column_name(2) == NANODBC_TEXT(""));
+            REQUIRE(ird.name(2) == NANODBC_TEXT("2 * 3"));
+            REQUIRE(!ird.unnamed(2));
+        }
+        else if (vendor_ == database_vendor::postgresql)
+        {
+            REQUIRE(ird.base_column_name(2) == NANODBC_TEXT("?column?"));
+            REQUIRE(ird.name(2) == NANODBC_TEXT("?column?"));
+            REQUIRE(!ird.unnamed(2));
+        }
+        else if (vendor_ == database_vendor::sqlite)
+        {
+            REQUIRE(ird.base_column_name(2) == NANODBC_TEXT("2 * 3"));
+            REQUIRE(ird.name(2) == NANODBC_TEXT("2 * 3"));
+            REQUIRE_THROWS_WITH(!ird.unnamed(2), Catch::Contains("unsupported column attribute"));
+        }
+        else
+        {
+            REQUIRE(ird.base_column_name(2) == NANODBC_TEXT(""));
+            REQUIRE(ird.name(2) == NANODBC_TEXT(""));
+            REQUIRE(ird.unnamed(2));
+        }
+        REQUIRE(ird.base_table_name(2) == NANODBC_TEXT(""));
+        REQUIRE(ird.table_name(2) == NANODBC_TEXT(""));
     }
 
     template <class T>

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1415,6 +1415,34 @@ PRIMARY KEY(t2_fid)
             nanodbc::implementation_row_descriptor ird(s);
             REQUIRE(ird.columns() == 2);
             REQUIRE(ird.columns() == ird.column_count());
+            for (short i = 0; i < ird.columns(); i++)
+            {
+                if (vendor_ == database_vendor::mysql)
+                {
+                    REQUIRE(ird.catalog_name(i) != NANODBC_TEXT(""));
+                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
+                }
+                else if (vendor_ == database_vendor::postgresql)
+                {
+                    REQUIRE(ird.catalog_name(i) == NANODBC_TEXT(""));
+                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
+                }
+                else if (vendor_ == database_vendor::sqlite)
+                {
+                    REQUIRE(ird.catalog_name(i) == NANODBC_TEXT(""));
+                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
+                }
+                else if (vendor_ == database_vendor::sqlserver)
+                {
+                    REQUIRE(ird.catalog_name(i) == NANODBC_TEXT(""));
+                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
+                }
+                else
+                {
+                    REQUIRE(ird.schema_name(i) != NANODBC_TEXT(""));
+                    REQUIRE(ird.schema_name(i) != NANODBC_TEXT(""));
+                }
+            }
             // name
             REQUIRE(!ird.auto_unique_value(0));
             if (vendor_ == database_vendor::sqlite || vendor_ == database_vendor::postgresql)
@@ -1448,6 +1476,37 @@ PRIMARY KEY(t2_fid)
             nanodbc::implementation_row_descriptor ird(s);
             REQUIRE(ird.columns() == 3);
             REQUIRE(ird.columns() == ird.column_count());
+            for (short i = 0; i < ird.columns(); i++)
+            {
+                if (vendor_ == database_vendor::mysql)
+                {
+                    REQUIRE(ird.catalog_name(i) != NANODBC_TEXT(""));
+                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
+                }
+                else if (vendor_ == database_vendor::postgresql)
+                {
+                    if (i == 0) // NOTICE: fid1 alias has no catalog!(?)
+                        REQUIRE(ird.catalog_name(i) == NANODBC_TEXT(""));
+                    else
+                        REQUIRE(ird.catalog_name(i) != NANODBC_TEXT(""));
+                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT("public"));
+                }
+                else if (vendor_ == database_vendor::sqlite)
+                {
+                    REQUIRE(ird.catalog_name(i) == NANODBC_TEXT("main"));
+                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
+                }
+                else if (vendor_ == database_vendor::sqlserver)
+                {
+                    REQUIRE(ird.catalog_name(i) != NANODBC_TEXT(""));
+                    REQUIRE(ird.schema_name(i) == NANODBC_TEXT(""));
+                }
+                else
+                {
+                    REQUIRE(ird.schema_name(i) != NANODBC_TEXT(""));
+                    REQUIRE(ird.schema_name(i) != NANODBC_TEXT(""));
+                }
+            }
             // t1_fid1
             REQUIRE(!ird.auto_unique_value(0));
             if (vendor_ == database_vendor::sqlite)

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1416,6 +1416,7 @@ PRIMARY KEY(t2_fid)
             REQUIRE(ird.columns() == 2);
             REQUIRE(ird.columns() == ird.column_count());
             // name
+            REQUIRE(!ird.auto_unique_value(0));
             if (vendor_ == database_vendor::sqlite || vendor_ == database_vendor::postgresql)
                 REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("name"));
             else
@@ -1424,6 +1425,7 @@ PRIMARY KEY(t2_fid)
             REQUIRE(ird.base_table_name(0) == NANODBC_TEXT(""));
             REQUIRE(ird.table_name(0) == NANODBC_TEXT(""));
             // age
+            REQUIRE(!ird.auto_unique_value(1));
             if (vendor_ == database_vendor::sqlite || vendor_ == database_vendor::postgresql)
                 REQUIRE(ird.base_column_name(1) == NANODBC_TEXT("age"));
             else
@@ -1447,6 +1449,7 @@ PRIMARY KEY(t2_fid)
             REQUIRE(ird.columns() == 3);
             REQUIRE(ird.columns() == ird.column_count());
             // t1_fid1
+            REQUIRE(!ird.auto_unique_value(0));
             if (vendor_ == database_vendor::sqlite)
                 REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("fid1"));
             else
@@ -1458,6 +1461,7 @@ PRIMARY KEY(t2_fid)
             else
                 REQUIRE(ird.table_name(0) == NANODBC_TEXT("t1"));
             // t1_fid2
+            REQUIRE(!ird.auto_unique_value(1));
             REQUIRE(ird.base_column_name(1) == NANODBC_TEXT("t1_fid2"));
             REQUIRE(ird.column_name(1) == NANODBC_TEXT("t1_fid2"));
             REQUIRE(ird.base_table_name(1) == NANODBC_TEXT("t1"));

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1413,9 +1413,9 @@ PRIMARY KEY(t2_fid)
 
             nanodbc::statement s(c, sql);
             nanodbc::implementation_row_descriptor ird(s);
-            REQUIRE(ird.columns() == 3);
-            REQUIRE(ird.columns() == ird.column_count());
-            for (short i = 0; i < ird.columns(); i++)
+            REQUIRE(ird.count() == 3);
+            REQUIRE(ird.count() == ird.count());
+            for (short i = 0; i < ird.count(); i++)
             {
                 if (vendor_ == database_vendor::mysql)
                 {
@@ -1449,7 +1449,7 @@ PRIMARY KEY(t2_fid)
                 REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("name"));
             else
                 REQUIRE(ird.base_column_name(0) == NANODBC_TEXT(""));
-            REQUIRE(ird.column_name(0) == NANODBC_TEXT("name"));
+            REQUIRE(ird.name(0) == NANODBC_TEXT("name"));
             REQUIRE(ird.base_table_name(0) == NANODBC_TEXT(""));
             REQUIRE(ird.table_name(0) == NANODBC_TEXT(""));
             // age
@@ -1458,7 +1458,7 @@ PRIMARY KEY(t2_fid)
                 REQUIRE(ird.base_column_name(1) == NANODBC_TEXT("age"));
             else
                 REQUIRE(ird.base_column_name(1) == NANODBC_TEXT(""));
-            REQUIRE(ird.column_name(1) == NANODBC_TEXT("age"));
+            REQUIRE(ird.name(1) == NANODBC_TEXT("age"));
             REQUIRE(ird.base_table_name(1) == NANODBC_TEXT(""));
             REQUIRE(ird.table_name(1) == NANODBC_TEXT(""));
             // 2 * 3
@@ -1466,26 +1466,26 @@ PRIMARY KEY(t2_fid)
             if (vendor_ == database_vendor::mysql)
             {
                 REQUIRE(ird.base_column_name(2) == NANODBC_TEXT(""));
-                REQUIRE(ird.column_name(2) == NANODBC_TEXT("2 * 3"));
-                REQUIRE(ird.column_named(2));
+                REQUIRE(ird.name(2) == NANODBC_TEXT("2 * 3"));
+                REQUIRE(!ird.unnamed(2));
             }
             else if (vendor_ == database_vendor::postgresql)
             {
                 REQUIRE(ird.base_column_name(2) == NANODBC_TEXT("?column?"));
-                REQUIRE(ird.column_name(2) == NANODBC_TEXT("?column?"));
-                REQUIRE(ird.column_named(2));
+                REQUIRE(ird.name(2) == NANODBC_TEXT("?column?"));
+                REQUIRE(!ird.unnamed(2));
             }
             else if (vendor_ == database_vendor::sqlite)
             {
                 REQUIRE(ird.base_column_name(2) == NANODBC_TEXT("2 * 3"));
-                REQUIRE(ird.column_name(2) == NANODBC_TEXT("2 * 3"));
-                REQUIRE_THROWS_WITH(ird.column_named(2), Catch::Contains("unsupported column attribute"));
+                REQUIRE(ird.name(2) == NANODBC_TEXT("2 * 3"));
+                REQUIRE_THROWS_WITH(!ird.unnamed(2), Catch::Contains("unsupported column attribute"));
             }
             else
             {
                 REQUIRE(ird.base_column_name(2) == NANODBC_TEXT(""));
-                REQUIRE(ird.column_name(2) == NANODBC_TEXT(""));
-                REQUIRE(!ird.column_named(2));
+                REQUIRE(ird.name(2) == NANODBC_TEXT(""));
+                REQUIRE(ird.unnamed(2));
             }
             REQUIRE(ird.base_table_name(2) == NANODBC_TEXT(""));
             REQUIRE(ird.table_name(2) == NANODBC_TEXT(""));
@@ -1502,9 +1502,9 @@ PRIMARY KEY(t2_fid)
 
             nanodbc::statement s(c, sql);
             nanodbc::implementation_row_descriptor ird(s);
-            REQUIRE(ird.columns() == 3);
-            REQUIRE(ird.columns() == ird.column_count());
-            for (short i = 0; i < ird.columns(); i++)
+            REQUIRE(ird.count() == 3);
+            REQUIRE(ird.count() == ird.count());
+            for (short i = 0; i < ird.count(); i++)
             {
                 if (vendor_ == database_vendor::mysql)
                 {
@@ -1541,7 +1541,7 @@ PRIMARY KEY(t2_fid)
                 REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("fid1"));
             else
                 REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("t1_fid1"));
-            REQUIRE(ird.column_name(0) == NANODBC_TEXT("fid1"));
+            REQUIRE(ird.name(0) == NANODBC_TEXT("fid1"));
             REQUIRE(ird.base_table_name(0) == NANODBC_TEXT("t1"));
             if (vendor_ == database_vendor::mysql)
                 REQUIRE(ird.table_name(0) == NANODBC_TEXT("t"));
@@ -1550,7 +1550,7 @@ PRIMARY KEY(t2_fid)
             // t1_fid2
             REQUIRE(!ird.auto_unique_value(1));
             REQUIRE(ird.base_column_name(1) == NANODBC_TEXT("t1_fid2"));
-            REQUIRE(ird.column_name(1) == NANODBC_TEXT("t1_fid2"));
+            REQUIRE(ird.name(1) == NANODBC_TEXT("t1_fid2"));
             REQUIRE(ird.base_table_name(1) == NANODBC_TEXT("t1"));
             if (vendor_ == database_vendor::mysql)
                 REQUIRE(ird.table_name(1) == NANODBC_TEXT("t"));
@@ -1558,7 +1558,7 @@ PRIMARY KEY(t2_fid)
                 REQUIRE(ird.table_name(1) == NANODBC_TEXT("t1"));
             // name
             REQUIRE(ird.base_column_name(2) == NANODBC_TEXT("name"));
-            REQUIRE(ird.column_name(2) == NANODBC_TEXT("name"));
+            REQUIRE(ird.name(2) == NANODBC_TEXT("name"));
             REQUIRE(ird.base_table_name(2) == NANODBC_TEXT("t1"));
             if (vendor_ == database_vendor::mysql)
                 REQUIRE(ird.table_name(2) == NANODBC_TEXT("t"));
@@ -1582,14 +1582,13 @@ PRIMARY KEY(t2_fid)
 
             nanodbc::statement s(c, sql);
             nanodbc::implementation_row_descriptor ird(s);
-            REQUIRE(ird.columns() == 5);
-            REQUIRE(ird.columns() == ird.column_count());
+            REQUIRE(ird.count() == 5);
             // fid1
             if (vendor_ == database_vendor::sqlite)
                 REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("fid1"));
             else
                 REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("t1_fid1"));
-            REQUIRE(ird.column_name(0) == NANODBC_TEXT("fid1"));
+            REQUIRE(ird.name(0) == NANODBC_TEXT("fid1"));
             if (vendor_ == database_vendor::mysql || vendor_ == database_vendor::postgresql)
             {
                 REQUIRE(ird.base_table_name(0) == NANODBC_TEXT("v_t1_t2"));


### PR DESCRIPTION
## What does this PR do?

First stab at adding support for access to metadata in [descriptors](https://docs.microsoft.com/en-us/sql/odbc/reference/develop-app/descriptor-handles).

Adds `implementation_row_descriptor` class which is a proxy to ODBC API function [SQLGetDescField](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdescfield-function) (as better alternative to [SQLColAttribute](https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlcolattribute-function)) which offers access to implicitly allocated **Implementation Row Descriptor (IRD)** with information about the columns in a result set.

The access to IRD can be especially useful with SQL Server e.g. to figure out name of base table of a column in a view.

For example, given `CREATE VIEW v1 AS SELECT t1.a, t2.b FROM t1, t2` which then is queried `SELECT a FROM v1 WHERE ...` it makes it possible to find out that `a` is a field sourced from table `t1`. It is useful to determine details about schema of query.

SQL Server Hint: As [documented for SQL Server drivers](https://docs.microsoft.com/en-us/sql/relational-databases/native-client-odbc-api/sqlcolattribute), certain records are only filled for `SELECT` statements containing a `FOR BROWSE` clause, e.g.: `SELECT a FROM v1 FOR BROWSE`. 

As usual for ODBC, there are differences in behaviour between various ODBC drivers. See the added tests for details.

## References

- https://docs.microsoft.com/en-us/sql/odbc/reference/develop-app/descriptor-handles
- https://www.ibm.com/docs/en/db2/11.5?topic=descriptors-manipulation-without-handles
- https://www.easysoft.com/developer/languages/c/examples/util.html
- 
## Tasklist

 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

