### PR TITLE
build: enable use as a git submodule

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,14 +15,14 @@ set(CATCH_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(Catch INTERFACE)
 target_include_directories(Catch INTERFACE ${CATCH_INCLUDE_DIR})
 
-include_directories(${CMAKE_SOURCE_DIR} ${ODBC_INCLUDE_DIR})
+include_directories(${nanodbc_SOURCE_DIR} ${ODBC_INCLUDE_DIR})
 link_directories(${CMAKE_BINARY_DIR}/lib)
 file(GLOB headers *.h *.hpp)
 add_custom_target(tests DEPENDS tests catch)
 
 # Common utilities tests
 add_executable(utility_tests utility_test.cpp)
-target_include_directories(utility_tests PRIVATE ${CMAKE_SOURCE_DIR}/nanodbc)
+target_include_directories(utility_tests PRIVATE ${nanodbc_SOURCE_DIR}/nanodbc)
 if (BUILD_SHARED_LIBS)
   target_link_libraries(utility_tests nanodbc Catch "${ODBC_LINK_FLAGS}")
 else()


### PR DESCRIPTION
## What does this PR do?

Enables the use of nanodbc as a git submodule.

The CMAKE_SOURCE_DIR reference in test results in a build failure when the nanodbc project has been added to a parent project as a git submodule in a subdirectory.

Changing the reference to the project's source nanodbc_SOURCE_DIR allows building both as a standalone git project and a git submodule.

## What are related issues/pull requests?

#348 

## Environment

Provide environment details, if relevant:

* CMake 3.23.2
* git 2.37.1
