### PR TITLE
ci: Add GHA workflow to build and test on Windows

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,236 @@
+---
+# GitHub Actions multi-job workflow for Windows to:
+# - build using matrix of Visual C++ versions
+# - build using latest defaults and run tests against number of databases
+name: "CI Windows"
+
+on:
+  push:
+    branches:
+    - main
+    - ml/*
+  pull_request:
+
+jobs:
+  build-msvc:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { cxxstd: '20', toolset: v143, vs: 2022, architecture: x64, os: windows-2022 }
+          - { cxxstd: '17', toolset: v143, vs: 2022, architecture: x64, os: windows-2022 }
+          - { cxxstd: '14', toolset: v143, vs: 2022, architecture: x64, os: windows-2022 }
+          - { cxxstd: '17', toolset: v142, vs: 2019, architecture: x64, os: windows-2019 }
+          - { cxxstd: '14', toolset: v142, vs: 2019, architecture: x64, os: windows-2019 }
+          # Visual Studio 2017
+          - { cxxstd: '17', toolset: v141, vs: 2019, architecture: x64, os: windows-2019 }
+          - { cxxstd: '14', toolset: v141, vs: 2019, architecture: x64, os: windows-2019 }
+          # Visual Studio 2015(TODO: remove as deprecated and to save CI time)
+          #- { cxxstd: '14', toolset: v141, vs: 2019, architecture: x64, os: windows-2019 }
+    name: build-vs${{ matrix.vs }}-${{ matrix.toolset }}-std-${{ matrix.cxxstd }}
+    runs-on: ${{ matrix.os }}
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check
+        run: |
+          cmake --version
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio ${{ matrix.vs == '2022' && '17' || '16' }} ${{matrix.vs }}" -A ${{ matrix.architecture }} -T ${{ matrix.toolset }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build
+
+  build-mingw:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { cxxstd: '14', configuration: Release, warnings-as-errors: 'OFF' }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install MinGW
+        uses: egor-tensin/setup-mingw@v2
+      - name: Check
+        run: |
+          cmake --version
+          cc --version
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE=${{ matrix.configuration }} -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ matrix.warnings-as-errors }}
+      # FIXME: undefined references to async methods
+      # - name: Build
+      #   run: |
+      #     cmake --build ${{ github.workspace }}/build --verbose
+  
+  test-utility:
+    needs: [build-msvc, build-mingw]
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check
+        run: |
+          cmake --version
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --config Release --target utility_tests 
+      - name: Test
+        run: |
+          ctest --test-dir ${{ github.workspace }}/build --build-config Release --output-on-failure --no-tests=error -R utility_tests
+
+  test-mssql:
+    needs: [test-utility]
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        mssql: [2017, 2019]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install SQL Server
+        # Alternative https://github.com/ankane/setup-sqlserver
+        # seems more flexible but it takes twice as long or longer
+        uses: potatoqualitee/mssqlsuite@v1.7
+        with:
+          install: localdb
+          sa-password: Password!123
+          version: ${{ matrix.mssql }}
+      - name: Check
+        run: |
+          sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "SELECT @@VERSION;"
+          Get-OdbcDriver -Platform 64-bit | Select-Object -ExpandProperty Name
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --config Release --target mssql_tests 
+      - name: Test
+        run: |
+          $env:NANODBC_TEST_CONNSTR_MSSQL="Driver={ODBC Driver 17 for SQL Server};Server=(localdb)\MSSQLLocalDB;Database=tempdb;UID=sa;PWD=Password!123;"
+          ctest --test-dir ${{ github.workspace }}/build --build-config Release --output-on-failure --no-tests=error -R mssql_tests
+
+  test-mariadb:
+    needs: [test-utility]
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        mariadb: ['10.10', '10.3']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install MariaDB
+        uses: ankane/setup-mariadb@v1
+        with:
+          database: nanodbc
+          mariadb-version: ${{ matrix.mariadb }}
+      - name: Install MySQL ODBC Driver 5.3
+        run: |
+          choco install mysql-odbc
+      - name: Check
+        run: |
+          mysql -D nanodbc -e 'SELECT VERSION()'
+          Get-OdbcDriver -Platform 64-bit | Select-Object -ExpandProperty Name
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --config Release --target mysql_tests
+      - name: Test
+        run: |
+          $env:NANODBC_TEST_CONNSTR_MYSQL="Driver={MySQL ODBC 5.3 ANSI Driver};Server=127.0.0.1;Database=nanodbc;User=root;Password=;big_packets=1;"
+          ctest --test-dir ${{ github.workspace }}/build --build-config Release --output-on-failure --no-tests=error -R mysql_tests
+
+  test-mysql:
+    needs: [test-utility]
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        mysql: [8.0, 5.7]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install MySQL
+        uses: ankane/setup-mysql@v1
+        with:
+          database: nanodbc
+          mysql-version: ${{ matrix.mysql }}
+      - name: Install MySQL ODBC Driver 5.3
+        run: |
+          choco install mysql-odbc
+      - name: Check
+        run: |
+          mysql -D nanodbc -e 'SELECT VERSION()'
+          Get-OdbcDriver -Platform 64-bit | Select-Object -ExpandProperty Name
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --config Release --target mysql_tests
+      - name: Test
+        run: |
+          $env:NANODBC_TEST_CONNSTR_MYSQL="Driver={MySQL ODBC 5.3 ANSI Driver};Server=127.0.0.1;Database=nanodbc;User=root;Password=;big_packets=1;"
+          ctest --test-dir ${{ github.workspace }}/build --build-config Release --output-on-failure --no-tests=error -R mysql_tests
+
+  test-postgresql:
+    needs: [test-utility]
+    runs-on: windows-2022
+    # strategy:
+    #   fail-fast: false
+    #   matrix:
+    #     postgres: [14] # Only version currently available on Windows via ankane/setup-postgres
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install PostgreSQL
+        uses: ankane/setup-postgres@v1
+        with:
+          database: nanodbc
+          postgres-version: 14 # ${{ matrix.postgres }}
+      - name: Install PostgreSQL ODBC Driver
+        run: |
+          choco install psqlodbc
+      - name: Check
+        run: |
+          psql -d nanodbc -c 'SHOW server_version'
+          Get-OdbcDriver -Platform 64-bit | Select-Object -ExpandProperty Name
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --config Release --target postgresql_tests 
+      - name: Test
+        run: |
+          $env:NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL ANSI(x64)};Server=localhost;Port=5432;Database=nanodbc;UID=postgres;PWD="
+          ctest --test-dir ${{ github.workspace }}/build --build-config Release --output-on-failure --no-tests=error -R postgresql_tests
+
+  test-sqlite:
+    needs: [test-utility]
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install SQLite ODBC Driver
+        run: |
+          (New-Object Net.WebClient).DownloadFile('http://www.ch-werner.de/sqliteodbc/sqliteodbc_w64.exe', 'sqliteodbc_w64.exe')
+           ./sqliteodbc_w64.exe /S
+      - name: Check
+        run: |
+          Get-OdbcDriver -Platform 64-bit | Select-Object -ExpandProperty Name
+      - name: Configure
+        run: |
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cmake --build ${{ github.workspace }}/build --config Release --target sqlite_tests 
+      - name: Test
+        run: |
+          ctest --test-dir ${{ github.workspace }}/build --build-config Release --output-on-failure --no-tests=error -R sqlite_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.0.0)
+message( STATUS "cmake version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" )
+
 project(nanodbc CXX)
 
 # NOTE: All options follow CMake convention:
@@ -28,15 +30,21 @@ string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+)" "\\1" NANODBC_VERSION_PATCH "
 message(STATUS "nanodbc version: ${NANODBC_VERSION}")
 
 ########################################
-## require and enable C++0x/11/14
+## nanodbc compilation
 ########################################
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ standard to use for NANODBC")
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ standard to use for nanodbc")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 message(STATUS "nanodbc compile: C++${CMAKE_CXX_STANDARD}")
 
+if((CMAKE_MAJOR_VERSION VERSION_GREATER_EQUAL 3) AND (CMAKE_MINOR_VERSION VERSION_GREATER_EQUAL 24))
+  set(CMAKE_COMPILE_WARNING_AS_ERROR ON CACHE BOOL "Treat warnings on nanodbc compile as errors")
+  message(STATUS "nanodbc compile: warning-as-error ${CMAKE_COMPILE_WARNING_AS_ERROR}")
+else()
+  message(STATUS "nanodbc compile: warning-as-error toolset defaults")
+endif()
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wnarrowing -Werror")
   include(CheckCXXCompilerFlag)
 
   if (NANODBC_ENABLE_COVERAGE)


### PR DESCRIPTION
- cmake: Replace hardcoded flags with CMAKE_COMPILE_WARNING_AS_ERROR
- ci: Add GHA workflow to build and test on Windows

### References

- https://github.com/nanodbc/nanodbc/issues/265
- https://github.com/nanodbc/nanodbc/issues/266
- https://github.com/nanodbc/nanodbc/issues/364
- https://github.com/nanodbc/nanodbc/pull/372