### PR TITLE
CMakeLists.txt updates for modern CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ package-lock.json
 *.code-workspace
 
 # Miscelenaous
+.cache
 *.log
 /doc/build/
 /.vagrant

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,317 +1,224 @@
-cmake_minimum_required(VERSION 3.0.0)
-message( STATUS "cmake version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" )
+cmake_minimum_required( VERSION 3.21.0 )
 
-project(nanodbc CXX)
+file( STRINGS VERSION.txt NANODBC_VERSION )
+string( REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)"
+  NANODBC_VERSION "${NANODBC_VERSION}" )
+set( NANODBC_VERSION_MAJOR ${CMAKE_MATCH_1} CACHE STRING "Major Version" )
+set( NANODBC_VERSION_MINOR ${CMAKE_MATCH_2} CACHE STRING "Minor Version" )
+set( NANODBC_VERSION_PATCH ${CMAKE_MATCH_3} CACHE STRING "Patch Version" )
 
-# NOTE: All options follow CMake convention:
-#       If no initial value is provided, OFF is used.
+project( nanodbc
+  LANGUAGES CXX
+  VERSION ${NANODBC_VERSION}
+  DESCRIPTION "nanodbc is a small library that makes ODBC API programming easy and fun"
+  HOMEPAGE_URL "https://nanodbc.github.io/nanodbc/"
+)
 
-# CMake standard options
-option(BUILD_SHARED_LIBS "Build shared library" OFF)
+# #######################################
+# # nanodbc version
+# #######################################
+
+# Default to honoring the visibility settings for static libraries
+cmake_policy( SET CMP0063 NEW )
+
+# Default to @rpath on macOS
+cmake_policy( SET CMP0042 NEW )
+
+# cmake dependent option supports full syntax
+cmake_policy( SET CMP0127 NEW )
+
 # nanodbc specific options
-option(NANODBC_DISABLE_ASYNC "Disable async features entirely" OFF)
-option(NANODBC_DISABLE_EXAMPLES "Do not build examples" OFF)
-option(NANODBC_DISABLE_INSTALL "Do not generate install target" OFF)
-option(NANODBC_DISABLE_LIBCXX "Do not use libc++, if available." OFF)
-option(NANODBC_DISABLE_TESTS "Do not build tests" OFF)
-option(NANODBC_DISABLE_MSSQL_TVP "Do not use MSSQL Table-valued parameter" OFF)
-option(NANODBC_ENABLE_COVERAGE "Enable test coverage reporting for GCC/clang" OFF)
-option(NANODBC_ENABLE_BOOST "Use Boost for Unicode string convertions (requires Boost.Locale)" OFF)
-option(NANODBC_ENABLE_UNICODE "Enable Unicode support" OFF)
-option(NANODBC_OVERALLOCATE_CHAR "Allocate buffers of sufficient length such that Unicode can be stored in VAR/CHAR columns" OFF)
-option(NANODBC_ENABLE_WORKAROUND_NODATA "Enable SQL_NO_DATA workaround (see Issue #33)" OFF)
+option( NANODBC_DISABLE_ASYNC "Disable async features entirely (default off)" OFF )
+option( NANODBC_DISABLE_MSSQL_TVP "Do not use MSSQL Table-valued parameter (default off)" OFF )
+option( NANODBC_DISABLE_ASYNC "Disable async features entirely (default off)" OFF )
+option( NANODBC_ENABLE_UNICODE "Enable Unicode support (default on)" OFF )
+option( NANODBC_ENABLE_WORKAROUND_NODATA "Enable SQL_NO_DATA workaround (see Issue #33) (default off)" OFF )
 
-########################################
-## nanodbc version
-########################################
-file(STRINGS VERSION.txt NANODBC_VERSION REGEX "[0-9]+\\.[0-9]+\\.[0-9]+")
-string(REGEX REPLACE "^([0-9]+)\\.[0-9]+\\.[0-9]+" "\\1" NANODBC_VERSION_MAJOR "${NANODBC_VERSION}")
-string(REGEX REPLACE "^[0-9]+\\.([0-9])+\\.[0-9]+" "\\1" NANODBC_VERSION_MINOR "${NANODBC_VERSION}")
-string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+)" "\\1" NANODBC_VERSION_PATCH "${NANODBC_VERSION}")
-message(STATUS "nanodbc version: ${NANODBC_VERSION}")
+include( CheckCXXCompilerFlag )
+check_cxx_compiler_flag( "-stdlib=libc++" CXX_COMPILER_SUPPORTS_LIBCXX )
+check_cxx_compiler_flag( "-Werror" CXX_COMPILER_SUPPORTS_WERROR )
+check_cxx_compiler_flag( "--coverage -O0" CXX_COMPILER_SUPPORTS_COVERAGE )
+
+include( CMakeDependentOption )
+cmake_dependent_option( NANODBC_FORCE_LIBCXX "Force the use of libc++ (default on if compiler supports it)" ON "CXX_COMPILER_SUPPORTS_LIBCXX" OFF )
+
+
+cmake_dependent_option( NANODBC_BUILD_EXAMPLES "Build examples (default on)" ON "PROJECT_IS_TOP_LEVEL" OFF)
+cmake_dependent_option( NANODBC_GENERATE_INSTALL "Generate install target (default on)" ON "PROJECT_IS_TOP_LEVEL" OFF)
+cmake_dependent_option( NANODBC_BUILD_TESTS "Build tests (default on)" ON "PROJECT_IS_TOP_LEVEL" OFF)
+
+cmake_dependent_option( NANODBC_ENABLE_BOOST
+  "Use Boost for Unicode string convertions (requires Boost.Locale) (default off if Unicode enabled)" OFF
+  "NANODBC_ENABLE_UNICODE" OFF
+)
+
+cmake_dependent_option( NANODBC_OVERALLOCATE_CHAR
+  "Allocate buffers of sufficient length such that Unicode can be stored in VAR/CHAR columns (default off)" OFF
+  "NANODBC_ENABLE_UNICODE" OFF
+)
+
+cmake_dependent_option( NANODBC_ENABLE_COVERAGE "Enable code coverage analysis (default off)" OFF
+  "CXX_COMPILER_SUPPORTS_COVERAGE AND NANODBC_BUILD_TESTS" OFF
+)
+
+cmake_dependent_option( NANODBC_FORCE_WARNINGS_AS_ERROR
+  "Treat warnings on nanodbc compile as errors" OFF
+  "(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24.0) OR CXX_COMPILER_SUPPORTS_WERROR" OFF
+)
+
+
+message( STATUS "nanodbc version: ${NANODBC_VERSION}" )
 
 ########################################
 ## nanodbc compilation
 ########################################
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ standard to use for nanodbc")
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-message(STATUS "nanodbc compile: C++${CMAKE_CXX_STANDARD}")
+# set project-global variables for tests/examples if we're not a subproject
+if( PROJECT_IS_TOP_LEVEL )
+  set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ standard to use for nanodbc")
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+# ==== CMAKE default vars must be set before target creation! ====
+# BUILD_SHARED_LIBS dictates type
+add_library( nanodbc nanodbc/nanodbc.cpp )
+target_sources( nanodbc PUBLIC FILE_SET HEADERS FILES nanodbc/nanodbc.h )
+message( STATUS "nanodbc compile: Global setting: C++${CMAKE_CXX_STANDARD}; nanodbc requires C++14 or greater" )
 
-if((CMAKE_MAJOR_VERSION VERSION_GREATER_EQUAL 3) AND (CMAKE_MINOR_VERSION VERSION_GREATER_EQUAL 24))
-  set(CMAKE_COMPILE_WARNING_AS_ERROR ON CACHE BOOL "Treat warnings on nanodbc compile as errors")
-  message(STATUS "nanodbc compile: warning-as-error ${CMAKE_COMPILE_WARNING_AS_ERROR}")
+# nanodbc requires at least C++14, but can use C++17 and beyond
+target_compile_features(nanodbc PRIVATE cxx_std_14)
+
+message( STATUS "nanodbc compile: warning-as-error ${NANODBC_FORCE_WARNINGS_AS_ERROR}" )
+if( NANODBC_FORCE_WARNINGS_AS_ERROR )
+  if (CMAKE_VERSION GREATER_EQUAL 3.24.0)
+    set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+  elseif( CXX_COMPILER_SUPPORTS_WERROR )
+    target_compile_options( nanodbc PRIVATE -Werror )
+  endif()
+endif()
+
+message( STATUS "nanodbc build: Force linking libc++ - ${NANODBC_FORCE_LIBCXX}" )
+if( NANODBC_FORCE_LIBCXX )
+  target_compile_options( nanodbc PUBLIC -stdlib=libc++ )
+  target_link_options( nanodbc PUBLIC -stdlib=libc++ -lc++abi )
+endif()
+
+set_target_properties( nanodbc PROPERTIES
+  VERSION ${NANODBC_VERSION}
+  WINDOWS_EXPORT_ALL_SYMBOLS ON
+  CXX_EXTENSIONS OFF
+)
+
+find_package( ODBC REQUIRED )
+target_link_libraries( nanodbc PUBLIC ODBC::ODBC )
+
+if( CMAKE_CXX_COMPILER_ID MATCHES "Intel" )
+  target_compile_options( nanodbc PRIVATE
+    /QaxCORE-AVX2
+    /fp:precise
+    "$<$<CONFIG:Debug>:/Od>"
+    "$<$<CONFIG:Release>:/O3 /Qipo>"
+  )
+endif()
+
+# AppleClang complains of unused `-I/path/` arguments.
+# These are harmless and can be safely ignored.
+target_compile_options( nanodbc PRIVATE
+  "$<$<CXX_COMPILER_ID:MSVC,Intel>:/W4>"
+  "$<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-unused-command-line-argument>"
+)
+
+# #######################################
+# # nanodbc features
+# #######################################
+IF( DEFINED NANODBC_ODBC_VERSION )
+  message( STATUS "nanodbc feature: ODBC Version Override - ${NANODBC_ODBC_VERSION}" )
+  target_compile_definitions( nanodbc PUBLIC NANODBC_ODBC_VERSION=${NANODBC_ODBC_VERSION} )
 else()
-  message(STATUS "nanodbc compile: warning-as-error toolset defaults")
+  message( STATUS "nanodbc feature: ODBC Version Override - OFF" )
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
-  include(CheckCXXCompilerFlag)
+message( STATUS "nanodbc feature: Enable Unicode - ${NANODBC_ENABLE_UNICODE}" )
 
-  if (NANODBC_ENABLE_COVERAGE)
-    add_compile_options(--coverage -O0)
-    link_libraries(gcov)
-    message(STATUS "nanodbc build: Enable test coverage - Yes")
-  endif()
+if( NANODBC_ENABLE_UNICODE )
+  target_compile_definitions( nanodbc PUBLIC
+    NANODBC_ENABLE_UNICODE
+    "$<$<CXX_COMPILER_ID:MSVC>:UNICODE _UNICODE>"
+  )
 
-  if(NOT NANODBC_DISABLE_LIBCXX)
-    check_cxx_compiler_flag("-stdlib=libc++" CXX_SUPPORTS_STDLIB)
-    if(CXX_SUPPORTS_STDLIB)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
-      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++")
-      set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -stdlib=libc++")
-    endif()
-    set(NANODBC_DISABLE_LIBCXX ${NANODBC_DISABLE_LIBCXX} CACHE BOOL "Do not use libc++, if available." FORCE)
-  endif()
-  message(STATUS "nanodbc build: Disable linking libc++ - ${NANODBC_DISABLE_LIBCXX}")
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-    string(REGEX REPLACE "[/-]W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    if (NOT (CMAKE_VERSION VERSION_LESS 3.6.0)) # Compiler features for Intel in CMake 3.6+
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Qstd=c++17")
-    endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /QaxCORE-AVX2")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:precise")
-    set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG}   /Od")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /O3")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Qipo")
-elseif(MSVC)
-  string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  if(MSVC_VERSION LESS 1700)
-    message(FATAL_ERROR, "nanodbc requires C++11-compliant compiler")
+  target_compile_definitions( nanodbc PRIVATE
+    "$<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>"
+  )
+
+  message( STATUS "nanodbc feature: Enable Boost - ${NANODBC_ENABLE_BOOST}" )
+
+  if( NANODBC_ENABLE_BOOST )
+    find_package( Boost REQUIRED COMPONENTS locale )
+    target_link_libraries( nanodbc PUBLIC Boost::locale )
+    target_compile_definitions( nanodbc PUBLIC NANODBC_ENABLE_BOOST )
   endif()
 endif()
 
-########################################
-## nanodbc features
-########################################
-IF(NOT DEFINED NANODBC_ODBC_VERSION)
-  message(STATUS "nanodbc feature: ODBC Version Override - OFF")
-else()
-  message(STATUS "nanodbc feature: ODBC Version Override - ${NANODBC_ODBC_VERSION}")
-  add_definitions(-DNANODBC_ODBC_VERSION=${NANODBC_ODBC_VERSION})
-endif()
+message( STATUS "nanodbc feature: Allocate buffers of sufficient length such that Unicode can be stored in VAR/CHAR columns - ${NANODBC_OVERALLOCATE_CHAR}" )
+message( STATUS "nanodbc feature: Enable SQL_NO_DATA bug workaround - ${NANODBC_ENABLE_WORKAROUND_NODATA}" )
+message( STATUS "nanodbc feature: Disable async features - ${NANODBC_DISABLE_ASYNC}" )
+message( STATUS "nanodbc feature: Disable MSSQL Table-valued parameter - ${NANODBC_DISABLE_MSSQL_TVP}" )
 
