### PR TITLE
SQL_NOUNICODEMAP define position changed before including sqlext.h

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -76,6 +76,15 @@ struct is_optional<std::optional<T>> : std::true_type
 #include <windows.h>
 #endif
 
+#if defined(_MSC_VER)
+#ifndef NANODBC_ENABLE_UNICODE
+// Disable unicode in sqlucode.h on Windows when NANODBC_ENABLE_UNICODE
+// is not defined. This is required because unicode is enabled by
+// default on many Windows systems.
+#define SQL_NOUNICODEMAP
+#endif
+#endif
+
 #include <sql.h>
 #include <sqlext.h>
 
@@ -204,15 +213,6 @@ using nanodbc::wide_string;
 #define NANODBC_CODECVT_TYPE std::codecvt_utf8_utf16
 #else
 #define NANODBC_CODECVT_TYPE std::codecvt_utf8_utf16
-#endif
-#endif
-
-#if defined(_MSC_VER)
-#ifndef NANODBC_ENABLE_UNICODE
-// Disable unicode in sqlucode.h on Windows when NANODBC_ENABLE_UNICODE
-// is not defined. This is required because unicode is enabled by
-// default on many Windows systems.
-#define SQL_NOUNICODEMAP
 #endif
 #endif
 


### PR DESCRIPTION
## What does this PR do?

When building nanodbc in visual studio under "Use Unicode Character Set", compile errors occur on sqlext functions. 
This PR fixes the problem by defining SQL_NOUNICODEMAP before including sqlext.h

## What are related issues/pull requests?

None

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [x] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* DBMS name/version:
* ODBC connection string:
* OS and Compiler:
