### PR TITLE
headers: Unconditionally include cstdint

### DIFF
--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -96,9 +96,7 @@
 #endif
 #include <vector>
 
-#ifndef __clang__
 #include <cstdint>
-#endif
 
 /// \brief The entirety of nanodbc can be found within this one namespace.
 ///


### PR DESCRIPTION
Hi Team:

This is a revert of 039f6b8d4bea6c5f62c59e29b73434359b45b2a8 I was wondering the motivation for it - but perhaps CI will uncover the reason behind.  Or, hopefully, whatever clang issue we were protecting against back then, has since been addressed.

When trying to build with clang-16 we get
```
error: no type named 'int16_t' in namespace 'std'; did you mean simply 'int16_t'?
```
which in turn is cured by including the `<cstdint>` header / this patch.

Thank you!