### PR TITLE
Allow callers to pass pre-connection attributes.

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -852,21 +852,21 @@ inline void allocate_dbc_handle(SQLHDBC& conn, SQLHENV env)
 namespace nanodbc
 {
 connection::attribute::attribute(
-    long const& attr,
-    long const& strLen,
-    std::variant<std::vector<uint8_t>, string, std::intptr_t, std::uintptr_t> const& rsrc)
-    : odbcAttribute(attr)
-    , odbcStringLength(strLen)
-    , resource(rsrc)
-    , odbcValuePtr(nullptr)
+    long const& attribute,
+    long const& string_length,
+    std::variant<std::vector<uint8_t>, string, std::intptr_t, std::uintptr_t> const& resource)
+    : attribute_(attribute)
+    , string_length_(string_length)
+    , resource_(resource)
+    , value_ptr_(nullptr)
 {
     this->extractValuePtr();
 }
 connection::attribute::attribute(attribute const& other)
-    : odbcAttribute(other.odbcAttribute)
-    , odbcStringLength(other.odbcStringLength)
-    , resource(other.resource)
-    , odbcValuePtr(nullptr)
+    : attribute_(other.attribute_)
+    , string_length_(other.string_length_)
+    , resource_(other.resource_)
+    , value_ptr_(nullptr)
 {
     this->extractValuePtr();
 }
@@ -878,15 +878,15 @@ void connection::attribute::extractValuePtr()
             using T = std::decay_t<decltype(arg)>;
             if constexpr (std::is_same_v<T, string> || std::is_same_v<T, std::vector<uint8_t>>)
             {
-                this->odbcValuePtr = (void*)&arg[0];
+                this->value_ptr_ = (void*)&arg[0];
             }
             else if constexpr (
                 std::is_same_v<T, std::intptr_t> || std::is_same_v<T, std::uintptr_t>)
             {
-                this->odbcValuePtr = (void*)(arg);
+                this->value_ptr_ = (void*)(arg);
             }
         },
-        this->resource);
+        this->resource_);
 }
 } // namespace nanodbc
 #endif
@@ -1114,8 +1114,8 @@ public:
 #if !defined(NANODBC_DISABLE_ASYNC) && defined(SQL_ATTR_ASYNC_DBC_EVENT)
         if (event_handle != nullptr)
         {
-            attributes.push_back({
-                SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE, SQL_IS_UINTEGER, SQL_ASYNC_DBC_ENABLE_ON});
+            attributes.push_back(
+                {SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE, SQL_IS_UINTEGER, SQL_ASYNC_DBC_ENABLE_ON});
             attributes.push_back({SQL_ATTR_ASYNC_DBC_EVENT, SQL_IS_POINTER, event_handle});
         }
 #endif
@@ -1138,18 +1138,18 @@ public:
         bool is_async = false;
         for (const attribute& attr : attributes)
         {
-            if (attr.odbcValuePtr == nullptr)
+            if (attr.value_ptr_ == nullptr)
             {
                 continue;
             }
 #if !defined(NANODBC_DISABLE_ASYNC) && defined(SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE)
-            if (attr.odbcAttribute == SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE &&
-                attr.odbcValuePtr == (void*)(std::intptr_t)SQL_ASYNC_DBC_ENABLE_ON)
+            if (attr.attribute_ == SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE &&
+                attr.value_ptr_ == (void*)(std::intptr_t)SQL_ASYNC_DBC_ENABLE_ON)
             {
                 is_async = true;
             }
 #endif
-            this->set_attribute(attr.odbcAttribute, attr.odbcStringLength, attr.odbcValuePtr);
+            this->set_attribute(attr.attribute_, attr.string_length_, attr.value_ptr_);
         }
 
         RETCODE rc;
@@ -1186,8 +1186,8 @@ public:
 #if !defined(NANODBC_DISABLE_ASYNC) && defined(SQL_ATTR_ASYNC_DBC_EVENT)
         if (event_handle != nullptr)
         {
-            attributes.push_back({
-                SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE, SQL_IS_UINTEGER, SQL_ASYNC_DBC_ENABLE_ON});
+            attributes.push_back(
+                {SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE, SQL_IS_UINTEGER, SQL_ASYNC_DBC_ENABLE_ON});
             attributes.push_back({SQL_ATTR_ASYNC_DBC_EVENT, SQL_IS_POINTER, event_handle});
         }
 #endif
