### PR TITLE
Add NANODBC_OVERALLOCATE_CHAR flag.

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -33,7 +33,7 @@ jobs:
         run: cmake -B ${{ env.build }} -DCMAKE_BUILD_TYPE=${{ env.config }}
 
       - name: Run MSVC Code Analysis
-        uses: microsoft/msvc-code-analysis-action@v0.1.0
+        uses: microsoft/msvc-code-analysis-action@v0.1.1
         # Provide a unique ID to access the sarif output path
         id: run-core-analysis
         with:
@@ -69,7 +69,7 @@ jobs:
         run: cmake -B ${{ env.build }} -DCMAKE_BUILD_TYPE=${{ env.config }}
 
       - name: Run MSVC Code Analysis
-        uses: microsoft/msvc-code-analysis-action@v0.1.0
+        uses: microsoft/msvc-code-analysis-action@v0.1.1
         # Provide a unique ID to access the sarif output path
         id: run-native-analysis
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ message( STATUS "cmake version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" )
 
 project(nanodbc CXX)
 
+set( CMAKE_VERBOSE_MAKEFILE on )
 # NOTE: All options follow CMake convention:
 #       If no initial value is provided, OFF is used.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ message( STATUS "cmake version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" )
 
 project(nanodbc CXX)
 
-set( CMAKE_VERBOSE_MAKEFILE on )
 # NOTE: All options follow CMake convention:
 #       If no initial value is provided, OFF is used.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option(NANODBC_DISABLE_MSSQL_TVP "Do not use MSSQL Table-valued parameter" OFF)
 option(NANODBC_ENABLE_COVERAGE "Enable test coverage reporting for GCC/clang" OFF)
 option(NANODBC_ENABLE_BOOST "Use Boost for Unicode string convertions (requires Boost.Locale)" OFF)
 option(NANODBC_ENABLE_UNICODE "Enable Unicode support" OFF)
+option(NANODBC_OVERALLOCATE_CHAR "Allocate buffers of sufficient length such that Unicode can be stored in VAR/CHAR columns" OFF)
 option(NANODBC_ENABLE_WORKAROUND_NODATA "Enable SQL_NO_DATA workaround (see Issue #33)" OFF)
 
 ########################################
@@ -120,6 +121,10 @@ if(NANODBC_ENABLE_WORKAROUND_NODATA)
 endif()
 message(STATUS "nanodbc feature: Enable SQL_NO_DATA bug workaround - ${NANODBC_ENABLE_WORKAROUND_NODATA}")
 
+if(NANODBC_OVERALLOCATE_CHAR)
+  add_definitions(-DNANODBC_OVERALLOCATE_CHAR)
+endif()
+message(STATUS "nanodbc feature: Allocate buffers of sufficient length such that Unicode can be stored in VAR/CHAR columns - ${NANODBC_OVERALLOCATE_CHAR}")
 ########################################
 ## find unixODBC or iODBC config binary
 ########################################

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ environment to use [Boost][boost].
 | `NANODBC_ENABLE_BOOST`             | `OFF` or `ON`        | Use Boost for Unicode string convertions (requires [Boost.Locale][boost-locale]). Workaround to issue [#24](https://github.com/nanodbc/nanodbc/issues/24). |
 | `NANODBC_ENABLE_UNICODE`           | `OFF` or `ON`        | Enable Unicode support. `nanodbc::string` becomes `std::u16string` or `std::u32string`. |
 | `NANODBC_ENABLE_WORKAROUND_NODATA` | `OFF` or `ON`        | Enable `SQL_NO_DATA` workaround to issue [#43](https://github.com/nanodbc/nanodbc/issues/43). |
+| `NANODBC_OVERALLOCATE_CHAR`        | `OFF` or `ON`        | Overallocate auto-bound n/var/char buffers to accomodate retrieving Unicode data in VARCHAR columns [#219](https://github.com/nanodbc/nanodbc/issues/219). |
 | `NANODBC_ODBC_VERSION`             | `SQL_OV_ODBC3[...]`  | Forces ODBC version to use. Default is `SQL_OV_ODBC3_80` if available, otherwise `SQL_OV_ODBC3`. |
 
 ### Note About iODBC

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,5 @@
 # nanodbc examples build configuration
 
-set( CMAKE_VERBOSE_MAKEFILE on )
 add_custom_target(examples DEPENDS example)
 set(examples northwind usage rowset_iteration table_schema table_valued_parameter)
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,6 @@
 # nanodbc examples build configuration
 
+set( CMAKE_VERBOSE_MAKEFILE on )
 add_custom_target(examples DEPENDS example)
 set(examples northwind usage rowset_iteration table_schema table_valued_parameter)
 
@@ -21,7 +22,8 @@ foreach(example ${examples})
 
   set_target_properties(example_${example}
     PROPERTIES
-    VERSION ${NANODBC_VERSION})
+    VERSION ${NANODBC_VERSION}
+    COMPILE_FLAGS "-DSIZEOF_LONG_INT=8")
 endforeach()
 
 set(example_empty ${CMAKE_CURRENT_SOURCE_DIR}/empty.cpp)
@@ -41,4 +43,5 @@ add_dependencies(examples example_empty)
 
 set_target_properties(example_empty
   PROPERTIES
-  VERSION ${NANODBC_VERSION})
+  VERSION ${NANODBC_VERSION}
+  COMPILE_FLAGS "-DSIZEOF_LONG_INT=8")

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -198,6 +198,16 @@ using nanodbc::wide_string;
 #endif
 #endif
 
+#if defined(NANODBC_OVERALLOCATE_CHAR)
+// If enabled, when auto-binding buffers to N/VAR/CHAR
+// columns, overallocate assuming each code-point
+// takes up MAX_CODE_POINT_SIZE bytes
+#define MAX_CODE_POINT_SIZE 4
+#define NBYTES(nchars, chartype) (nchars + 1) * MAX_CODE_POINT_SIZE
+#else
+#define NBYTES(nchars, chartype) (nchars + 1) * sizeof(chartype)
+#endif
+
 // clang-format off
 //  .d88888b.  8888888b.  888888b.    .d8888b.       888b     d888
 // d88P" "Y88b 888  "Y88b 888  "88b  d88P  Y88b      8888b   d8888
@@ -3772,26 +3782,6 @@ private:
             if (!success(rc))
                 NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
 
-            // Adjust the sqlsize parameter in case of "unlimited" data (varchar(max),
-            // nvarchar(max)).
-            bool is_blob = false;
-
-            if (sqlsize == 0)
-            {
-                switch (sqltype)
-                {
-                case SQL_VARCHAR:
-                case SQL_WVARCHAR:
-                case SQL_SS_XML:
-                    // Divide in half, due to sqlsize being 32-bit in Win32 (and 64-bit in x64)
-                    // sqlsize = std::numeric_limits<int32_t>::max() / 2 - 1;
-                    is_blob = true;
-                    break;
-                default:
-                    is_blob = false;
-                }
-            }
-
             bound_column& col = bound_columns_[i];
             col.name_ = reinterpret_cast<string::value_type*>(column_name);
             col.column_ = i;
@@ -3845,8 +3835,8 @@ private:
             case SQL_CHAR:
             case SQL_VARCHAR:
                 col.ctype_ = sql_ctype<std::string>::value;
-                col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLCHAR);
-                if (is_blob)
+                col.clen_ = NBYTES(col.sqlsize_, SQLCHAR);
+                if (col.sqlsize_ == 0)
                 {
                     col.clen_ = 0;
                     col.blob_ = true;
@@ -3854,15 +3844,18 @@ private:
                 break;
             case SQL_WCHAR:
             case SQL_WVARCHAR:
-            case SQL_SS_TIMESTAMPOFFSET:
             case SQL_SS_XML:
                 col.ctype_ = sql_ctype<wide_string>::value;
-                col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLWCHAR);
-                if (is_blob)
+                col.clen_ = NBYTES(col.sqlsize_, SQLWCHAR);
+                if (col.sqlsize_ == 0)
                 {
                     col.clen_ = 0;
                     col.blob_ = true;
                 }
+                break;
+            case SQL_SS_TIMESTAMPOFFSET:
+                col.ctype_ = sql_ctype<wide_string>::value;
+                col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLWCHAR);
                 break;
             case SQL_LONGVARCHAR:
                 col.ctype_ = sql_ctype<std::string>::value;

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1643,11 +1643,11 @@ public:
     /// \brief Reports if number of affected rows is available.
     /// \return true if number of affected rows is known, regardless of the value;
     /// false if the number is not available.
