### PR TITLE
Fix C17 build: more explicit variant construction

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -854,7 +854,7 @@ namespace nanodbc
 connection::attribute::attribute(
     long const& attribute,
     long const& string_length,
-    std::variant<std::vector<uint8_t>, string, std::intptr_t, std::uintptr_t> const& resource)
+    attribute::variant const& resource)
     : attribute_(attribute)
     , string_length_(string_length)
     , resource_(resource)
@@ -876,7 +876,9 @@ void connection::attribute::extractValuePtr()
         [this](auto&& arg)
         {
             using T = std::decay_t<decltype(arg)>;
-            if constexpr (std::is_same_v<T, string> || std::is_same_v<T, std::vector<uint8_t>>)
+            if constexpr (
+                std::is_same_v<T, string> || std::is_same_v<T, std::string> ||
+                std::is_same_v<T, std::vector<uint8_t>>)
             {
                 this->value_ptr_ = (void*)&arg[0];
             }
@@ -1109,14 +1111,18 @@ public:
         // operation is not supported by the Driver.
         if (timeout != 0)
         {
-            attributes.push_back({SQL_ATTR_LOGIN_TIMEOUT, SQL_IS_UINTEGER, timeout});
+            attributes.push_back(
+                {SQL_ATTR_LOGIN_TIMEOUT, SQL_IS_UINTEGER, (std::uintptr_t)timeout});
         }
 #if !defined(NANODBC_DISABLE_ASYNC) && defined(SQL_ATTR_ASYNC_DBC_EVENT)
         if (event_handle != nullptr)
         {
             attributes.push_back(
-                {SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE, SQL_IS_UINTEGER, SQL_ASYNC_DBC_ENABLE_ON});
-            attributes.push_back({SQL_ATTR_ASYNC_DBC_EVENT, SQL_IS_POINTER, event_handle});
+                {SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE,
+                 SQL_IS_UINTEGER,
+                 (std::uintptr_t)SQL_ASYNC_DBC_ENABLE_ON});
+            attributes.push_back(
+                {SQL_ATTR_ASYNC_DBC_EVENT, SQL_IS_POINTER, (std::uintptr_t)event_handle});
         }
 #endif
         return this->connect(dsn, user, pass, attributes);
@@ -1181,14 +1187,18 @@ public:
         // operation is not supported by the Driver.
         if (timeout != 0)
         {
-            attributes.push_back({SQL_ATTR_LOGIN_TIMEOUT, SQL_IS_UINTEGER, timeout});
+            attributes.push_back(
+                {SQL_ATTR_LOGIN_TIMEOUT, SQL_IS_UINTEGER, (std::uintptr_t)timeout});
         }
 #if !defined(NANODBC_DISABLE_ASYNC) && defined(SQL_ATTR_ASYNC_DBC_EVENT)
         if (event_handle != nullptr)
         {
             attributes.push_back(
-                {SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE, SQL_IS_UINTEGER, SQL_ASYNC_DBC_ENABLE_ON});
-            attributes.push_back({SQL_ATTR_ASYNC_DBC_EVENT, SQL_IS_POINTER, event_handle});
+                {SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE,
+                 SQL_IS_UINTEGER,
+                 (std::uintptr_t)SQL_ASYNC_DBC_ENABLE_ON});
+            attributes.push_back(
+                {SQL_ATTR_ASYNC_DBC_EVENT, SQL_IS_POINTER, (std::uintptr_t)event_handle});
         }
 #endif
         return this->connect(connection_string, attributes);

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -87,8 +87,12 @@
 #include <string>
 #include <type_traits>
 #include <utility>
-#if __cpp_lib_variant >= 201606L
+#ifdef __has_include         // Check if __has_include is present
+#if __has_include(<variant>) // Check for a standard library
 #include <variant>
+#elif __has_include(<experimental/variant>) // Check for an experimental version
+#include <experimental/variant>
+#endif
 #endif
 #include <vector>
 
@@ -1306,21 +1310,24 @@ public:
     class attribute
     {
     public:
+#ifdef NANODBC_ENABLE_UNICODE
+        typedef std::
+            variant<std::vector<uint8_t>, string, std::string, std::intptr_t, std::uintptr_t>
+                variant;
+#else
+        typedef std::variant<std::vector<uint8_t>, string, std::intptr_t, std::uintptr_t> variant;
+#endif
         attribute() = delete;
         attribute& operator=(attribute const&) = delete;
         attribute(attribute const& other);
-        attribute(
-            long const& attribute,
-            long const& string_length,
-            std::variant<std::vector<uint8_t>, string, std::intptr_t, std::uintptr_t> const&
-                resource);
+        attribute(long const& attribute, long const& string_length, variant const& resource);
 
     private:
         void extractValuePtr();
 
         long attribute_;
         long string_length_;
-        std::variant<std::vector<uint8_t>, string, std::intptr_t, std::uintptr_t> resource_;
+        variant resource_;
         void* value_ptr_;
         friend class nanodbc::connection::connection_impl;
     };
@@ -1333,10 +1340,10 @@ private:
     class attribute
     {
     public:
-        attribute(long const& attribute, long const& string_length, long const& value)
+        attribute(long const& attribute, long const& string_length, std::uintptr_t value)
             : attribute_(attribute)
             , string_length_(string_length)
-            , value_ptr_((void*)(std::intptr_t)value){};
+            , value_ptr_((void*)value){};
         attribute(long const& attribute, long const& string_length, void* value_ptr)
             : attribute_(attribute)
             , string_length_(string_length)

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1600,9 +1600,10 @@ TEST_CASE_METHOD(mssql_fixture, "test_conn_attributes", "[mssql][conn_attibutes]
         size_t TRACEFILE_IN_LENGTH = TRACEFILE_IN.size();
         long TIMEOUT_IN = 7;
 
-        attributes.push_back({SQL_ATTR_LOGIN_TIMEOUT, SQL_IS_UINTEGER, TIMEOUT_IN});
+        attributes.push_back({SQL_ATTR_LOGIN_TIMEOUT, SQL_IS_UINTEGER, (std::uintptr_t)TIMEOUT_IN});
         attributes.push_back({SQL_ATTR_CURRENT_CATALOG, (long)CATALOG_IN_LENGTH, CATALOG_IN});
-        attributes.push_back({SQL_ATTR_TRACE, (long)SQL_IS_UINTEGER, SQL_OPT_TRACE_ON});
+        attributes.push_back(
+            {SQL_ATTR_TRACE, (long)SQL_IS_UINTEGER, (std::uintptr_t)SQL_OPT_TRACE_ON});
         attributes.push_back({SQL_ATTR_TRACEFILE, (long)TRACEFILE_IN_LENGTH, TRACEFILE_IN});
 
         auto conn = connect(attributes, false);
@@ -1649,9 +1650,10 @@ TEST_CASE_METHOD(mssql_fixture, "test_conn_attributes", "[mssql][conn_attibutes]
         attributes.push_back(
             {SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE,
              SQL_IS_UINTEGER,
-             SQL_ASYNC_DBC_ENABLE_ON});
+             (std::uintptr_t)SQL_ASYNC_DBC_ENABLE_ON});
         HANDLE event_handle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        attributes.push_back({SQL_ATTR_ASYNC_DBC_EVENT, SQL_IS_POINTER, event_handle});
+        attributes.push_back(
+            {SQL_ATTR_ASYNC_DBC_EVENT, SQL_IS_POINTER, (std::uintptr_t)event_handle});
 
         auto conn = connect(attributes, true);
         WaitForSingleObject(event_handle, INFINITE);


### PR DESCRIPTION
Hi @mloskot 

This fixes https://github.com/nanodbc/nanodbc/issues/363

In addition to addressing the issue where the Windows compiler can't identify the appropriate  variant constructor, this also addresses an issue with how the ```<variant>``` header was included ( it needs to be included if available, not conditional on ``` __cpp_lib_variant >= X ``` ).

Tested the C++17 build on the appveyor pipeline; reverted back to C++14 before submitting here.

Thanks