### PR TITLE
feat: add support for SQL_DRIVER_VER (#351)

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1132,6 +1132,8 @@ public:
 
     string driver_name() const;
 
+    string driver_version() const;
+
     string database_name() const;
 
     string catalog_name() const
@@ -1219,6 +1221,11 @@ string connection::connection_impl::dbms_version() const
 string connection::connection_impl::driver_name() const
 {
     return get_info<string>(SQL_DRIVER_NAME);
+}
+
+string connection::connection_impl::driver_version() const
+{
+    return get_info<string>(SQL_DRIVER_VER);
 }
 
 string connection::connection_impl::database_name() const
@@ -4827,6 +4834,11 @@ string connection::dbms_version() const
 string connection::driver_name() const
 {
     return impl_->driver_name();
+}
+
+string connection::driver_version() const
+{
+    return impl_->driver_version();
 }
 
 string connection::database_name() const

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1441,6 +1441,10 @@ public:
     /// \throws database_error
     string driver_name() const;
 
+    /// \brief Returns the version of the ODBC driver.
+    /// \throws database_error
+    string driver_version() const;
+
     /// \brief Returns the name of the currently connected database.
     /// Returns the current SQL_DATABASE_NAME information value associated with the connection.
     string database_name() const;

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -99,6 +99,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_driver", "[mssql][driver]")
     test_driver();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_driver_info", "[mssql][driver][metadata][info]")
+{
+    test_driver_info();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_datasources", "[mssql][datasources]")
 {
     test_datasources();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -25,6 +25,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_driver", "[mysql][driver]")
     test_driver();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_driver_info", "[mysql][driver][metadata][info]")
+{
+    test_driver_info();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_datasources", "[mysql][datasources]")
 {
     test_datasources();

--- a/test/odbc_test.cpp
+++ b/test/odbc_test.cpp
@@ -19,6 +19,11 @@ TEST_CASE_METHOD(odbc_fixture, "test_driver", "[odbc][driver]")
     test_driver();
 }
 
+TEST_CASE_METHOD(odbc_fixture, "test_driver_info", "[odbc][driver][metadata][info]")
+{
+    test_driver_info();
+}
+
 TEST_CASE_METHOD(odbc_fixture, "test_blob", "[odbc][blob]")
 {
     test_blob();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -24,6 +24,11 @@ TEST_CASE_METHOD(postgresql_fixture, "test_driver", "[postgresql][driver]")
     test_driver();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "test_driver_info", "[postgresql][driver][metadata][info]")
+{
+    test_driver_info();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_datasources", "[postgresql][datasources]")
 {
     test_datasources();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -110,6 +110,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_driver", "[sqlite][driver]")
     test_driver();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_driver_info", "[sqlite][driver][metadata][info]")
+{
+    test_driver_info();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_datasources", "[sqlite][datasources]")
 {
     test_datasources();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1060,6 +1060,15 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(found);
     }
 
+    void test_driver_info()
+    {
+      // A generic test to exercise the ODBC driver info API is callable.
+      // Driver-specific tests may perform extended checks.
+      nanodbc::connection connection = connect();
+      REQUIRE(!connection.driver_name().empty());
+      REQUIRE(!connection.driver_version().empty());
+    }
+
     void test_datasources()
     {
         auto const dsns = nanodbc::list_datasources();

--- a/test/vertica_test.cpp
+++ b/test/vertica_test.cpp
@@ -21,6 +21,11 @@ TEST_CASE_METHOD(vertica_fixture, "test_driver", "[vertica][driver]")
     test_driver();
 }
 
+TEST_CASE_METHOD(vertica_fixture, "test_driver_info", "[vertica][driver][metadata][info]")
+{
+    test_driver_info();
+}
+
 TEST_CASE_METHOD(vertica_fixture, "test_datasources", "[vertica][datasources]")
 {
     test_datasources();


### PR DESCRIPTION
implement driver_version()

test: add cases for driver_version support

## What does this PR do?

Adds a call returning SQL_DRIVER_VER through nanodbc.

## What are related issues/pull requests?

#351 

## Tasklist

 - [ ] Add ```connection::driver_version()```
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

Tested locally with Oracle 11, PostgreSQL 12, Microsoft SQL Server 2017