### PR TITLE
ci: Move clang-format check to build workflows

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -22,7 +22,28 @@ on:
     - '.github/workflows/ci-linux.yml'
 
 jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        path:
+        - check: 'nanodbc'
+          ignore: ''
+        - check: 'test'
+          ignore: 'catch'
+        - check: 'example'
+          ignore: ''
+    steps:
+    - uses: actions/checkout@v3
+    - uses: jidicula/clang-format-action@v4.11.0
+      with:
+        clang-format-version: '15'
+        check-path: ${{ matrix.path['check'] }}
+        exclude-regex: ${{ matrix.path['ignore'] }}
+
   build-gcc:
+    needs: [check-format]
     strategy:
       fail-fast: false
       matrix:
@@ -83,6 +104,7 @@ jobs:
         cmake --build ${GITHUB_WORKSPACE}/build
 
   build-clang:
+    needs: [check-format]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -21,7 +21,28 @@ on:
     - '.github/workflows/ci-windows.yml'
 
 jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        path:
+        - check: 'nanodbc'
+          ignore: ''
+        - check: 'test'
+          ignore: 'catch'
+        - check: 'example'
+          ignore: ''
+    steps:
+    - uses: actions/checkout@v3
+    - uses: jidicula/clang-format-action@v4.11.0
+      with:
+        clang-format-version: '15'
+        check-path: ${{ matrix.path['check'] }}
+        exclude-regex: ${{ matrix.path['ignore'] }}
+
   build-msvc:
+    needs: [check-format]
     strategy:
       fail-fast: false
       matrix:
@@ -52,12 +73,13 @@ jobs:
         cmake --build ${{ github.workspace }}/build
 
   build-mingw:
-    runs-on: windows-latest
+    needs: [check-format]
     strategy:
       fail-fast: false
       matrix:
         include:
         - { cxxstd: '14', configuration: Release, warnings-as-errors: 'OFF' }
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
     - name: Install MinGW

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,25 +9,7 @@ on:
   pull_request:
 
 jobs:
-  sources:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        path:
-        - check: 'nanodbc'
-          ignore: ''
-        - check: 'test'
-          ignore: 'catch'
-        - check: 'example'
-          ignore: ''
-    steps:
-    - uses: actions/checkout@v3
-    - uses: jidicula/clang-format-action@v4.10.2
-      with:
-        clang-format-version: '15'
-        check-path: ${{ matrix.path['check'] }}
-        exclude-regex: ${{ matrix.path['ignore'] }}
+  # source code format checked before builds by ci-{linux,windows}.yml
 
   documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Require clang-format conformance before continuing with builds.
This should save GHA time on unnecessary builds.
