### PR TITLE
Work with non english ODBC drivers

### DIFF
--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -542,7 +542,7 @@ TEST_CASE_METHOD(
         REQUIRE(results.next());
         REQUIRE(results.get<int>(0) == 1);
         REQUIRE_THROWS_WITH(
-            results.get<nanodbc::string>(1), Catch::Contains("Invalid Descriptor Index"));
+            results.get<nanodbc::string>(1), Catch::Contains("07009")); // Invalid Descriptor Index
     }
 
     // Query bound first, then unbound.
@@ -584,7 +584,7 @@ TEST_CASE_METHOD(
         REQUIRE(results.get<int>(1) == 11);
         REQUIRE(results.get<nanodbc::string>(3) == NANODBC_TEXT("this is text"));
         REQUIRE_THROWS_WITH(
-            results.get<nanodbc::string>(2), Catch::Contains("Invalid Descriptor Index"));
+            results.get<nanodbc::string>(2), Catch::Contains("07009")); // Invalid Descriptor Index
     }
 
     // Query bound and unbound interleaved.
@@ -613,7 +613,8 @@ TEST_CASE_METHOD(
         results.unbind();
         REQUIRE(results.next());
         REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("this is varchar max"));
-        REQUIRE_THROWS_WITH(results.get<int>(0), Catch::Contains("Invalid Descriptor Index"));
+        REQUIRE_THROWS_WITH(
+            results.get<int>(0), Catch::Contains("07009")); // Invalid Descriptor Index
     }
 
     // Query bound and unbound interleaved.
@@ -785,7 +786,7 @@ TEST_CASE_METHOD(mssql_fixture, "test_statement_with_empty_connection", "[mssql]
     c.allocate();
     nanodbc::statement s;
     REQUIRE_THROWS_AS(s.open(c), nanodbc::database_error);
-    REQUIRE_THROWS_WITH(s.open(c), Catch::Contains("Connection"));
+    REQUIRE_THROWS_WITH(s.open(c), Catch::Contains("08003")); // Connection not open
 }
 
 TEST_CASE_METHOD(mssql_fixture, "test_string", "[mssql][string]")


### PR DESCRIPTION
## Issue
In the Microsoft SQLserver unit test when an error is raised the check was done on words in string contents.
When working with a localized ODBC drivers (mine answer in French) the string could not match the English message.

## What does this PR do?
This PR replace the check on word by a check on error code. Microsoft error are prefixed by an error code from [this list](https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/appendix-a-odbc-error-codes?view=sql-server-ver16) and this error code is the same whichever version/localization of ODBCDriver you use.

## Tests
I checked on those 2 targets all the unit tests now pass

### Windows 10
- Windows 10 French
- ODBCDriver 18 x64 French 
- MSVC 2022 with cmake
- SQLServer 2019 Linux 

### Ubuntu 22.04
- Ubuntu 22.04 
- ODBCDriver 18 x64 
- GCC12 with cmake from Visual 2022
- SQLServer 2019 Linux 
