### PR TITLE
tvp: complete parameter_* API

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2171,7 +2171,7 @@ public:
         describe_parameters(param_index);
         const SQLSMALLINT& param_type = param_descr_data_.at(param_index).type_;
         NANODBC_ASSERT(param_type < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
-        return static_cast<unsigned long>(param_type);
+        return static_cast<short>(param_type);
     }
 
     static SQLSMALLINT param_type_from_direction(param_direction direction)
@@ -3115,6 +3115,48 @@ public:
             param_descr_data_[idx[i]].index_ = static_cast<SQLUSMALLINT>(i);
             param_descr_data_[idx[i]].iotype_ = SQL_PARAM_INPUT;
         }
+    }
+
+    short parameters() const { return param_descr_data_.size(); }
+
+    unsigned long parameter_size(short param_index)
+    {
+        if (param_descr_data_.count(param_index))
+        {
+            return static_cast<unsigned long>(param_descr_data_.at(param_index).size_);
+        }
+
+        prepare_tvp_param_all();
+        const SQLULEN& param_size = param_descr_data_.at(param_index).size_;
+        NANODBC_ASSERT(
+            param_size < static_cast<SQLULEN>(std::numeric_limits<unsigned long>::max()));
+        return static_cast<unsigned long>(param_size);
+    }
+
+    short parameter_scale(short param_index)
+    {
+        if (param_descr_data_.count(param_index))
+        {
+            return static_cast<short>(param_descr_data_.at(param_index).scale_);
+        }
+
+        prepare_tvp_param_all();
+        const SQLSMALLINT& param_scale = param_descr_data_.at(param_index).scale_;
+        NANODBC_ASSERT(param_scale < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        return static_cast<short>(param_scale);
+    }
+
+    short parameter_type(short param_index)
+    {
+        if (param_descr_data_.count(param_index))
+        {
+            return static_cast<short>(param_descr_data_.at(param_index).type_);
+        }
+
+        prepare_tvp_param_all();
+        const SQLSMALLINT& param_type = param_descr_data_.at(param_index).type_;
+        NANODBC_ASSERT(param_type < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        return static_cast<short>(param_type);
     }
 
     // comparator for null sentry values
@@ -6351,6 +6393,26 @@ void table_valued_parameter::describe_parameters(
     const std::vector<short>& scale)
 {
     impl_->describe_parameters(idx, type, size, scale);
+}
+
+short table_valued_parameter::parameters() const
+{
+    return impl_->parameters();
+}
+
+unsigned long table_valued_parameter::parameter_size(short param_index) const
+{
+    return impl_->parameter_size(param_index);
+}
+
+short table_valued_parameter::parameter_scale(short param_index) const
+{
+    return impl_->parameter_scale(param_index);
+}
+
+short table_valued_parameter::parameter_type(short param_index) const
+{
+    return impl_->parameter_type(param_index);
 }
 } // namespace nanodbc
 #endif // NANODBC_DISABLE_MSSQL_TVP

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -752,6 +752,19 @@ public:
         const std::vector<unsigned long>& size,
         const std::vector<short>& scale);
 
+    /// \brief Returns the number of columns in the table valued parameter.
+    /// \throws database_error
+    short parameters() const;
+
+    /// \brief Returns parameter size for indicated column in the TVP.
+    unsigned long parameter_size(short param_index) const;
+
+    /// \brief Returns parameter scale for indicated column in the TVP.
+    short parameter_scale(short param_index) const;
+
+    /// \brief Returns parameter type for indicated column in the TVP.
+    short parameter_type(short param_index) const;
+
 private:
     class table_valued_parameter_impl;
     friend class statement;


### PR DESCRIPTION
Hello!

This completes the `parameter_*` API for table_valued_parameter, needed to extend the method overlap with objects of type `statement`.   Allows downstream libraries to write templated code where the type could be either a `statement` or `table_valued_parameter`.  For example:

```
template<typename T>
void bind_datetime(T& obj, short idx, ... )  {
  ...
  auto precision = obj.parameter_scale(idx);
  ...
  obj.bind( ... );
}
```
For what is worth, I think parameters are described when the `table_valued_parameter` is instantiated, so there is no chance, at least today, that we would need to hit the `prepare_tvp_apram_all` fallback.

Let me know if you think it warrants a unit test.