-    /// \throws database_error
-    ///
+    /// \throws database_error {
     /// \code{.cpp}
     /// assert(r.has_affected_rows() == (r.affected_rows() >= 0));
     /// \endcode
+    /// }
     bool has_affected_rows() const;
 
     /// \brief Rows in the current rowset or 0 if the number of rows is not available.

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1644,6 +1644,7 @@ public:
     /// \return true if number of affected rows is known, regardless of the value;
     /// false if the number is not available.
     /// \throws database_error
+    ///
     /// \code{.cpp}
     /// assert(r.has_affected_rows() == (r.affected_rows() >= 0));
     /// \endcode

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 # nanodbc tests build configuration
 
+set( CMAKE_VERBOSE_MAKEFILE on )
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
   # Workaround for AppVeyor + Catch: `error: ignoring #pragma gcc diagnostic`
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
@@ -28,7 +29,11 @@ if (BUILD_SHARED_LIBS)
 else()
   target_link_libraries(utility_tests nanodbc Catch ${ODBC_LIBRARIES})
 endif()
-set_target_properties(utility_tests PROPERTIES VERSION ${NANODBC_VERSION})
+# Must define SIZE_OF_LONG_INT to avoid sqltypes.h requiring presence of
+# unixodbc.h
+set_target_properties(utility_tests PROPERTIES
+  VERSION ${NANODBC_VERSION}
+  COMPILE_FLAGS "-DSIZEOF_LONG_INT=8")
 add_test(NAME utility_tests COMMAND utility_tests)
 if(NOT CMAKE_GENERATOR MATCHES "^Visual Studio")
   add_custom_target(utility_test
@@ -74,7 +79,8 @@ foreach(test_item ${test_list})
       $<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>)
   set_target_properties(${test_name}
     PROPERTIES
-    VERSION ${NANODBC_VERSION})
+    VERSION ${NANODBC_VERSION}
+    COMPILE_FLAGS "-DSIZEOF_LONG_INT=8")
   add_test(NAME ${test_name} COMMAND ${test_name})
 
   set_tests_properties(${test_name} PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,5 @@
 # nanodbc tests build configuration
 
-set( CMAKE_VERBOSE_MAKEFILE on )
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
   # Workaround for AppVeyor + Catch: `error: ignoring #pragma gcc diagnostic`
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1678,4 +1678,33 @@ TEST_CASE_METHOD(mssql_fixture, "test_conn_attributes", "[mssql][conn_attibutes]
 #endif
 }
 #endif
+
+#if defined(NANODBC_ENABLE_UNICODE)
+/* Test that when we have Unicode data stored in a
+ * varchar column, if we have the OVERALLOCATE_CHAR
+ * flag enabled, we are able to retrieve the entire
+ * result.
+ */
+TEST_CASE_METHOD(mssql_fixture, "test_overallocate", "[mssql][overallocate]")
+{
+    auto conn = connect();
+    auto val = nanodbc::string(u"grün");
+    auto sql = NANODBC_TEXT("SELECT '") + val + NANODBC_TEXT("' AS A");
+    nanodbc::result result = execute(conn, sql);
+    REQUIRE(result.next());
+    auto res = result.get<nanodbc::string>(0);
+#if defined(NANODBC_OVERALLOCATE_CHAR)
+    REQUIRE(res == val);
+    REQUIRE(res.size() == 4);
+#else
+    /*
+     * Commented out since testing for "incorrect" behavior is probably
+     * not a good idea.  But here to demonstrate the effect of
+     * enabling the NANODBC_OVERALLOCATE_CHAR flag.
+    REQUIRE( res != val );
+    REQUIRE(res.size() == 3);
+    */
+#endif
+}
+#endif
 #endif


### PR DESCRIPTION
When enabled N/VAR/CHAR buffers are allocated assuming one character ( code point ) equates to 4 bytes.

Fixes https://github.com/nanodbc/nanodbc/issues/219

Some notes:
* Looks like there is wide-spread breakage in CI, maybe related to https://github.com/microsoft/linux-package-repositories/issues/36
   There's so much red, i am having trouble figuring out if CI is flagging anything in the PR.  I'll try and work through some of this, but wanted to get at least the code out.
* Wonder if it's worth adding (back) the `ENABLE_UNICODE` dimension to the unit test matrix.