### PR TITLE
more frugal with calls to SQLDescribeParam

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2071,6 +2071,11 @@ public:
 
     unsigned long parameter_size(short param_index) const
     {
+        if (!param_descr_data_.count(param_index))
+        {
+            return static_cast<unsigned long>(param_descr_data_.at(param_index).size_);
+        }
+
         RETCODE rc;
         SQLSMALLINT data_type;
         SQLSMALLINT nullable;
@@ -2140,21 +2145,17 @@ public:
                 rc,
                 stmt_,
                 static_cast<SQLUSMALLINT>(param_index + 1),
-                &param.type_,
-                &param.size_,
-                &param.scale_,
+                &param_descr_data_[param_index].type_,
+                &param_descr_data_[param_index].size_,
+                &param_descr_data_[param_index].scale_,
                 &nullable);
             if (!success(rc))
                 NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
         }
-        else
-        {
-            param.type_ = param_descr_data_[param_index].type_;
-            param.size_ = param_descr_data_[param_index].size_;
-            param.scale_ = param_descr_data_[param_index].scale_;
-        }
-
         param.index_ = param_index;
+        param.type_ = param_descr_data_[param_index].type_;
+        param.size_ = param_descr_data_[param_index].size_;
+        param.scale_ = param_descr_data_[param_index].scale_;
         param.iotype_ = param_type_from_direction(direction);
 
         if (!bind_len_or_null_.count(param_index))


### PR DESCRIPTION
Hi @mloskot @lexicalunit 

I was hoping you wouldn't mind taking a look.

Previously:
* If user explicitly called the `describe_parameters` endpoint, we would forego calls to `SQLDescribeParam`.  That's great.
* However, if they did not, every time `prepare_bind` was called for the same parameter we would happily keep on executing `SQLDescribeParam` over and over again, despite, after the first call having all the information we need.

With this update:
* The first time the we bind to a parameter and we call `SQLDescribeParam`, we store off those results so that we can avoid the API calls in the future.

Let me know if you think this necessitates  an additional call to `reset_parameters` somewhere ( currently called when the statement is destroyed ).

This helps with some odd-ball SIMBA/SQL Server drivers we came across recently, where repeated `SQLDescribeParam` calls for the same parameter return incoherent results.

Thanks!