@@ -1206,18 +1206,18 @@ public:
         bool is_async = false;
         for (const attribute& attr : attributes)
         {
-            if (attr.odbcValuePtr == nullptr)
+            if (attr.value_ptr_ == nullptr)
             {
                 continue;
             }
 #if !defined(NANODBC_DISABLE_ASYNC) && defined(SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE)
-            if (attr.odbcAttribute == SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE &&
-                attr.odbcValuePtr == (void*)(std::intptr_t)SQL_ASYNC_DBC_ENABLE_ON)
+            if (attr.attribute_ == SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE &&
+                attr.value_ptr_ == (void*)(std::intptr_t)SQL_ASYNC_DBC_ENABLE_ON)
             {
                 is_async = true;
             }
 #endif
-            this->set_attribute(attr.odbcAttribute, attr.odbcStringLength, attr.odbcValuePtr);
+            this->set_attribute(attr.attribute_, attr.string_length_, attr.value_ptr_);
         }
 
         RETCODE rc;

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1283,6 +1283,13 @@ private:
 class connection
 {
 public:
+    /// \brief A 3-element tuple representing a connection attribute.
+    ///
+    /// The first element is the Attribute argument to the ODBC SQLSetConnectAttr
+    /// function.  The second is the StringLength, and the third is the ValuePtr
+    /// argument.
+    ///
+    /// See https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlsetconnectattr-function
     typedef std::tuple<long, long, void*> attribute;
     /// \brief Create new connection object, initially not connected.
     connection();

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1283,6 +1283,7 @@ private:
 class connection
 {
 public:
+    typedef std::tuple<long, long, void*> attribute;
     /// \brief Create new connection object, initially not connected.
     connection();
 
@@ -1310,6 +1311,24 @@ public:
     /// \see connected(), connect()
     connection(string const& dsn, string const& user, string const& pass, long timeout = 0);
 
+    /// \brief Create new connection object, set the connection attributes passed as
+    /// arguments and connect to the given data source.
+    ///
+    /// The function calls ODBC API SQLConnect.  To set connection attributes,
+    /// SQLSetConnectAttr is called.
+    ///
+    /// \param dsn The name of the data source name (DSN).
+    /// \param user The username for authenticating to the data source.
+    /// \param pass The password for authenticating to the data source.
+    /// \param attributes A list of connection attributes to be set prior to connecting.
+    /// \throws database_error
+    /// \see connected(), connect(), attribute
+    connection(
+        string const& dsn,
+        string const& user,
+        string const& pass,
+        std::list<attribute> const& attributes);
+
     /// \brief Create new connection object and immediately connect using the given connection
     /// string.
     ///
@@ -1320,6 +1339,18 @@ public:
     /// \throws database_error
     /// \see connected(), connect()
     explicit connection(string const& connection_string, long timeout = 0);
+
+    /// \brief Create new connection object, set the connection attributes passed as
+    /// arguments and connect to the given connection string.
+    ///
+    /// The function calls ODBC API SQLDriverConnect.  To set connection attributes,
+    /// SQLSetConnectAttr is called.
+    ///
+    /// \param connection_string The connection string for establishing a connection.
+    /// \param attributes A list of connection attributes to be set prior to connecting.
+    /// \throws database_error
+    /// \see connected(), connect(), attribute
+    connection(string const& connection_string, std::list<attribute> const& attributes);
 
     /// \brief Automatically disconnects from the database and frees all associated resources.
     ///
@@ -1350,12 +1381,34 @@ public:
     /// \see connected()
     void connect(string const& dsn, string const& user, string const& pass, long timeout = 0);
 
+    /// \brief Set the connection attributes passed by the user, and connect to the given
+    /// data source.
+    /// \param dsn The name of the data source.
+    /// \param user The username for authenticating to the data source.
+    /// \param pass The password for authenticating to the data source.
+    /// \param attributes A list of connection attributes to be set prior to connecting.
+    /// \throws database_error
+    /// \see connected(), attribute
+    void connect(
+        string const& dsn,
+        string const& user,
+        string const& pass,
+        std::list<attribute> const& attributes);
+
     /// \brief Connect using the given connection string.
     /// \param connection_string The connection string for establishing a connection.
     /// \param timeout Seconds before connection timeout. Default is 0 indicating no timeout.
     /// \throws database_error
     /// \see connected()
     void connect(string const& connection_string, long timeout = 0);
+
+    /// \brief Set the connection attributes passed by the user, and connect to the given
+    /// connection string.
+    /// \param connection_string The connection string for establishing a connection.
+    /// \param attributes A list of connection attributes to be set prior to connecting.
+    /// \throws database_error
+    /// \see connected(), attribute
+    void connect(string const& connection_string, std::list<attribute> const& attributes);
 
 #if !defined(NANODBC_DISABLE_ASYNC)
     /// \brief Initiate an asynchronous connection operation to the given data source.

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1310,17 +1310,18 @@ public:
         attribute& operator=(attribute const&) = delete;
         attribute(attribute const& other);
         attribute(
-            long const& attr,
-            long const& strLen,
-            std::variant<std::vector<uint8_t>, string, std::intptr_t, std::uintptr_t> const& rsrc);
+            long const& attribute,
+            long const& string_length,
+            std::variant<std::vector<uint8_t>, string, std::intptr_t, std::uintptr_t> const&
+                resource);
 
     private:
         void extractValuePtr();
 
-        long odbcAttribute;
-        long odbcStringLength;
-        std::variant<std::vector<uint8_t>, string, std::intptr_t, std::uintptr_t> resource;
-        void* odbcValuePtr;
+        long attribute_;
+        long string_length_;
+        std::variant<std::vector<uint8_t>, string, std::intptr_t, std::uintptr_t> resource_;
+        void* value_ptr_;
         friend class nanodbc::connection::connection_impl;
     };
 #else
