### PR TITLE
get_info: zero-initialize numeric return value

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1346,7 +1346,10 @@ public:
     void rollback(bool onoff) { rollback_ = onoff; }
 
 private:
-    template <class T>
+    template <class T, typename std::enable_if<!is_string<T>::value, int>::type = 0>
+    T get_info_impl(short info_type) const;
+
+    template <class T, typename std::enable_if<is_string<T>::value, int>::type = 0>
     T get_info_impl(short info_type) const;
 
     HENV env_;
@@ -1356,10 +1359,10 @@ private:
     bool rollback_; // if true, this connection is marked for eventual transaction rollback
 };
 
-template <class T>
+template <class T, typename std::enable_if<!is_string<T>::value, int>::type = 0>
 T connection::connection_impl::get_info_impl(short info_type) const
 {
-    T value;
+    T value = 0;
     RETCODE rc;
     NANODBC_CALL_RC(NANODBC_FUNC(SQLGetInfo), rc, dbc_, info_type, &value, 0, nullptr);
     if (!success(rc))
@@ -1367,8 +1370,8 @@ T connection::connection_impl::get_info_impl(short info_type) const
     return value;
 }
 
-template <>
-string connection::connection_impl::get_info_impl<string>(short info_type) const
+template <class T, typename std::enable_if<is_string<T>::value, int>::type = 0>
+T connection::connection_impl::get_info_impl(short info_type) const
 {
     NANODBC_SQLCHAR value[1024] = {0};
     SQLSMALLINT length(0);

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1359,7 +1359,7 @@ private:
     bool rollback_; // if true, this connection is marked for eventual transaction rollback
 };
 
-template <class T, typename std::enable_if<!is_string<T>::value, int>::type = 0>
+template <class T, typename std::enable_if<!is_string<T>::value, int>::type>
 T connection::connection_impl::get_info_impl(short info_type) const
 {
     T value = 0;
@@ -1370,7 +1370,7 @@ T connection::connection_impl::get_info_impl(short info_type) const
     return value;
 }
 
-template <class T, typename std::enable_if<is_string<T>::value, int>::type = 0>
+template <class T, typename std::enable_if<is_string<T>::value, int>::type>
 T connection::connection_impl::get_info_impl(short info_type) const
 {
     NANODBC_SQLCHAR value[1024] = {0};

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1367,6 +1367,12 @@ struct test_case_fixture : public base_test_fixture
         // Test SQUINTEGER results
         REQUIRE(connection.get_info<uint32_t>(SQL_ODBC_INTERFACE_CONFORMANCE) > 0);
 
+        // get_info is robust to a SQUINTEGER InfoType being retrieved
+        // as uint64_t
+        REQUIRE(
+            connection.get_info<uint64_t>(SQL_ODBC_INTERFACE_CONFORMANCE) ==
+            connection.get_info<uint32_t>(SQL_ODBC_INTERFACE_CONFORMANCE));
+
         // Test SQUINTEGER bitmask results
         REQUIRE((connection.get_info<uint32_t>(SQL_CREATE_TABLE) & SQL_CT_CREATE_TABLE));
 


### PR DESCRIPTION
Hi Team:

I was thinking about possible low-touch approaches to resolving the issue highlighted in https://github.com/nanodbc/nanodbc/pull/398.  One way to do that, *I think*, is whenever a user retrieves an `InfoType` returning a numeric value, we should advise them that they should consider using the `uint64_t` flavor of `get_info`.

To make that possible, we need to zero-initialize the return value to make sure that any over-allocated bits are unset; Both on x86/debian/gcc11 as well as x86/macos/clang15 the updated unit test fails highlighting the issue.

Thanks!
