### PR TITLE
Add bind/handling for DB2 XML

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -99,6 +99,9 @@ struct is_optional<std::optional<T>> : std::true_type
 #endif
 
 // Driver specific SQL data type defines.
+#ifndef SQL_DB2_XML
+#define SQL_DB2_XML (-370)
+#endif
 // Microsoft has -150 thru -199 reserved for Microsoft SQL Server Native Client driver usage.
 // Originally, defined in sqlncli.h (old SQL Server Native Client driver)
 // and msodbcsql.h (new Microsoft ODBC Driver for SQL Server)
@@ -4094,6 +4097,7 @@ private:
             case SQL_VARBINARY:
             case SQL_LONGVARBINARY:
             case SQL_SS_UDT: // MSDN: Essentially, UDT is a varbinary type with additional metadata.
+            case SQL_DB2_XML:
                 col.ctype_ = SQL_C_BINARY;
                 col.blob_ = true;
                 col.clen_ = 0;


### PR DESCRIPTION
Hi:

Please consider this commit adding support for handling DB2/XML data.  I am not sure what the philosophy is for enumerating and handling all driver specific data types;  Happy to try and come up with a different solution or only carry this locally.

cc: @nattomi
https://www.ibm.com/docs/en/db2-for-zos/13.0.0?topic=xdioa-xml-data-retrieval-in-odbc-applications