### PR TITLE
statement: Add parameter_scale, _type to complement existing

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2134,36 +2134,46 @@ public:
         return params;
     }
 
-    unsigned long parameter_size(short param_index) const
+    unsigned long parameter_size(short param_index)
     {
-        if (!param_descr_data_.count(param_index))
+        if (param_descr_data_.count(param_index))
         {
             return static_cast<unsigned long>(param_descr_data_.at(param_index).size_);
         }
 
-        RETCODE rc;
-        SQLSMALLINT data_type;
-        SQLSMALLINT nullable;
-        SQLULEN parameter_size;
-
-#if defined(NANODBC_DO_ASYNC_IMPL)
-        disable_async();
-#endif
-
-        NANODBC_CALL_RC(
-            SQLDescribeParam,
-            rc,
-            stmt_,
-            static_cast<SQLUSMALLINT>(param_index + 1),
-            &data_type,
-            &parameter_size,
-            nullptr,
-            &nullable);
-        if (!success(rc))
-            NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
+        describe_parameters(param_index);
+        const SQLULEN& param_size = param_descr_data_.at(param_index).size_;
         NANODBC_ASSERT(
-            parameter_size < static_cast<SQLULEN>(std::numeric_limits<unsigned long>::max()));
-        return static_cast<unsigned long>(parameter_size);
+            param_size < static_cast<SQLULEN>(std::numeric_limits<unsigned long>::max()));
+        return static_cast<unsigned long>(param_size);
+    }
+
+    short parameter_scale(short param_index)
+    {
+        if (param_descr_data_.count(param_index))
+        {
+            return static_cast<short>(param_descr_data_.at(param_index).scale_);
+        }
+
+        describe_parameters(param_index);
+        const SQLSMALLINT& param_scale = param_descr_data_.at(param_index).scale_;
+        NANODBC_ASSERT(
+            param_scale < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        return static_cast<short>(param_scale);
+    }
+
+    short parameter_type(short param_index)
+    {
+        if (param_descr_data_.count(param_index))
+        {
+            return static_cast<short>(param_descr_data_.at(param_index).type_);
+        }
+
+        describe_parameters(param_index);
+        const SQLSMALLINT& param_type = param_descr_data_.at(param_index).type_;
+        NANODBC_ASSERT(
+            param_type < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        return static_cast<unsigned long>(param_type);
     }
 
     static SQLSMALLINT param_type_from_direction(param_direction direction)
@@ -2203,19 +2213,7 @@ public:
 
         if (!param_descr_data_.count(param_index))
         {
-            RETCODE rc;
-            SQLSMALLINT nullable; // unused
-            NANODBC_CALL_RC(
-                SQLDescribeParam,
-                rc,
-                stmt_,
-                static_cast<SQLUSMALLINT>(param_index + 1),
-                &param_descr_data_[param_index].type_,
-                &param_descr_data_[param_index].size_,
-                &param_descr_data_[param_index].scale_,
-                &nullable);
-            if (!success(rc))
-                NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
+            describe_parameters(param_index);
         }
         param.index_ = param_index;
         param.type_ = param_descr_data_[param_index].type_;
@@ -2415,6 +2413,26 @@ public:
             nullptr,     // null value
             0,           // buffe length
             bind_len_or_null_[param.index_].data());
+        if (!success(rc))
+            NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
+    }
+
+    void describe_parameters(const short param_index)
+    {
+        RETCODE rc;
+        SQLSMALLINT nullable; // unused
+#if defined(NANODBC_DO_ASYNC_IMPL)
+        disable_async();
+#endif
+        NANODBC_CALL_RC(
+            SQLDescribeParam,
+            rc,
+            stmt_,
+            static_cast<SQLUSMALLINT>(param_index + 1),
+            &param_descr_data_[param_index].type_,
+            &param_descr_data_[param_index].size_,
+            &param_descr_data_[param_index].scale_,
+            &nullable);
         if (!success(rc))
             NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
     }
@@ -5559,6 +5577,16 @@ void statement::reset_parameters() noexcept
 unsigned long statement::parameter_size(short param_index) const
 {
     return impl_->parameter_size(param_index);
+}
+
+short statement::parameter_scale(short param_index) const
+{
+    return impl_->parameter_scale(param_index);
+}
+
+short statement::parameter_type(short param_index) const
+{
+    return impl_->parameter_type(param_index);
 }
 
 // We need to instantiate each form of bind() for each of our supported data types.

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2157,8 +2157,7 @@ public:
 
         describe_parameters(param_index);
         const SQLSMALLINT& param_scale = param_descr_data_.at(param_index).scale_;
-        NANODBC_ASSERT(
-            param_scale < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        NANODBC_ASSERT(param_scale < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
         return static_cast<short>(param_scale);
     }
 
@@ -2171,8 +2170,7 @@ public:
 
         describe_parameters(param_index);
         const SQLSMALLINT& param_type = param_descr_data_.at(param_index).type_;
-        NANODBC_ASSERT(
-            param_type < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        NANODBC_ASSERT(param_type < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
         return static_cast<unsigned long>(param_type);
     }
 

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1104,6 +1104,12 @@ public:
     /// \brief Returns parameter size for indicated parameter placeholder in a prepared statement.
     unsigned long parameter_size(short param_index) const;
 
+    /// \brief Returns parameter scale for indicated parameter placeholder in a prepared statement.
+    short parameter_scale(short param_index) const;
+
+    /// \brief Returns parameter type for indicated parameter placeholder in a prepared statement.
+    short parameter_type(short param_index) const;
+
     /// \addtogroup binding Binding parameters
     /// \brief These functions are used to bind values to ODBC parameters.
     ///

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -244,6 +244,14 @@ TEST_CASE_METHOD(
     test_batch_insert_describe_param();
 }
 
+TEST_CASE_METHOD(
+    mssql_fixture,
+    "test_param_size_scale_type",
+    "[mssql][param][methods]")
+{
+    test_param_size_scale_type();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_multi_statement_insert_select", "[mssql]")
 {
     nanodbc::connection c = connect();

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -244,10 +244,7 @@ TEST_CASE_METHOD(
     test_batch_insert_describe_param();
 }
 
-TEST_CASE_METHOD(
-    mssql_fixture,
-    "test_param_size_scale_type",
-    "[mssql][param][methods]")
+TEST_CASE_METHOD(mssql_fixture, "test_param_size_scale_type", "[mssql][param][methods]")
 {
     test_param_size_scale_type();
 }

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -2908,6 +2908,37 @@ PRIMARY KEY(t2_fid)
         }
     }
 
+    void test_param_size_scale_type()
+    {
+        auto conn = connect();
+        create_table(
+            conn,
+            NANODBC_TEXT("test_param_size_scale_type"),
+            NANODBC_TEXT("(i int, s varchar(60), f float, d decimal(9, 3))"));
+        nanodbc::string insert(NANODBC_TEXT(
+            "insert into test_param_size_scale_type (i, s, f, d) values(?, ?, ?, ?)"));
+        nanodbc::statement stmt(conn);
+        prepare(stmt, insert);
+
+        //size: For numeirc maximum number of digits
+        REQUIRE(stmt.parameter_size(0) == 10);
+        REQUIRE(stmt.parameter_type(0) == SQL_INTEGER);
+        REQUIRE(stmt.parameter_scale(0) == 0);
+
+        //size: number of characters
+        REQUIRE(stmt.parameter_size(1) == 60);
+        REQUIRE(stmt.parameter_type(1) == SQL_VARCHAR);
+        REQUIRE(stmt.parameter_scale(1) == 0);
+
+        REQUIRE(stmt.parameter_size(2) == 53);
+        REQUIRE(stmt.parameter_type(2) == SQL_FLOAT);
+        REQUIRE(stmt.parameter_scale(2) == 0);
+
+        REQUIRE(stmt.parameter_size(3) == 9);
+        REQUIRE(stmt.parameter_type(3) == SQL_DECIMAL);
+        REQUIRE(stmt.parameter_scale(3) == 3);
+    }
+
     void test_statement_prepare_reuse()
     {
         nanodbc::connection connection = connect();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -2915,17 +2915,17 @@ PRIMARY KEY(t2_fid)
             conn,
             NANODBC_TEXT("test_param_size_scale_type"),
             NANODBC_TEXT("(i int, s varchar(60), f float, d decimal(9, 3))"));
-        nanodbc::string insert(NANODBC_TEXT(
-            "insert into test_param_size_scale_type (i, s, f, d) values(?, ?, ?, ?)"));
+        nanodbc::string insert(
+            NANODBC_TEXT("insert into test_param_size_scale_type (i, s, f, d) values(?, ?, ?, ?)"));
         nanodbc::statement stmt(conn);
         prepare(stmt, insert);
 
-        //size: For numeirc maximum number of digits
+        // size: For numeirc maximum number of digits
         REQUIRE(stmt.parameter_size(0) == 10);
         REQUIRE(stmt.parameter_type(0) == SQL_INTEGER);
         REQUIRE(stmt.parameter_scale(0) == 0);
 
-        //size: number of characters
+        // size: number of characters
         REQUIRE(stmt.parameter_size(1) == 60);
         REQUIRE(stmt.parameter_type(1) == SQL_VARCHAR);
         REQUIRE(stmt.parameter_scale(1) == 0);


### PR DESCRIPTION
Hi @mloskot @lexicalunit 

When you get a chance hope you can take a look at this.

1. Fixes a bug in `parameter_size` that I introduced in https://github.com/nanodbc/nanodbc/commit/7c4b142084a959b1e52adc1314af1322186e96ef Note the `if (!param_descr_data_.count(param_index))` call.
3. Adds `statement::parameter_type`, `statement::parameter_scale` methods to complement `parameter_size`.
4. For all three ( including existing `parameter_size` ): if needing to making a call to `SQLDescribeParam` to answer the user, make sure the results are recorded in the internal  `param_descr_data_` map, to prevent future roundtrips when answering the same question ( for example when subsequently binding data to the statement ).
5. Added unit test for all three that would have caught bug fixed in 1.

On 3: to make this happen needed to change the internal `statement_impl::parameter_size` to non-const.  Note the compiler is happy to keep the external  facing methods ( `statement::*` ) as `const`, but it does feel like I am obfuscating something.  Let me know if you have any thoughts - but I am hoping we can somehow retain the "if have to reach out to DB, will make sure to retain that information" portion.