-if(NANODBC_DISABLE_ASYNC)
-  add_definitions(-DNANODBC_DISABLE_ASYNC)
-endif()
-message(STATUS "nanodbc feature: Disable async features - ${NANODBC_DISABLE_ASYNC}")
+target_compile_definitions( nanodbc PUBLIC
+  $<$<BOOL:${NANODBC_DISABLE_MSSQL_TVP}>:NANODBC_DISABLE_MSSQL_TVP>
+  $<$<BOOL:${NANODBC_OVERALLOCATE_CHAR}>:NANODBC_OVERALLOCATE_CHAR>
+  $<$<BOOL:${NANODBC_ENABLE_WORKAROUND_NODATA}>:NANODBC_ENABLE_WORKAROUND_NODATA>
+  $<$<BOOL:${NANODBC_DISABLE_ASYNC}>:NANODBC_DISABLE_ASYNC>
+)
 
-if(NANODBC_DISABLE_MSSQL_TVP)
-  add_definitions(-DNANODBC_DISABLE_MSSQL_TVP)
-endif()
-message(STATUS "nanodbc feature: Disable MSSQL Table-valued parameter - ${NANODBC_DISABLE_MSSQL_TVP}")
+# #######################################
+# # install targets
+# #######################################
+message( STATUS "nanodbc build: Generate install target - ${NANODBC_GENERATE_INSTALL}" )
 
-if(NANODBC_ENABLE_UNICODE)
-  add_definitions(-DNANODBC_ENABLE_UNICODE)
-  if(MSVC)
-    # Sets "Use Unicode Character Set" property in Visual Studio projects
-    add_definitions(-DUNICODE -D_UNICODE)
-  endif()
-endif()
-message(STATUS "nanodbc feature: Enable Unicode - ${NANODBC_ENABLE_UNICODE}")
+if( NANODBC_GENERATE_INSTALL )
+  include( GNUInstallDirs )
 
