### PR TITLE
ci: Add GHA workflow to build and test on Linux

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,0 +1,226 @@
+---
+# GitHub Actions multi-job workflow for Linux to:
+# - build using matrix of GCC and clang versions
+# - build using latest defaults and run tests against number of databases
+name: "CI Linux"
+
+on:
+  push:
+    branches:
+    - main
+    - ml/*
+  pull_request:
+
+jobs:
+  build-gcc:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # TODO: Compilation with GCC 12 fails with errors related to char8_t conversions
+          #- { cxxstd: '20', cxx: g++-12, cc: gcc-12, os: ubuntu-22.04 }
+          #- { cxxstd: '17', cxx: g++-12, cc: gcc-12, os: ubuntu-22.04 }
+          #- { cxxstd: '14', cxx: g++-12, cc: gcc-12, os: ubuntu-22.04 }
+          - { cxxstd: '17', cxx: g++-11, cc: gcc-11, os: ubuntu-22.04 }
+          - { cxxstd: '14', cxx: g++-11, cc: gcc-11, os: ubuntu-22.04 }
+          - { cxxstd: '17', cxx: g++-10, cc: gcc-10, os: ubuntu-22.04 }
+          - { cxxstd: '14', cxx: g++-10, cc: gcc-10, os: ubuntu-22.04 }
+          - { cxxstd: '17', cxx: g++-9,  cc: gcc-9,  os: ubuntu-20.04 }
+          - { cxxstd: '14', cxx: g++-9,  cc: gcc-9,  os: ubuntu-20.04 }
+          - { cxxstd: '17', cxx: g++-8,  cc: gcc-8,  os: ubuntu-20.04 }
+          - { cxxstd: '14', cxx: g++-8,  cc: gcc-8,  os: ubuntu-20.04 }
+          - { cxxstd: '17', cxx: g++-7,  cc: gcc-7,  os: ubuntu-18.04 }
+          - { cxxstd: '14', cxx: g++-7,  cc: gcc-7,  os: ubuntu-18.04 }
+          - { cxxstd: '14', cxx: g++-6,  cc: gcc-6,  os: ubuntu-18.04 }
+          - { cxxstd: '14', cxx: g++-5,  cc: gcc-5,  os: ubuntu-18.04 }
+
+    name: build-${{ matrix.cc }}-std-${{ matrix.cxxstd }}
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install
+        run: |
+          sudo apt-get install -y cmake ${{ matrix.cxx }}
+      - name: Check
+        run: |
+          echo && type g++ && which g++ && g++ --version
+          echo && type ${CXX} && which ${CXX} && ${CXX} --version
+          echo && type cmake && which cmake && cmake --version
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build
+
+  build-clang:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { cxxstd: '20', cxx: clang++-14,  cc: clang-14,  os: ubuntu-22.04, pkg: 'libc++-14-dev libc++abi-14-dev' }
+          - { cxxstd: '17', cxx: clang++-14,  cc: clang-14,  os: ubuntu-22.04, pkg: 'libc++-14-dev libc++abi-14-dev' }
+          - { cxxstd: '14', cxx: clang++-14,  cc: clang-14,  os: ubuntu-22.04, pkg: 'libc++-14-dev libc++abi-14-dev' }
+          - { cxxstd: '20', cxx: clang++-13,  cc: clang-13,  os: ubuntu-22.04, pkg: 'libc++-13-dev libc++abi-13-dev' }
+          - { cxxstd: '17', cxx: clang++-13,  cc: clang-13,  os: ubuntu-22.04, pkg: 'libc++-13-dev libc++abi-13-dev' }
+          - { cxxstd: '14', cxx: clang++-13,  cc: clang-13,  os: ubuntu-22.04, pkg: 'libc++-13-dev libc++abi-13-dev' }
+          - { cxxstd: '17', cxx: clang++-12,  cc: clang-12,  os: ubuntu-20.04, pkg: 'libc++-12-dev libc++abi-12-dev' }
+          - { cxxstd: '14', cxx: clang++-12,  cc: clang-12,  os: ubuntu-20.04, pkg: 'libc++-12-dev libc++abi-12-dev' }
+          - { cxxstd: '17', cxx: clang++-11,  cc: clang-11,  os: ubuntu-20.04, pkg: 'libc++-11-dev libc++abi-11-dev' }
+          - { cxxstd: '14', cxx: clang++-11,  cc: clang-11,  os: ubuntu-20.04, pkg: 'libc++-11-dev libc++abi-11-dev' }
+          - { cxxstd: '17', cxx: clang++-10,  cc: clang-10,  os: ubuntu-20.04, pkg: 'libc++-10-dev libc++abi-10-dev' }
+          - { cxxstd: '14', cxx: clang++-10,  cc: clang-10,  os: ubuntu-20.04, pkg: 'libc++-10-dev libc++abi-10-dev' }
+          - { cxxstd: '17', cxx: clang++-9,   cc: clang-9,   os: ubuntu-20.04, pkg: 'libc++-9-dev libc++abi-9-dev' }
+          - { cxxstd: '14', cxx: clang++-9,   cc: clang-9,   os: ubuntu-20.04, pkg: 'libc++-9-dev libc++abi-9-dev' }
+          - { cxxstd: '17', cxx: clang++-8,   cc: clang-8,   os: ubuntu-20.04, pkg: 'libc++-8-dev libc++abi-8-dev' }
+          - { cxxstd: '14', cxx: clang++-8,   cc: clang-8,   os: ubuntu-20.04, pkg: 'libc++-8-dev libc++abi-8-dev' }
+          - { cxxstd: '17', cxx: clang++-7,   cc: clang-7,   os: ubuntu-18.04, pkg: 'libc++-7-dev libc++abi-7-dev' }
+          - { cxxstd: '14', cxx: clang++-7,   cc: clang-7,   os: ubuntu-18.04, pkg: 'libc++-dev libc++abi-dev' }
+          - { cxxstd: '17', cxx: clang++-6.0, cc: clang-6.0, os: ubuntu-18.04, pkg: 'libc++-dev libc++abi-dev' }
+          - { cxxstd: '14', cxx: clang++-6.0, cc: clang-6.0, os: ubuntu-18.04, pkg: 'libc++-dev libc++abi-dev' }
+          - { cxxstd: '14', cxx: clang++-5.0, cc: clang-5.0, os: ubuntu-18.04, pkg: 'libc++-dev libc++abi-dev' }
+          - { cxxstd: '14', cxx: clang++-4.0, cc: clang-4.0, os: ubuntu-18.04, pkg: 'libc++-dev libc++abi-dev' }
+          - { cxxstd: '14', cxx: clang++-3.9, cc: clang-3.9, os: ubuntu-18.04, pkg: 'libc++-dev libc++abi-dev' }
+
+    name: build-${{ matrix.cc }}-std-${{ matrix.cxxstd }}
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install
+        run: |
+          sudo apt-get install -y cmake ${{ matrix.cc }} ${{ matrix.pkg }}
+      - name: Check
+        run: |
+          echo && type clang++ && which clang++ && clang++ --version
+          echo && type ${CXX} && which ${CXX} && ${CXX} --version
+          echo && type cmake && which cmake && cmake --version
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build
+
+  test-utility:
+    needs: [build-gcc, build-clang]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check
+        run: |
+          echo && type g++ && which g++ && g++ --version
+          echo && type cmake && which cmake && cmake --version
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --target utility_tests
+      - name: Test
+        run: |
+          ctest --test-dir ${{ github.workspace }}/build --output-on-failure --no-tests=error -R utility_tests
+
+  test-postgresql:
+    needs: [test-utility]
+    runs-on: ubuntu-latest
+    services:
+      postgresql:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: nanodbc
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install
+        run: |
+          sudo apt-get install -y unixodbc-dev odbc-postgresql
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --target postgresql_tests
+      - name: Test
+        run: |
+          export NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL ANSI};Server=localhost;Port=5432;Database=nanodbc;UID=postgres;PWD=postgres"
+          ctest --test-dir ${{ github.workspace }}/build --output-on-failure --no-tests=error -R postgresql_tests
+
+  test-mssql:
+    needs: [test-utility]
+    runs-on: ubuntu-latest
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+        ports:
+        - 1433:1433
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: Password!123
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install
+        run: |
+          apt-get update
+          curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+          curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list > /etc/apt/sources.list.d/mssql-release.list
+          ACCEPT_EULA=Y apt-get install -y unixodbc-dev msodbcsql17
+        shell: sudo bash {0}
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --target mssql_tests
+      - name: Test
+        run: |
+          export NANODBC_TEST_CONNSTR_MSSQL="Driver={ODBC Driver 17 for SQL Server};Server=localhost;Database=master;UID=sa;PWD=Password!123;"
+          ctest --test-dir ${{ github.workspace }}/build --output-on-failure --no-tests=error -R mssql_tests
+
+  test-sqlite:
+    needs: [test-utility]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install
+        run: |
+          apt-get install -y unixodbc-dev libsqliteodbc
+          cat <<EOF > ${{ github.workspace }}/.odbcinst.ini
+          [SQLite3]
+          Description=SQLite 3 ODBC Driver
+          Driver=/usr/lib/x86_64-linux-gnu/odbc/libsqlite3odbc.so
+          Setup=/usr/lib/x86_64-linux-gnu/odbc/libsqlite3odbc.so
+          UsageCount=1
+          EOF
+          sudo odbcinst -i -d -f ${{ github.workspace }}/.odbcinst.ini
+          cat /etc/odbcinst.ini
+        shell: sudo bash {0}
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --target sqlite_tests
+      - name: Test
+        run: |
+          ctest --test-dir ${{ github.workspace }}/build --output-on-failure --no-tests=error -R sqlite_tests
+ 

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -870,7 +870,8 @@ struct test_case_fixture : public base_test_fixture
         }
         else if (vendor_ == database_vendor::sqlite)
         {
-            REQUIRE_THAT(result.column_datatype_name(0), Catch::Contains(NANODBC_TEXT("int"), Catch::CaseSensitive::No));
+            std::string const type_name = nanodbc::test::convert(result.column_datatype_name(0));
+            REQUIRE_THAT(type_name, Catch::Contains("int", Catch::CaseSensitive::No));
             REQUIRE(result.column_c_datatype(0) == SQL_C_SBIGINT);
         }
         REQUIRE(result.column_size(0) == 10);

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -395,7 +395,7 @@ struct test_case_fixture : public base_test_fixture
                 REQUIRE(columns.column_size() == 3);
 #else
                 REQUIRE(columns.sql_data_type() == SQL_VARCHAR);
-                REQUIRE(columns.column_size() == 9);
+                REQUIRE(columns.column_size() == 3);
 #endif
             }
             else
@@ -870,7 +870,7 @@ struct test_case_fixture : public base_test_fixture
         }
         else if (vendor_ == database_vendor::sqlite)
         {
-            REQUIRE(result.column_datatype_name(0) == NANODBC_TEXT("int"));
+            REQUIRE_THAT(result.column_datatype_name(0), Catch::Contains(NANODBC_TEXT("int"), Catch::CaseSensitive::No));
             REQUIRE(result.column_c_datatype(0) == SQL_C_SBIGINT);
         }
         REQUIRE(result.column_size(0) == 10);


### PR DESCRIPTION
Build library, tests and examples using matrix comprised of
variety of GCC and clang versions and C++ standard versions.
Build selection of tests with GCC on Ubuntu 22.04 aka ubuntu-latest
and run against corresponding databases - currently it is PostgreSQL,
SQL Server and SQLite. TODO: Add MySQL.

Part of #265
Part of #266