@@ -1332,19 +1333,19 @@ private:
     class attribute
     {
     public:
-        attribute(long const& attr, long const& strLen, long const& val)
-            : odbcAttribute(attr)
-            , odbcStringLength(strLen)
-            , odbcValuePtr((void*)(std::intptr_t)val){};
-        attribute(long const& attr, long const& strLen, void* val)
-            : odbcAttribute(attr)
-            , odbcStringLength(strLen)
-            , odbcValuePtr(val){};
+        attribute(long const& attribute, long const& string_length, long const& value)
+            : attribute_(attribute)
+            , string_length_(string_length)
+            , value_ptr_((void*)(std::intptr_t)value){};
+        attribute(long const& attribute, long const& string_length, void* value_ptr)
+            : attribute_(attribute)
+            , string_length_(string_length)
+            , value_ptr_(value_ptr){};
 
     private:
-        long odbcAttribute;
-        long odbcStringLength;
-        void* odbcValuePtr;
+        long attribute_;
+        long string_length_;
+        void* value_ptr_;
         friend class nanodbc::connection::connection_impl;
     };
 #endif

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1292,14 +1292,15 @@ private:
 
 #if __cpp_lib_variant >= 201606L
 public:
-    /// \brief A 3-element tuple representing a connection attribute.
+    /// \brief A class representing a connection attribute.
     ///
-    /// The first element is the Attribute argument to the ODBC SQLSetConnectAttr
-    /// function.  The second is the StringLength, and the third is the ValuePtr
-    /// argument.  This element (third in tuple) is stored in a std::variant,
-    /// a type safe union of std::vector<uint8_t> ( binary buffer payloads ),
-    /// nanodbc::string ( string payloads ), or std::(u)intptr_t, for both
-    /// u/int payloads, as well as pointers to more generic buffers.
+    /// Callers should create attributes using the 3 argument constructor.
+    /// First argument is the Attribute argument to the ODBC SQLSetConnectAttr
+    /// function.  The second is the StringLength, and the third is used to
+    /// inform the ValuePtr argument to SQLSetConnectAttr.  This argument,
+    /// a std::variant, is a type safe union of std::vector<uint8_t> ( binary
+    /// buffer payloads ), nanodbc::string ( string payloads ), or std::(u)intptr_t,
+    /// for both u/int payloads, as well as pointers to more generic buffers.
     ///
     /// See https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlsetconnectattr-function
     class attribute
@@ -1334,11 +1335,12 @@ private:
         attribute(long const& attr, long const& strLen, long const& val)
             : odbcAttribute(attr)
             , odbcStringLength(strLen)
-            , odbcValuePtr((void*)(std::intptr_t)val) {};
+            , odbcValuePtr((void*)(std::intptr_t)val){};
         attribute(long const& attr, long const& strLen, void* val)
             : odbcAttribute(attr)
             , odbcStringLength(strLen)
-            , odbcValuePtr(val) {};
+            , odbcValuePtr(val){};
+
     private:
         long odbcAttribute;
         long odbcStringLength;

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -28,6 +28,47 @@ struct mssql_fixture : public test_case_fixture
             connection_string_ = get_env("NANODBC_TEST_CONNSTR_MSSQL");
     }
 
