### PR TITLE
#276 Fix memory access violation when parsing datetime types

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4060,11 +4060,17 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         st.tm_year = d.year - 1900;
         st.tm_mon = d.month - 1;
         st.tm_mday = d.day;
-        std::string old_lc_time = std::setlocale(LC_TIME, nullptr);
+        std::string old_lc_time_container;
+        const char* old_lc_time = nullptr;
+        if (char* olc_lc_time_ptr = std::setlocale(LC_TIME, nullptr))
+        {
+            old_lc_time_container = olc_lc_time_ptr;
+            old_lc_time = old_lc_time_container.c_str();
+        }
         std::setlocale(LC_TIME, "");
         char date_str[512];
         std::strftime(date_str, sizeof(date_str), "%Y-%m-%d", &st);
-        std::setlocale(LC_TIME, old_lc_time.c_str());
+        std::setlocale(LC_TIME, old_lc_time);
         convert(date_str, result);
         return;
     }
@@ -4076,11 +4082,17 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         st.tm_hour = t.hour;
         st.tm_min = t.min;
         st.tm_sec = t.sec;
-        std::string old_lc_time = std::setlocale(LC_TIME, nullptr);
+        std::string old_lc_time_container;
+        const char* old_lc_time = nullptr;
+        if (char* olc_lc_time_ptr = std::setlocale(LC_TIME, nullptr))
+        {
+            old_lc_time_container = olc_lc_time_ptr;
+            old_lc_time = old_lc_time_container.c_str();
+        }
         std::setlocale(LC_TIME, "");
         char date_str[512];
         std::strftime(date_str, sizeof(date_str), "%H:%M:%S", &st);
-        std::setlocale(LC_TIME, old_lc_time.c_str());
+        std::setlocale(LC_TIME, old_lc_time);
         convert(date_str, result);
         return;
     }
@@ -4095,11 +4107,17 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         st.tm_hour = stamp.hour;
         st.tm_min = stamp.min;
         st.tm_sec = stamp.sec;
-        std::string old_lc_time = std::setlocale(LC_TIME, nullptr);
+        std::string old_lc_time_container;
+        const char* old_lc_time = nullptr;
+        if (char* olc_lc_time_ptr = std::setlocale(LC_TIME, nullptr))
+        {
+            old_lc_time_container = olc_lc_time_ptr;
+            old_lc_time = old_lc_time_container.c_str();
+        }
         std::setlocale(LC_TIME, "");
         char date_str[512];
         std::strftime(date_str, sizeof(date_str), "%Y-%m-%d %H:%M:%S %z", &st);
-        std::setlocale(LC_TIME, old_lc_time.c_str());
+        std::setlocale(LC_TIME, old_lc_time);
         convert(date_str, result);
         return;
     }

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4060,11 +4060,11 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         st.tm_year = d.year - 1900;
         st.tm_mon = d.month - 1;
         st.tm_mday = d.day;
-        char* old_lc_time = std::setlocale(LC_TIME, nullptr);
+        std::string old_lc_time = std::setlocale(LC_TIME, nullptr);
         std::setlocale(LC_TIME, "");
         char date_str[512];
         std::strftime(date_str, sizeof(date_str), "%Y-%m-%d", &st);
-        std::setlocale(LC_TIME, old_lc_time);
+        std::setlocale(LC_TIME, old_lc_time.c_str());
         convert(date_str, result);
         return;
     }
@@ -4076,11 +4076,11 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         st.tm_hour = t.hour;
         st.tm_min = t.min;
         st.tm_sec = t.sec;
-        char* old_lc_time = std::setlocale(LC_TIME, nullptr);
+        std::string old_lc_time = std::setlocale(LC_TIME, nullptr);
         std::setlocale(LC_TIME, "");
         char date_str[512];
         std::strftime(date_str, sizeof(date_str), "%H:%M:%S", &st);
-        std::setlocale(LC_TIME, old_lc_time);
+        std::setlocale(LC_TIME, old_lc_time.c_str());
         convert(date_str, result);
         return;
     }
@@ -4095,11 +4095,11 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         st.tm_hour = stamp.hour;
         st.tm_min = stamp.min;
         st.tm_sec = stamp.sec;
-        char* old_lc_time = std::setlocale(LC_TIME, nullptr);
+        std::string old_lc_time = std::setlocale(LC_TIME, nullptr);
         std::setlocale(LC_TIME, "");
         char date_str[512];
         std::strftime(date_str, sizeof(date_str), "%Y-%m-%d %H:%M:%S %z", &st);
-        std::setlocale(LC_TIME, old_lc_time);
+        std::setlocale(LC_TIME, old_lc_time.c_str());
         convert(date_str, result);
         return;
     }


### PR DESCRIPTION
## What does this PR do?

This PR fixes memory access violation when changing locale state inside `SQL_C_DATE`, `SQL_C_TIME` and `SQL_C_TIMESTAMP` cases in function `result::result_impl::get_ref_impl` by storing copy of the old locale.

## What are related issues/pull requests?

Related issue is #276 where problem is also explained in details.

## Other

I ran only `mssql_tests.exe` where existing tests passed with the following output:

```
All tests passed (28297 assertions in 74 test cases)                           
```

## Environment

* DBMS name/version: SQLExpress
* ODBC connection string: Driver={ODBC Driver 17 for SQL Server};Server=localhost\SQLEXPRESS;Database=nanodbc;Trusted_Connection=Yes;Encrypt=No;TrustServerCertificate=Yes;
* OS and Compiler: Windows10, MSVC (v143)
