### PR TITLE
Standardize get_info() return types

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1412,9 +1412,9 @@ string connection::connection_impl::database_name() const
 }
 
 template string connection::get_info(short info_type) const;
-template unsigned short connection::get_info(short info_type) const;
-template uint32_t connection::get_info(short info_type) const;
-template uint64_t connection::get_info(short info_type) const;
+template SQLUSMALLINT short connection::get_info(short info_type) const;
+template SQLUINTEGER connection::get_info(short info_type) const;
+template SQLULEN connection::get_info(short info_type) const;
 
 } // namespace nanodbc
 

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1362,16 +1362,16 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(!connection.get_info<nanodbc::string>(SQL_ODBC_VER).empty());
 
         // Test SQLUSMALLINT results
-        REQUIRE(connection.get_info<unsigned short>(SQL_NON_NULLABLE_COLUMNS) == SQL_NNC_NON_NULL);
+        REQUIRE(connection.get_info<SQLUSMALLINT>(SQL_NON_NULLABLE_COLUMNS) == SQL_NNC_NON_NULL);
 
-        // Test SQUINTEGER results
-        REQUIRE(connection.get_info<uint32_t>(SQL_ODBC_INTERFACE_CONFORMANCE) > 0);
+        // Test SQLUINTEGER results
+        REQUIRE(connection.get_info<SQLUINTEGER>(SQL_ODBC_INTERFACE_CONFORMANCE) > 0);
 
-        // Test SQUINTEGER bitmask results
-        REQUIRE((connection.get_info<uint32_t>(SQL_CREATE_TABLE) & SQL_CT_CREATE_TABLE));
+        // Test SQLUINTEGER bitmask results
+        REQUIRE((connection.get_info<SQLUINTEGER>(SQL_CREATE_TABLE) & SQL_CT_CREATE_TABLE));
 
         // Test SQLULEN results
-        REQUIRE(connection.get_info<uint64_t>(SQL_DRIVER_HDBC) > 0);
+        REQUIRE(connection.get_info<SQLULEN>(SQL_DRIVER_HDBC) > 0);
     }
 
     template <class T>


### PR DESCRIPTION
## What does this PR do?

Use the official return types in `get_info()`, as in the docs. See
https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetinfo-function?view=sql-server-ver16

> InfoValuePtr
> [Output] Pointer to a buffer in which to return the information.
> Depending on the InfoType requested, the information returned will
> be one of the following: a null-terminated character string, an
> SQLUSMALLINT value, an SQLUINTEGER bitmask, an SQLUINTEGER flag,
> a SQLUINTEGER binary value, or a SQLULEN value.

It seems better to use these types instead of matching them to the C data types, which can be platform dependent. For example SQLUINTEGER is currently different on Linux and Windows. Specifying the wrong type can cause undefined behavior and crashes, see e.g. https://github.com/r-dbi/odbc/pull/677

## What are related issues/pull requests?

None.

## Tasklist

 - [x] Add test case(s) (they were already there)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* DBMS name/version:
* ODBC connection string:
* OS and Compiler:
