### PR TITLE
bugfix: describe_data: if unsuccesful cleanup

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2432,7 +2432,10 @@ public:
             &param_descr_data_[param_index].scale_,
             &nullable);
         if (!success(rc))
+        {
+            param_descr_data_.erase(param_index);
             NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
+        }
     }
 
     void describe_parameters(


### PR DESCRIPTION
Hi @lexicalunit , @mloskot 

This fixes a bug in `describe_parameters`.  Previously, if unsuccessful in retrieving a parameter description, we would leave the garbage `param_descr_data_[idx]` entry in the map.  However,  throughout the code we assume that if `idx` is present in the `param_descr_data_`, it is good to use (I think I've introduced, or at least promoted that use pattern so my bad).

