### PR TITLE
Improve mapping of SQL integer types to C corresponding types

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3852,9 +3852,21 @@ private:
             switch (col.sqltype_)
             {
             case SQL_BIT:
+                col.ctype_ = SQL_C_BIT;
+                col.clen_ = sizeof(uint8_t);
+                break;
             case SQL_TINYINT:
+                col.ctype_ = SQL_C_STINYINT;
+                col.clen_ = sizeof(int8_t);
+                break;
             case SQL_SMALLINT:
-            case SQL_INTEGER:
+                col.ctype_ = SQL_C_SSHORT;
+                col.clen_ = sizeof(int16_t);
+                break;
+            case SQL_INTEGER: // TODO: Can be 32 or 64 bit? Then sizeof(SQLINTEGER)
+                col.ctype_ = SQL_C_SLONG;
+                col.clen_ = sizeof(int32_t);
+                break;
             case SQL_BIGINT:
                 col.ctype_ = SQL_C_SBIGINT;
                 col.clen_ = sizeof(int64_t);
@@ -4200,6 +4212,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
     }
 
     case SQL_C_LONG:
+    case SQL_C_SLONG:
     {
         std::string buffer(column_size + 1, 0); // ensure terminating null
         const int32_t data = *ensure_pdata<int32_t>(column);

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4725,9 +4725,13 @@ void result::result_impl::get_ref_impl(short column, T& result) const
     case SQL_C_WCHAR:
         get_ref_from_string_column(column, result);
         return;
+    case SQL_C_TINYINT:
+    case SQL_C_STINYINT:
+    case SQL_C_SHORT:
     case SQL_C_SSHORT:
         result = (T) * (ensure_pdata<short>(column));
         return;
+    case SQL_C_UTINYINT:
     case SQL_C_USHORT:
         result = (T) * (ensure_pdata<unsigned short>(column));
         return;

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4721,6 +4721,9 @@ void result::result_impl::get_ref_impl(short column, T& result) const
     using namespace std; // if int64_t is in std namespace (in c++11)
     switch (col.ctype_)
     {
+    case SQL_C_BIT:
+        result = (T) * (ensure_pdata<int16_t>(column));
+        return;
     case SQL_C_CHAR:
     case SQL_C_WCHAR:
         get_ref_from_string_column(column, result);

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3861,7 +3861,7 @@ private:
             {
             case SQL_BIT:
                 col.ctype_ = SQL_C_BIT;
-                col.clen_ = sizeof(uint8_t);
+                col.clen_ = sizeof(int8_t);
                 break;
             case SQL_TINYINT:
                 col.ctype_ = SQL_C_STINYINT;
@@ -4465,7 +4465,7 @@ inline void result::result_impl::get_ref_impl<_variant_t>(short column, _variant
     }
     case SQL_C_BIT:
     {
-        auto const v = *(ensure_pdata<int16_t>(column));
+        auto const v = *(ensure_pdata<int8_t>(column));
         result = _variant_t(!!v ? VARIANT_TRUE : VARIANT_FALSE, VT_BOOL);
         break;
     }
@@ -4736,7 +4736,7 @@ void result::result_impl::get_ref_impl(short column, T& result) const
     switch (col.ctype_)
     {
     case SQL_C_BIT:
-        result = (T) * (ensure_pdata<int16_t>(column));
+        result = (T) * (ensure_pdata<int8_t>(column));
         return;
     case SQL_C_CHAR:
     case SQL_C_WCHAR:

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4457,7 +4457,7 @@ inline void result::result_impl::get_ref_impl<_variant_t>(short column, _variant
     }
     case SQL_C_BIT:
     {
-        auto const v = *(ensure_pdata<short>(column));
+        auto const v = *(ensure_pdata<int16_t>(column));
         result = _variant_t(!!v ? VARIANT_TRUE : VARIANT_FALSE, VT_BOOL);
         break;
     }
@@ -4477,17 +4477,17 @@ inline void result::result_impl::get_ref_impl<_variant_t>(short column, _variant
     }
     case SQL_C_TINYINT:
     case SQL_C_STINYINT:
-        result = (char)*(ensure_pdata<short>(column));
+        result = (char)*(ensure_pdata<int16_t>(column));
         break;
     case SQL_C_UTINYINT:
-        result = (unsigned char)*(ensure_pdata<unsigned short>(column));
+        result = (unsigned char)*(ensure_pdata<uint16_t>(column));
         break;
     case SQL_C_SHORT:
     case SQL_C_SSHORT:
         result = *(ensure_pdata<short>(column));
         break;
     case SQL_C_USHORT:
-        result = *(ensure_pdata<unsigned short>(column));
+        result = *(ensure_pdata<uint16_t>(column));
         break;
     case SQL_C_LONG:
     case SQL_C_SLONG:
@@ -4732,11 +4732,11 @@ void result::result_impl::get_ref_impl(short column, T& result) const
     case SQL_C_STINYINT:
     case SQL_C_SHORT:
     case SQL_C_SSHORT:
-        result = (T) * (ensure_pdata<short>(column));
+        result = (T) * (ensure_pdata<int16_t>(column));
         return;
     case SQL_C_UTINYINT:
     case SQL_C_USHORT:
-        result = (T) * (ensure_pdata<unsigned short>(column));
+        result = (T) * (ensure_pdata<uint16_t>(column));
         return;
     case SQL_C_LONG:
     case SQL_C_SLONG:

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -632,6 +632,14 @@ struct sql_ctype
 {
 };
 
+template <typename T>
+struct sql_ctype<
+    T,
+    typename std::enable_if<is_integral8<T>::value && std::is_signed<T>::value>::type>
+{
+    static const SQLSMALLINT value = SQL_C_STINYINT;
+};
+
 template <>
 struct sql_ctype<uint8_t>
 {
@@ -4736,6 +4744,8 @@ void result::result_impl::get_ref_impl(short column, T& result) const
         return;
     case SQL_C_TINYINT:
     case SQL_C_STINYINT:
+        result = (T) * (ensure_pdata<int8_t>(column));
+        return;
     case SQL_C_SHORT:
     case SQL_C_SSHORT:
         result = (T) * (ensure_pdata<int16_t>(column));

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4484,15 +4484,21 @@ inline void result::result_impl::get_ref_impl<_variant_t>(short column, _variant
         break;
     case SQL_C_SHORT:
     case SQL_C_SSHORT:
-        result = *(ensure_pdata<short>(column));
+    {
+        auto d = *(ensure_pdata<int16_t>(column));
+        result = _variant_t(d, VT_I2);
         break;
+    }
     case SQL_C_USHORT:
         result = *(ensure_pdata<uint16_t>(column));
         break;
     case SQL_C_LONG:
     case SQL_C_SLONG:
-        result = *(ensure_pdata<int32_t>(column));
+    {
+        long d = *(ensure_pdata<int32_t>(column));
+        result = _variant_t(d, VT_I4); // avoid VT_INT
         break;
+    }
     case SQL_C_ULONG:
         result = *(ensure_pdata<uint32_t>(column));
         break;

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1938,6 +1938,17 @@ public:
     /// \brief Returns a identifying integer value representing the C type of this column by name.
     int column_c_datatype(string const& column_name) const;
 
+    /// \brief SQL_TRUE if the column is unsigned (or not numeric). SQL_FALSE if the column is signed.
+    ///
+    /// Signedness of some of numeric types like SQL_TINYINT depends on backend or driver.
+    /// For example, if nmot unsigned, the MySQL TINYINT datatype can range from -127 to 127;
+    /// whereas the SQL Server TINYINT type always ranges 0 to 255. So, unless it is an unsigned
+    /// TINYINT, a MySQL TINYINT datatype should be converted to the SQL Server SMALLINT datatype.
+    bool column_unsigned(short column) const;
+
+    /// \brief SQL_TRUE if the column is unsigned (or not numeric). SQL_FALSE if the column is signed.
+    bool column_unsigned(string const& column_name) const;
+
     /// \brief Returns the next result, e.g. when stored procedure returns multiple result sets.
     bool next_result();
 

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1938,7 +1938,8 @@ public:
     /// \brief Returns a identifying integer value representing the C type of this column by name.
     int column_c_datatype(string const& column_name) const;
 
-    /// \brief SQL_TRUE if the column is unsigned (or not numeric). SQL_FALSE if the column is signed.
+    /// \brief SQL_TRUE if the column is unsigned (or not numeric). SQL_FALSE if the column is
+    /// signed.
     ///
     /// Signedness of some of numeric types like SQL_TINYINT depends on backend or driver.
     /// For example, if nmot unsigned, the MySQL TINYINT datatype can range from -127 to 127;
@@ -1946,7 +1947,8 @@ public:
     /// TINYINT, a MySQL TINYINT datatype should be converted to the SQL Server SMALLINT datatype.
     bool column_unsigned(short column) const;
 
-    /// \brief SQL_TRUE if the column is unsigned (or not numeric). SQL_FALSE if the column is signed.
+    /// \brief SQL_TRUE if the column is unsigned (or not numeric). SQL_FALSE if the column is
+    /// signed.
     bool column_unsigned(string const& column_name) const;
 
     /// \brief Returns the next result, e.g. when stored procedure returns multiple result sets.

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -745,6 +745,44 @@ TEST_CASE_METHOD(mssql_fixture, "test_column_descriptor", "[mssql][columns]")
     test_column_descriptor();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_column_descriptor_unsigned", "[mssql][columns]")
+{
+    auto c = connect();
+    create_table(c, NANODBC_TEXT("test_column_descriptor_unsigned"), NANODBC_TEXT("(name text, ti tinyint, si smallint, i int, bi bigint"));
+
+    // insert
+    {
+        execute(c, NANODBC_TEXT("insert into test_column_descriptor_unsigned (name,ti,si,i,bi) values ('min', 0, -32768, -2147483648, -9223372036854775808);"));
+        execute(c, NANODBC_TEXT("insert into test_column_descriptor_unsigned (name,ti,si,i,bi) values ('mid', 128, 1, 2, 3);"));
+        execute(c, NANODBC_TEXT("insert into test_column_descriptor_unsigned (name,ti,si,i,bi) values ('max', 255, 32767, 2147483647, 9223372036854775807);"));
+    }
+
+    // select
+    {
+        auto result = execute(c, NANODBC_TEXT("select name,ti,si,i,bi from test_column_descriptor_unsigned order by ti asc;"));
+        REQUIRE(result.column_unsigned(0)); // SQL_TRUE for non-numeric by default
+        REQUIRE(result.column_unsigned(1)); // SQL_TRUE for TINYINT as always unsigned in SQL Server
+        REQUIRE(!result.column_unsigned(2)); // SMALLINT
+        REQUIRE(!result.column_unsigned(3)); // INT
+        REQUIRE(!result.column_unsigned(4)); // BIGINT
+        REQUIRE(result.next());
+        REQUIRE(result.get<std::int16_t>(1) == 0);
+        REQUIRE(result.get<std::int16_t>(2) == -32768);
+        REQUIRE(result.get<std::int32_t>(3) == -2147483648LL);
+        REQUIRE(result.get<std::int64_t>(4) == -9223372036854775808LL);
+        REQUIRE(result.next());
+        REQUIRE(result.get<std::int16_t>(1) == 128);
+        REQUIRE(result.get<std::int16_t>(2) == 1);
+        REQUIRE(result.get<std::int32_t>(3) == 2);
+        REQUIRE(result.get<std::int64_t>(4) == 3);
+        REQUIRE(result.next());
+        REQUIRE(result.get<std::int16_t>(1) == 255);
+        REQUIRE(result.get<std::int16_t>(2) == 32767);
+        REQUIRE(result.get<std::int32_t>(3) == 2147483647);
+        REQUIRE(result.get<std::int64_t>(4) == 9223372036854775807);
+    }
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_connection_environment", "[mssql][connection]")
 {
     test_connection_environment();
@@ -1143,6 +1181,23 @@ TEST_CASE_METHOD(mssql_fixture, "test_win32_variant_bit", "[mssql][variant][wind
     auto v = rs.get<_variant_t>(0);
     REQUIRE(v.vt == VT_BOOL);
     REQUIRE(static_cast<bool>(v) == true);
+}
+
+TEST_CASE_METHOD(mssql_fixture, "test_win32_variant_tinyint", "[mssql][variant][windows]")
+{
+    auto cn = connect();
+    auto rs = execute(cn, NANODBC_TEXT("select CAST(0 AS TINYINT), CAST(128 AS TINYINT), CAST(255 AS TINYINT);"));
+    rs.next();
+
+    auto v0 = rs.get<_variant_t>(0);
+    REQUIRE(v0.vt == VT_UI1);
+    REQUIRE(static_cast<int>(v0) == 0);
+    auto v1 = rs.get<_variant_t>(1);
+    REQUIRE(v1.vt == VT_UI1);
+    REQUIRE(static_cast<int>(v1) == 128);
+    auto v2 = rs.get<_variant_t>(2);
+    REQUIRE(v2.vt == VT_UI1);
+    REQUIRE(static_cast<int>(v2) == 255);
 }
 
 TEST_CASE_METHOD(mssql_fixture, "test_win32_variant_timestamp", "[mssql][variant][windows]")

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -748,18 +748,33 @@ TEST_CASE_METHOD(mssql_fixture, "test_column_descriptor", "[mssql][columns]")
 TEST_CASE_METHOD(mssql_fixture, "test_column_descriptor_unsigned", "[mssql][columns]")
 {
     auto c = connect();
-    create_table(c, NANODBC_TEXT("test_column_descriptor_unsigned"), NANODBC_TEXT("(name text, ti tinyint, si smallint, i int, bi bigint"));
+    create_table(
+        c,
+        NANODBC_TEXT("test_column_descriptor_unsigned"),
+        NANODBC_TEXT("(name text, ti tinyint, si smallint, i int, bi bigint"));
 
     // insert
     {
-        execute(c, NANODBC_TEXT("insert into test_column_descriptor_unsigned (name,ti,si,i,bi) values ('min', 0, -32768, -2147483648, -9223372036854775808);"));
-        execute(c, NANODBC_TEXT("insert into test_column_descriptor_unsigned (name,ti,si,i,bi) values ('mid', 128, 1, 2, 3);"));
-        execute(c, NANODBC_TEXT("insert into test_column_descriptor_unsigned (name,ti,si,i,bi) values ('max', 255, 32767, 2147483647, 9223372036854775807);"));
+        execute(
+            c,
+            NANODBC_TEXT("insert into test_column_descriptor_unsigned (name,ti,si,i,bi) values "
+                         "('min', 0, -32768, -2147483648, -9223372036854775808);"));
+        execute(
+            c,
+            NANODBC_TEXT("insert into test_column_descriptor_unsigned (name,ti,si,i,bi) values "
+                         "('mid', 128, 1, 2, 3);"));
+        execute(
+            c,
+            NANODBC_TEXT("insert into test_column_descriptor_unsigned (name,ti,si,i,bi) values "
+                         "('max', 255, 32767, 2147483647, 9223372036854775807);"));
     }
 
     // select
     {
-        auto result = execute(c, NANODBC_TEXT("select name,ti,si,i,bi from test_column_descriptor_unsigned order by ti asc;"));
+        auto result = execute(
+            c,
+            NANODBC_TEXT(
+                "select name,ti,si,i,bi from test_column_descriptor_unsigned order by ti asc;"));
         REQUIRE(result.column_unsigned(0)); // SQL_TRUE for non-numeric by default
         REQUIRE(result.column_unsigned(1)); // SQL_TRUE for TINYINT as always unsigned in SQL Server
         REQUIRE(!result.column_unsigned(2)); // SMALLINT
@@ -1186,7 +1201,8 @@ TEST_CASE_METHOD(mssql_fixture, "test_win32_variant_bit", "[mssql][variant][wind
 TEST_CASE_METHOD(mssql_fixture, "test_win32_variant_tinyint", "[mssql][variant][windows]")
 {
     auto cn = connect();
-    auto rs = execute(cn, NANODBC_TEXT("select CAST(0 AS TINYINT), CAST(128 AS TINYINT), CAST(255 AS TINYINT);"));
+    auto rs = execute(
+        cn, NANODBC_TEXT("select CAST(0 AS TINYINT), CAST(128 AS TINYINT), CAST(255 AS TINYINT);"));
     rs.next();
 
     auto v0 = rs.get<_variant_t>(0);

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -768,8 +768,8 @@ TEST_CASE_METHOD(mssql_fixture, "test_column_descriptor_unsigned", "[mssql][colu
         REQUIRE(result.next());
         REQUIRE(result.get<std::int16_t>(1) == 0);
         REQUIRE(result.get<std::int16_t>(2) == -32768);
-        REQUIRE(result.get<std::int32_t>(3) == -2147483648LL);
-        REQUIRE(result.get<std::int64_t>(4) == -9223372036854775808LL);
+        REQUIRE(result.get<std::int32_t>(3) == (-2147483647 - 1));
+        REQUIRE(result.get<std::int64_t>(4) == (-9223372036854775807 - 1));
         REQUIRE(result.next());
         REQUIRE(result.get<std::int16_t>(1) == 128);
         REQUIRE(result.get<std::int16_t>(2) == 1);

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -307,7 +307,7 @@ TEST_CASE_METHOD(sqlite_fixture, "test_integral_boundary", "[sqlite][integral]")
     execute(
         connection,
         NANODBC_TEXT(
-            "create table test_integral_boundary(i1 integer,i2 integer,i4 integer,i8 integer);"));
+            "create table test_integral_boundary(i1 tinyint,i2 smallint,i4 integer,i8 bigint);"));
 
     auto const sql =
         NANODBC_TEXT("insert into test_integral_boundary(i1,i2,i4,i8) values (?,?,?,?);");

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -918,7 +918,7 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(result.column_datatype(0) == SQL_INTEGER);
         if (vendor_ == database_vendor::sqlserver)
         {
-            REQUIRE(result.column_c_datatype(0) == SQL_C_SBIGINT);
+            REQUIRE(result.column_c_datatype(0) == SQL_C_SLONG);
         }
         else if (vendor_ == database_vendor::sqlite)
         {
@@ -2292,7 +2292,7 @@ struct test_case_fixture : public base_test_fixture
         rs.next();
         {
             auto v = rs.get<_variant_t>(0);
-            REQUIRE(v.vt == VT_I8);
+            REQUIRE(v.vt == VT_I4);
             REQUIRE(static_cast<int>(v) == i);
         }
         {

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -928,6 +928,7 @@ struct test_case_fixture : public base_test_fixture
         }
         REQUIRE(result.column_size(0) == 10);
         REQUIRE(result.column_decimal_digits(0) == 0);
+        REQUIRE(!result.column_unsigned(0));
         // d decimal(7,3)
         REQUIRE(result.column_name(1) == NANODBC_TEXT("d"));
         if (vendor_ == database_vendor::sqlite)
@@ -955,6 +956,7 @@ struct test_case_fixture : public base_test_fixture
             REQUIRE(result.column_c_datatype(1) == SQL_C_CHAR);
         }
         REQUIRE(result.column_size(1) == 7);
+        REQUIRE(!result.column_unsigned(1));
         // n numeric(7,3)
         REQUIRE(result.column_name(2) == NANODBC_TEXT("n"));
         REQUIRE(result.column_size(2) == 7);
@@ -974,6 +976,7 @@ struct test_case_fixture : public base_test_fixture
             REQUIRE(result.column_decimal_digits(2) == 3);
             REQUIRE(result.column_c_datatype(2) == SQL_C_CHAR);
         }
+        REQUIRE(!result.column_unsigned(2));
     }
 
     void test_connection_environment()

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -969,6 +969,8 @@ struct test_case_fixture : public base_test_fixture
             // FIXME: SQLite ODBC mis-reports decimal digits?
             REQUIRE(result.column_decimal_digits(2) == 0);
             REQUIRE(result.column_c_datatype(2) == SQL_C_DOUBLE);
+            // FIXME: SQLite ODBC mis-reports unsigned for DECIMAL
+            REQUIRE(result.column_unsigned(2));
         }
         else
         {
@@ -977,8 +979,8 @@ struct test_case_fixture : public base_test_fixture
                  result.column_datatype(2) == SQL_NUMERIC));
             REQUIRE(result.column_decimal_digits(2) == 3);
             REQUIRE(result.column_c_datatype(2) == SQL_C_CHAR);
+            REQUIRE(!result.column_unsigned(2));
         }
-        REQUIRE(!result.column_unsigned(2));
     }
 
     void test_connection_environment()

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -924,7 +924,7 @@ struct test_case_fixture : public base_test_fixture
         {
             std::string const type_name = nanodbc::test::convert(result.column_datatype_name(0));
             REQUIRE_THAT(type_name, Catch::Contains("int", Catch::CaseSensitive::No));
-            REQUIRE(result.column_c_datatype(0) == SQL_C_SBIGINT);
+            REQUIRE(result.column_c_datatype(0) == SQL_C_SLONG);
         }
         REQUIRE(result.column_size(0) == 10);
         REQUIRE(result.column_decimal_digits(0) == 0);

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -947,6 +947,8 @@ struct test_case_fixture : public base_test_fixture
 #endif
             // FIXME: SQLite ODBC mis-reports decimal digits?
             REQUIRE(result.column_decimal_digits(2) == 0);
+            // FIXME: SQLite ODBC mis-reports unsigned for DECIMAL
+            REQUIRE(result.column_unsigned(1));
         }
         else
         {
@@ -954,9 +956,9 @@ struct test_case_fixture : public base_test_fixture
                 (result.column_datatype(1) == SQL_DECIMAL ||
                  result.column_datatype(1) == SQL_NUMERIC));
             REQUIRE(result.column_c_datatype(1) == SQL_C_CHAR);
+            REQUIRE(!result.column_unsigned(1));
         }
         REQUIRE(result.column_size(1) == 7);
-        REQUIRE(!result.column_unsigned(1));
         // n numeric(7,3)
         REQUIRE(result.column_name(2) == NANODBC_TEXT("n"));
         REQUIRE(result.column_size(2) == 7);


### PR DESCRIPTION
- Fine-grained mapping of SQL integer types to C corresponding types
- Add reading of missing C data types for integers
- Distinguish SQL_C_BIT data type for reading
- Prefer mapping of SQL_C_* types to fixed-width integer types
- Ensure SQL_C_SHORT and SQL_C_LONG are mapped to fixed-width variant types
- Refine reading of SQL_C_TINYINT into int8_t instead of int16_t
- Refine reading of SQL_C_BIT into int8_t
- Make auto-binding of numeric columns signedness-aware

### References

Closes #369