+    using base_test_fixture::connect;
+    nanodbc::connection
+    connect(std::list<nanodbc::connection::attribute> const& attributes, bool const& is_async)
+    {
+        nanodbc::connection connection(connection_string_, attributes);
+        if (!is_async)
+        {
+            REQUIRE(connection.connected());
+            vendor_ = get_vendor(connection.dbms_name());
+        }
+        return connection;
+    }
+
+#if !defined(NANODBC_DISABLE_ASYNC) && defined(WIN32)
+    void test_async_internal(nanodbc::connection& conn, HANDLE& event_handle)
+    {
+        nanodbc::statement stmt(conn);
+        if (stmt.async_prepare(NANODBC_TEXT("select count(*) from sys.tables;"), event_handle))
+            WaitForSingleObject(event_handle, INFINITE);
+        stmt.complete_prepare();
+
+        if (stmt.async_execute(event_handle))
+            WaitForSingleObject(event_handle, INFINITE);
+        nanodbc::result row = stmt.complete_execute();
+
+        if (row.async_next(event_handle))
+            WaitForSingleObject(event_handle, INFINITE);
+        REQUIRE(row.complete_next());
+
+        REQUIRE(row.get<int>(0) >= 0);
+    }
+#endif
+
+    inline bool success(RETCODE rc)
+    {
+#ifdef NANODBC_ODBC_API_DEBUG
+        std::cerr << "<-- rc: " << return_code(rc) << " | " << std::endl;
+#endif
+        return rc == SQL_SUCCESS || rc == SQL_SUCCESS_WITH_INFO;
+    }
+
     // `name` is a type name
     // `def` is a comma separated column definitions, trailing '(' and ')' are optional.
     void create_table_type(
@@ -1126,20 +1167,7 @@ TEST_CASE_METHOD(mssql_fixture, "test_async", "[mssql][async]")
         WaitForSingleObject(event_handle, INFINITE);
     conn.async_complete();
 
-    nanodbc::statement stmt(conn);
-    if (stmt.async_prepare(NANODBC_TEXT("select count(*) from sys.tables;"), event_handle))
-        WaitForSingleObject(event_handle, INFINITE);
-    stmt.complete_prepare();
-
-    if (stmt.async_execute(event_handle))
-        WaitForSingleObject(event_handle, INFINITE);
-    nanodbc::result row = stmt.complete_execute();
-
-    if (row.async_next(event_handle))
-        WaitForSingleObject(event_handle, INFINITE);
-    REQUIRE(row.complete_next());
-
-    REQUIRE(row.get<int>(0) >= 0);
+    test_async_internal(conn, event_handle);
 }
 #endif
 
@@ -1556,6 +1584,85 @@ TEST_CASE_METHOD(
         REQUIRE(p2_ == results.get<nanodbc::string>(6));
         ++rcnt;
     }
+}
+
+TEST_CASE_METHOD(mssql_fixture, "test_conn_attributes", "[mssql][conn_attibutes]")
+{
+    {
+        std::list<nanodbc::connection::attribute> attributes;
+        nanodbc::string CATALOG_IN(NANODBC_TEXT("tempdb"));
+        std::string TRACEFILE_IN("nanodbc_test.log");
+        size_t CATALOG_IN_LENGTH = CATALOG_IN.size() * sizeof(nanodbc::string::value_type);
+        size_t TRACEFILE_IN_LENGTH = TRACEFILE_IN.size();
+        long TIMEOUT_IN = 7;
+
+        attributes.push_back(
+            {SQL_ATTR_LOGIN_TIMEOUT, SQL_IS_UINTEGER, (void*)(std::intptr_t)TIMEOUT_IN});
+        attributes.push_back(
+            {SQL_ATTR_CURRENT_CATALOG, (long)CATALOG_IN_LENGTH, (void*)&CATALOG_IN[0]});
+        attributes.push_back(
+            {SQL_ATTR_TRACE, SQL_IS_UINTEGER, (void*)(std::intptr_t)SQL_OPT_TRACE_ON});
+        attributes.push_back(
+            {SQL_ATTR_TRACEFILE, (long)TRACEFILE_IN_LENGTH, (void*)&TRACEFILE_IN[0]});
+
+        auto conn = connect(attributes, false);
+        // We may have connected async, but the following calls to
+        // SQLGetConnectAttr are OK despite the state possibly being
+        // SQL_STILL_EXECUTING.
+
+        // Test whether catalog was set
+        // REQUIRE(conn.catalog_name() == CATALOG_IN);
+
+        // Test whether timeout was set
+        long timeout_out(0);
+        SQLINTEGER length(0);
+        RETCODE rc = ::SQLGetConnectAttr(
+            conn.native_dbc_handle(),
+            SQL_ATTR_LOGIN_TIMEOUT,
+            &timeout_out,
+            sizeof(timeout_out),
+            &length);
+        REQUIRE(success(rc));
+        REQUIRE(timeout_out == TIMEOUT_IN);
+
+        // Test trace-file.
+        // 1. Call GetConnectAttr to get length
+        // 2. Call GetConnectAttr to get actual
+        //    buffer
+        length = 0;
+        rc = ::SQLGetConnectAttr(conn.native_dbc_handle(), SQL_ATTR_TRACEFILE, nullptr, 0, &length);
+        printf("Tracefile length %d\n", length);
+        REQUIRE(success(rc));
+
+        std::string tracefile_out(TRACEFILE_IN_LENGTH + 5, 0);
+        rc = ::SQLGetConnectAttr(
+            conn.native_dbc_handle(),
+            SQL_ATTR_TRACEFILE,
+            &tracefile_out[0],
+            (SQLINTEGER)(TRACEFILE_IN_LENGTH + 5),
+            &length);
+        printf("Tracefile get rc %d\n", (int)rc);
+        printf("Tracefile length %d\n", length);
+        REQUIRE(success(rc));
+        REQUIRE(tracefile_out.substr(0, TRACEFILE_IN_LENGTH) == TRACEFILE_IN);
+    }
+#if !defined(NANODBC_DISABLE_ASYNC) && defined(WIN32)
+    {
+        std::list<nanodbc::connection::attribute> attributes;
+        attributes.push_back(
+            {SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE,
+             SQL_IS_UINTEGER,
+             (void*)(std::intptr_t)SQL_ASYNC_DBC_ENABLE_ON});
+        HANDLE event_handle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+        attributes.push_back({SQL_ATTR_ASYNC_DBC_EVENT, SQL_IS_POINTER, event_handle});
+
+        auto conn = connect(attributes, true);
+        WaitForSingleObject(event_handle, INFINITE);
+        conn.async_complete();
+        REQUIRE(conn.connected());
+        test_async_internal(conn, event_handle);
+    }
+#endif
 }
 
 #endif


### PR DESCRIPTION

Hi @mloskot, @lexicalunit :

This PR is one approach to exposing mechanisms to the user to set pre-connection attributes (  for example, #215 ). 

The high level:

- It defines/exposes a connection::attribute.  This is a 3-element tuple defining a connection attribute.
- It adds `connection::connection(…., std::list< attribute > )` constructor, and a `connection::connect(…., std::list< attribute > )` methods, allowing the caller to pass a list of pre-connection attributes as an argument.  At the implementation level, other constructors (timeout, async) and other connect methods are routed through this one since this is intended to be the most generic one.

Some more detail:

1. Also considered a different workflow, where the user interaction would be:

```
c.allocate();
c.set_attribute(…);
c.connect(…)
```
  but ultimately went in a different direction for a couple of reasons. 
  * We would be treating connection arguments like timeout and async, differently relative to other connection arguments: timeout as part of the connect() call, versus other attributes set using set_attribute.  But, timeout (and async), at the end is just another connection attribute; it made some sense to have a unified API point.
  * Separating the set_attribute and connect calls may be fine for some attributes but not all.  In particular for some of the attributes that pass a buffer, that buffer is only read by the driver as part of the subsequent connect call, not as part of the set attribute call.  So if, for example, the buffer went out of scope (or was somehow otherwise destroyed) between the set_attribute and connect calls, this could lead to subtle issues ( i.e. spending inordinate amount of time trying to understand why the azure token I was passing was incorrect, or chasing down segfaults with gdb ).

  Not done here, but we could easily expose a connection.set_attribute method; if there is a desire to 		do this in addition to the mechanisms for setting pre-connection attributes above (rather than replace them).

2. The definition of the attribute: currently a tuple - so if for example a user wanted to add an azure authentication token they would need to do something along the lines of

```
attributes.push_back(
        { SQL_COPT_SS_ACCESS_TOKEN, SQL_IS_POINTER, buffer } );
```
  Not in-love with this; feels a little bare-metal.  Tried to infer the middle argument (StringLength to SQLSetConnectAttr) based on the type of buffer.  But had trouble codifying the rules since it seemed to me they are not uniform - see for example ODBC documentation for the case of ValuePtr a binary buffer and how it is treated with the attribute is ODBC- versus driver-defined.  It can probably be done, but also was mindful of the “nano” in nanodbc.

3. Added tests for integer ( timeout ), string ( trace file ), and more generic buffer ( async ) attribute payloads.   ( The new async test is probably an overkill, since through the routing of the existing methods, the previous async test was also testing the attributes logic ).  Also tested locally with an azure token where the payload is a pointer to a custom defined struct.

Feedback is appreciated.
Thank you!