-if(NANODBC_ENABLE_BOOST)
-  add_definitions(-DNANODBC_ENABLE_BOOST)
-endif()
-message(STATUS "nanodbc feature: Enable Boost - ${NANODBC_ENABLE_BOOST}")
-
-if(NANODBC_ENABLE_WORKAROUND_NODATA)
-  add_definitions(-DNANODBC_ENABLE_WORKAROUND_NODATA)
-endif()
-message(STATUS "nanodbc feature: Enable SQL_NO_DATA bug workaround - ${NANODBC_ENABLE_WORKAROUND_NODATA}")
-
-if(NANODBC_OVERALLOCATE_CHAR)
-  add_definitions(-DNANODBC_OVERALLOCATE_CHAR)
-endif()
-message(STATUS "nanodbc feature: Allocate buffers of sufficient length such that Unicode can be stored in VAR/CHAR columns - ${NANODBC_OVERALLOCATE_CHAR}")
-########################################
-## find unixODBC or iODBC config binary
-########################################
-if(UNIX)
-  # Try to find unixODBC first via odbc_config program.
-  find_program(ODBC_CONFIG odbc_config
-    PATHS $ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin)
-  if(ODBC_CONFIG)
-    message(STATUS "nanodbc build: ODBC on Unix - unixODBC")
-    set(ODBCLIB odbc)
-    execute_process(COMMAND ${ODBC_CONFIG} --include-prefix
-      OUTPUT_VARIABLE ODBC_INCLUDE_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
-    set(ODBC_CFLAGS "-I${ODBC_INCLUDE_DIR}")
-    set(CMAKE_FLAGS "${CMAKE_FLAGS} ${ODBC_CFLAGS}")
-    execute_process(COMMAND ${ODBC_CONFIG} --libs
-      OUTPUT_VARIABLE ODBC_LINK_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-  endif()
-
-  # Fallback to finding unixODBC via install paths
-  if(NOT ODBC_CONFIG)
-    find_path(UnixODBC_INCLUDE_DIR uodbc_stats.h
-      /usr/include
-      /usr/local/include
-      /usr/include/odbc
-      /usr/local/include/odbc
-      /usr/include/libodbc
-      /usr/local/include/libodbc)
-    if(UnixODBC_INCLUDE_DIR)
-      set(ODBC_CONFIG 1)
-      message(STATUS "nanodbc build: ODBC on Unix - unixODBC")
-      set(ODBCLIB odbc)
-      set(ODBC_CFLAGS "-I${UnixODBC_INCLUDE_DIR} -DHAVE_UNISTD_H -DHAVE_PWD_H -DHAVE_SYS_TYPES_H -DHAVE_LONG_LONG -DSIZEOF_LONG_INT=8")
-    endif()
-  endif()
-
-  # Fallback to using iODBC
-  if(NOT ODBC_CONFIG)
-    find_program(ODBC_CONFIG iodbc-config
-      PATHS $ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin)
-    if(ODBC_CONFIG)
-      message(STATUS "nanodbc build: ODBC on Unix - iODBC")
-      set(ODBCLIB iodbc)
-      execute_process(COMMAND ${ODBC_CONFIG} --cflags
-        OUTPUT_VARIABLE ODBC_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-      set(CMAKE_FLAGS "${CMAKE_FLAGS} ${ODBC_CFLAGS}")
-      execute_process(COMMAND ${ODBC_CONFIG} --libs
-        OUTPUT_VARIABLE ODBC_LINK_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-      if(NANODBC_ENABLE_UNICODE)
-        add_definitions(-DNANODBC_USE_IODBC_WIDE_STRINGS)
-      endif()
-    endif()
-  endif()
-
-  if(NOT ODBC_CONFIG)
-    message(FATAL_ERROR "can not find a suitable odbc driver manager")
-  endif()
-
-  message(STATUS "ODBC compile flags: ${ODBC_CFLAGS}")
-  message(STATUS "ODBC link flags: ${ODBC_LINK_FLAGS}")
-endif()
-
-########################################
-## find ODBC libraries to link
-########################################
-if(UNIX)
-  set(ODBC_LIBRARIES ${ODBCLIB})
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ODBC_LINK_FLAGS}")
-elseif(MSVC OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-  set(ODBC_LIBRARIES odbc32.lib odbccp32.lib Ws2_32.lib)
-elseif(MINGW)
-  set(ODBC_LIBRARIES odbc32 odbccp32)
-endif()
-
-########################################
-## find Boost if necessary
-########################################
-if(NANODBC_ENABLE_BOOST)
-  set(Boost_USE_STATIC_LIBS ON)
-  set(Boost_USE_MULTITHREADED ON)
-  find_package(Boost COMPONENTS locale REQUIRED)
-  if(Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIRS})
-    link_directories(${CMAKE_BINARY_DIR}/lib ${Boost_LIBRARY_DIRS})
-  else()
-    message(FATAL_ERROR "can not find boost")
-  endif()
-endif()
-
-########################################
-## Mac OS X specifics for targets
-########################################
-if(APPLE)
-  set(CMAKE_MACOSX_RPATH ON)
-  message(STATUS "Use rpaths on Mac OS X - ${CMAKE_MACOSX_RPATH}")
-
-  # AppleClang complains of unused `-I/path/` arguments.
-  # These are harmless and can be safely ignored.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
-endif()
-
-########################################
-## library target
-########################################
-if(BUILD_SHARED_LIBS)
-  message(STATUS "nanodbc build: Enable nanodbc target - SHARED")
-else()
-  message(STATUS "nanodbc build: Enable nanodbc target - STATIC")
-endif()
-
-add_library(nanodbc nanodbc/nanodbc.cpp nanodbc/nanodbc.h)
-
-target_link_libraries(nanodbc ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
-
-target_include_directories(nanodbc PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:include/nanodbc>) # <prefix>/include/nanodbc
-
-if(UNIX)
-  set_target_properties(nanodbc PROPERTIES
-    COMPILE_FLAGS "${ODBC_CFLAGS}"
-    LIBRARY_OUTPUT_DIRECTORY "lib")
-endif()
-
-if(BUILD_SHARED_LIBS)
-  set_target_properties(nanodbc PROPERTIES
-    VERSION ${NANODBC_VERSION})
-    # export all symobols from windows DLL
-    set_target_properties(nanodbc PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
-endif()
-
-target_compile_definitions(nanodbc
-  PRIVATE
-    $<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>)
-
-########################################
-## install targets
-########################################
-if(NOT NANODBC_DISABLE_INSTALL)
-  set(NANODBC_CONFIG nanodbc-config)
   # 'make install' to the correct location
-  if(BUILD_SHARED_LIBS)
-    install(TARGETS nanodbc
-      EXPORT ${NANODBC_CONFIG} # associate installed target files with export
-      INCLUDES DESTINATION include
-      LIBRARY DESTINATION lib
-      ARCHIVE DESTINATION lib
-      RUNTIME DESTINATION bin) # for Windows
-  else()
-    install(TARGETS nanodbc
-      EXPORT ${NANODBC_CONFIG} # associate installed target files with export
-      INCLUDES DESTINATION include
-      LIBRARY DESTINATION lib
-      ARCHIVE DESTINATION lib)
-  endif()
-  # Install public include headers
-  install(FILES nanodbc/nanodbc.h DESTINATION include/nanodbc)
+  install( TARGETS nanodbc
+      EXPORT nanodbc-config
+      ARCHIVE
+      LIBRARY
+      RUNTIME
+      FILE_SET HEADERS
+  )
+
   # Make project importable from the install directory
-  ## Generate and install *-config.cmake exporting targets from install tree.
-  if (WIN32 AND NOT MINGW)
-    install(EXPORT ${NANODBC_CONFIG} DESTINATION "cmake")
-  else()
-    install(EXPORT ${NANODBC_CONFIG} DESTINATION "lib/cmake/nanodbc")
-  endif()
-  # Make project importable from the build directory
-  ## Generate file *-config.cmake exporting targets from build tree.
-  export(TARGETS nanodbc FILE ${NANODBC_CONFIG}.cmake)
+  # Generate and install *-config.cmake exporting targets from install tree.
+  install( EXPORT nanodbc-config
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nanodbc"
+  )
+  export( TARGETS nanodbc NAMESPACE nanodbc:: FILE nanodbc-config.cmake )
 endif()
-message(STATUS "nanodbc build: Disable install target - ${NANODBC_DISABLE_INSTALL}")
 
-########################################
-## tests targets
-########################################
-if(NOT NANODBC_DISABLE_TESTS)
-  enable_testing()
-  add_subdirectory(test)
-  if(NOT CMAKE_GENERATOR MATCHES "^Visual Studio")
-    add_custom_target(check
-      COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure
-      DEPENDS tests)
-  endif()
-endif()
-message(STATUS "nanodbc build: Disable tests target - ${NANODBC_DISABLE_TESTS}")
+# #######################################
+# # tests targets
+# #######################################
+message( STATUS "nanodbc build: Build tests - ${NANODBC_BUILD_TESTS}" )
 
-########################################
-## examples targets
-########################################
-if(NOT NANODBC_DISABLE_EXAMPLES)
-  add_subdirectory(example)
+if( NANODBC_BUILD_TESTS )
+  include (CTest)
+  list(APPEND CMAKE_CTEST_ARGUMENTS --force-new-ctest-process --output-on-failure )
+  add_subdirectory( test )
 endif()
-message(STATUS "nanodbc build: Disable examples target - ${NANODBC_DISABLE_EXAMPLES}")
+
+message( STATUS "nanodbc build: Enable test coverage - ${NANODBC_ENABLE_COVERAGE}" )
+
+if( NANODBC_ENABLE_COVERAGE )
+  target_compile_options( nanodbc PUBLIC --coverage -O0 )
+  find_library( gcov gcov )
+  target_link_libraries( nanodbc PUBLIC gcov )
+endif()
+
+# #######################################
+# # examples targets
+# #######################################
+message( STATUS "nanodbc build: Build examples - ${NANODBC_BUILD_EXAMPLES}" )
+
+if( NANODBC_BUILD_EXAMPLES )
+  add_subdirectory( example )
+endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,46 +1,25 @@
-# nanodbc examples build configuration
+# # nanodbc examples build configuration
+find_package(ODBC REQUIRED)
+add_compile_definitions( "$<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>" )
 
-add_custom_target(examples DEPENDS example)
-set(examples northwind usage rowset_iteration table_schema table_valued_parameter)
+add_custom_target( examples )
 
-include_directories(${CMAKE_SOURCE_DIR} ${ODBC_INCLUDE_DIR})
-link_directories(${CMAKE_BINARY_DIR}/lib)
+set( example_list empty northwind usage rowset_iteration table_schema table_valued_parameter )
 
-foreach(example ${examples})
-  add_executable(example_${example} ${example}.cpp example_unicode_utils.h)
-  if (BUILD_SHARED_LIBS)
-    target_link_libraries(example_${example} nanodbc "${ODBC_LINK_FLAGS}")
-  else()
-    target_link_libraries(example_${example} nanodbc ${ODBC_LIBRARIES})
-  endif()
-  target_compile_definitions(example_${example}
-    PRIVATE
-      $<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>)
+# Generate an empty.cpp from the template, for experimentation
+# empty.cpp is ignored by git
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/empty.cpp) # Behavior is well-defined only for full paths.
+  configure_file(empty.cpp.in ${CMAKE_CURRENT_SOURCE_DIR}/empty.cpp COPYONLY)
+endif()
 
-  add_dependencies(examples example_${example})
-
-  set_target_properties(example_${example}
-    PROPERTIES
-    VERSION ${NANODBC_VERSION}
-    COMPILE_FLAGS "-DSIZEOF_LONG_INT=8")
+foreach( example IN LISTS example_list )
+    add_executable( example_${example} ${example}.cpp example_unicode_utils.h )
+    target_link_libraries( example_${example} PRIVATE nanodbc ODBC::ODBC )
+    target_compile_features(example_${example} PRIVATE cxx_std_14)
+    set_target_properties(example_${example}
+      PROPERTIES
+      CXX_EXTENSIONS OFF
+      VERSION ${NANODBC_VERSION}
+    )
+    add_dependencies( examples example_${example})
 endforeach()
-
-set(example_empty ${CMAKE_CURRENT_SOURCE_DIR}/empty.cpp)
-if(NOT EXISTS ${example_empty}) # Behavior is well-defined only for full paths.
-  configure_file(${example_empty}.in ${example_empty} COPYONLY)
-endif()
-add_executable(example_empty ${example_empty} example_unicode_utils.h)
-if (BUILD_SHARED_LIBS)
-  target_link_libraries(example_empty nanodbc "${ODBC_LINK_FLAGS}")
-else()
-  target_link_libraries(example_empty nanodbc ${ODBC_LIBRARIES})
-endif()
-target_compile_definitions(example_empty
-  PRIVATE
-    $<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>)
-add_dependencies(examples example_empty)
-
-set_target_properties(example_empty
-  PROPERTIES
-  VERSION ${NANODBC_VERSION}
-  COMPILE_FLAGS "-DSIZEOF_LONG_INT=8")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,98 +1,64 @@
 # nanodbc tests build configuration
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
-  # Workaround for AppVeyor + Catch: `error: ignoring #pragma gcc diagnostic`
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
-endif()
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  # Workaround for AppVeyor + Catch: `suggest parentheses around comparison in operand of '=='`
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=parentheses")
-endif()
+find_package(ODBC REQUIRED)
+add_compile_definitions( "$<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>" )
 
 # Prepare "Catch" library for other executables
-set(CATCH_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(Catch INTERFACE)
-target_include_directories(Catch INTERFACE ${CATCH_INCLUDE_DIR})
+add_custom_target(tests)
 
-include_directories(${nanodbc_SOURCE_DIR} ${ODBC_INCLUDE_DIR})
-link_directories(${CMAKE_BINARY_DIR}/lib)
-file(GLOB headers *.h *.hpp)
-add_custom_target(tests DEPENDS tests catch)
-
-# Common utilities tests
+message( STATUS "Building utility tests")
 add_executable(utility_tests utility_test.cpp)
-target_include_directories(utility_tests PRIVATE ${nanodbc_SOURCE_DIR}/nanodbc)
-if (BUILD_SHARED_LIBS)
-  target_link_libraries(utility_tests nanodbc Catch "${ODBC_LINK_FLAGS}")
-else()
-  target_link_libraries(utility_tests nanodbc Catch ${ODBC_LIBRARIES})
-endif()
-# Must define SIZE_OF_LONG_INT to avoid sqltypes.h requiring presence of
-# unixodbc.h
-set_target_properties(utility_tests PROPERTIES
-  VERSION ${NANODBC_VERSION}
-  COMPILE_FLAGS "-DSIZEOF_LONG_INT=8")
+target_link_libraries(utility_tests PRIVATE ODBC::ODBC Catch nanodbc)
+target_compile_features(utility_tests PRIVATE cxx_std_14)
 add_test(NAME utility_tests COMMAND utility_tests)
-if(NOT CMAKE_GENERATOR MATCHES "^Visual Studio")
-  add_custom_target(utility_test
-    COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R utility_tests)
-  add_custom_target(${test_item}_check
-    COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R utility_tests
-    DEPENDS utility_tests)
-endif()
 add_dependencies(tests utility_tests)
-
 
 # Database-specific tests
 set(test_list mssql mysql postgresql sqlite vertica) # odbc_test.cpp is a dummy
 
-# AppVeyor set common environment variable CI
-# and nanodbc-specific DB (in CI build configuration).
-# The CI builds enable DB test for DB specified in build job configuration.
-if (DEFINED ENV{CI} AND DEFINED ENV{DB})
-  if ($ENV{CI})
-    foreach(test_item ${test_list})
-      string(TOLOWER $ENV{DB} test_db)
-      string(FIND ${test_db} ${test_item} test_found)
-      if (test_found LESS 0)
-        list(REMOVE_ITEM test_list ${test_item})
-      endif()
-    endforeach()
-    if (NOT test_list)
-      message(FATAL_ERROR "CI build misconfigured: no tests specified")
+foreach(test_item IN LISTS test_list)
+  # AppVeyor set common environment variable CI
+  # and nanodbc-specific DB (in CI build configuration).
+  # The CI builds enable DB test for DB specified in build job configuration.
+  if (DEFINED ENV{CI} AND DEFINED ENV{DB})
+    string(TOLOWER $ENV{DB} test_db)
+    string(FIND ${test_db} ${test_item} test_found)
+    if (test_found LESS 0)
+      message(TRACE "Skipping ${test_item} tests")
+      continue()
     endif()
   endif()
-endif()
-
-foreach(test_item ${test_list})
+  message( STATUS "Building ${test_item} tests")
   set(test_name ${test_item}_tests)
-  add_executable(${test_name} main.cpp ${test_item}_test.cpp ${headers})
-  if (BUILD_SHARED_LIBS)
-    target_link_libraries(${test_name} nanodbc Catch "${ODBC_LINK_FLAGS}")
-  else()
-    target_link_libraries(${test_name} nanodbc Catch ${ODBC_LIBRARIES})
-  endif()
+  add_executable(${test_name}
+      main.cpp
+      ${test_item}_test.cpp
+      base_test_fixture.h
+      test_case_fixture.h
+      )
+  target_link_libraries(${test_name} PRIVATE Catch ODBC::ODBC nanodbc)
+
   target_compile_definitions(${test_name}
     PRIVATE
-      $<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>)
+      NANODBC_TEST_DATA="${CMAKE_CURRENT_SOURCE_DIR}/data"
+      $<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>
+  )
+
+  target_compile_options(${test_name}
+    PRIVATE
+    $<$<CXX_COMPILER_ID:Clang,AppleClang,GNU>:-Wno-unknown-pragmas>
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-error=parentheses>
+  )
+
+  target_compile_features(${test_name} PRIVATE cxx_std_14)
+
   set_target_properties(${test_name}
     PROPERTIES
+    CXX_EXTENSIONS OFF
     VERSION ${NANODBC_VERSION}
-    COMPILE_FLAGS "-DSIZEOF_LONG_INT=8")
+  )
+
   add_test(NAME ${test_name} COMMAND ${test_name})
 
-  set_tests_properties(${test_name} PROPERTIES
-    ENVIRONMENT "NANODBC_TEST_DATADIR=${CMAKE_CURRENT_SOURCE_DIR}/data")
-
-  add_definitions(-DNANODBC_TEST_DATA="${CMAKE_CURRENT_SOURCE_DIR}/data")
-
-  if(NOT CMAKE_GENERATOR MATCHES "^Visual Studio")
-    add_custom_target(${test_item}_test
-      COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R ${test_name})
-    add_custom_target(${test_item}_check
-      COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R ${test_name}
-      DEPENDS ${test_name})
-  endif()
   add_dependencies(tests ${test_name})
 endforeach()

--- a/test/utility_test.cpp
+++ b/test/utility_test.cpp
@@ -3,7 +3,7 @@
 
 // clang-format off
 #define NANODBC_DISABLE_NANODBC_NAMESPACE_FOR_INTERNAL_TESTS
-#include "nanodbc.cpp" // access private conversion routines
+#include "nanodbc/nanodbc.cpp" // access private conversion routines
 // clang-format on
 
 #include <string>


### PR DESCRIPTION
Update cmake to 3.21+ and simplify the logic

Uses the bundled FindODBC and uses dependent options

 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed
