### PR TITLE
Feature/deatetimeoffset support

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -743,6 +743,12 @@ struct sql_ctype<nanodbc::timestamp>
     static const SQLSMALLINT value = SQL_C_TIMESTAMP;
 };
 
+template <>
+struct sql_ctype<nanodbc::timestampoffset>
+{
+    static const SQLSMALLINT value = SQL_C_BINARY;
+};
+
 // Encapsulates resources needed for column binding.
 class bound_column
 {
@@ -4083,8 +4089,8 @@ private:
                 }
                 break;
             case SQL_SS_TIMESTAMPOFFSET:
-                col.ctype_ = sql_ctype<wide_string>::value;
-                col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLWCHAR);
+                col.ctype_ = SQL_C_BINARY;
+                col.clen_ = sizeof(timestampoffset);
                 break;
             case SQL_LONGVARCHAR:
                 col.ctype_ = sql_ctype<std::string>::value;
@@ -4214,9 +4220,16 @@ inline void result::result_impl::get_ref_impl<date>(short column, date& result) 
     case SQL_C_TIMESTAMP:
     {
         timestamp stamp = *ensure_pdata<timestamp>(column);
-        date d = {stamp.year, stamp.month, stamp.day};
-        result = d;
+        result = date{stamp.year, stamp.month, stamp.day};
         return;
+    }
+    case SQL_C_BINARY:
+    {
+      if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET) {
+        timestampoffset offsetstamp = *ensure_pdata<timestampoffset>(column);
+        result = date{offsetstamp.stamp.year, offsetstamp.stamp.month, offsetstamp.stamp.day};
+        return;
+      }
     }
     }
     throw type_incompatible_error();
@@ -4234,9 +4247,16 @@ inline void result::result_impl::get_ref_impl<time>(short column, time& result) 
     case SQL_C_TIMESTAMP:
     {
         timestamp stamp = *ensure_pdata<timestamp>(column);
-        time t = {stamp.hour, stamp.min, stamp.sec};
-        result = t;
+        result = time{stamp.hour, stamp.min, stamp.sec};
         return;
+    }
+    case SQL_C_BINARY:
+    {
+      if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET) {
+        timestampoffset tstwoffset = *ensure_pdata<timestampoffset>(column);
+        result = time{tstwoffset.stamp.hour, tstwoffset.stamp.min, tstwoffset.stamp.sec};
+        return;
+      }
     }
     }
     throw type_incompatible_error();
@@ -4251,13 +4271,52 @@ inline void result::result_impl::get_ref_impl<timestamp>(short column, timestamp
     case SQL_C_DATE:
     {
         date d = *ensure_pdata<date>(column);
-        timestamp stamp = {d.year, d.month, d.day, 0, 0, 0, 0};
-        result = stamp;
+        result = timestamp{d.year, d.month, d.day, 0, 0, 0, 0};
         return;
     }
     case SQL_C_TIMESTAMP:
+    {
         result = *ensure_pdata<timestamp>(column);
         return;
+    }
+    case SQL_C_BINARY:
+    {
+      if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET) {
+        timestampoffset tstwoffset = *ensure_pdata<timestampoffset>(column);
+        result = tstwoffset.stamp;
+        return;
+      }
+    }
+    }
+    throw type_incompatible_error();
+}
+
+template <>
+inline void result::result_impl::get_ref_impl<timestampoffset>(short column, timestampoffset& result) const
+{
+    bound_column& col = bound_columns_[column];
+    switch (col.ctype_)
+    {
+    case SQL_C_DATE:
+    {
+        date d = *ensure_pdata<date>(column);
+        timestamp stamp = {d.year, d.month, d.day, 0, 0, 0, 0};
+        result = timestampoffset{stamp, 0, 0};
+        return;
+    }
+    case SQL_C_TIMESTAMP:
+    {
+        timestamp stamp = *ensure_pdata<timestamp>(column);
+        result = timestampoffset{stamp, 0, 0};
+        return;
+    }
+    case SQL_C_BINARY:
+    {
+      if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET) {
+        result = *ensure_pdata<timestampoffset>(column);
+        return;
+      }
+    }
     }
     throw type_incompatible_error();
 }
@@ -7576,6 +7635,7 @@ template wide_string result::get(short) const;
 template date result::get(short) const;
 template time result::get(short) const;
 template timestamp result::get(short) const;
+template timestampoffset result::get(short) const;
 template std::vector<std::uint8_t> result::get(short) const;
 #if defined(_MSC_VER)
 template _variant_t result::get(short) const;
@@ -7598,6 +7658,7 @@ template wide_string result::get(string const&) const;
 template date result::get(string const&) const;
 template time result::get(string const&) const;
 template timestamp result::get(string const&) const;
+template timestampoffset result::get(string const&) const;
 template std::vector<std::uint8_t> result::get(string const&) const;
 #if defined(_MSC_VER)
 template _variant_t result::get(string const&) const;
@@ -7668,6 +7729,7 @@ template wide_string result::get(short, const wide_string&) const;
 template date result::get(short, const date&) const;
 template time result::get(short, const time&) const;
 template timestamp result::get(short, const timestamp&) const;
+template timestampoffset result::get(short, const timestampoffset&) const;
 template std::vector<std::uint8_t> result::get(short, const std::vector<std::uint8_t>&) const;
 #if defined(_MSC_VER)
 template _variant_t result::get(short, _variant_t const&) const;
@@ -7690,6 +7752,7 @@ template wide_string result::get(string const&, const wide_string&) const;
 template date result::get(string const&, const date&) const;
 template time result::get(string const&, const time&) const;
 template timestamp result::get(string const&, const timestamp&) const;
+template timestampoffset result::get(string const&, const timestampoffset&) const;
 template std::vector<std::uint8_t>
 result::get(string const&, const std::vector<std::uint8_t>&) const;
 #if defined(_MSC_VER)

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4227,7 +4227,7 @@ inline void result::result_impl::get_ref_impl<date>(short column, date& result) 
     {
         if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET)
         {
-            timestampoffset offsetstamp = *ensure_pdata<timestampoffset>(column);
+            const timestampoffset offsetstamp = *ensure_pdata<timestampoffset>(column);
             result = date{offsetstamp.stamp.year, offsetstamp.stamp.month, offsetstamp.stamp.day};
             return;
         }
@@ -4255,8 +4255,8 @@ inline void result::result_impl::get_ref_impl<time>(short column, time& result) 
     {
         if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET)
         {
-            timestampoffset tstwoffset = *ensure_pdata<timestampoffset>(column);
-            result = time{tstwoffset.stamp.hour, tstwoffset.stamp.min, tstwoffset.stamp.sec};
+            const timestampoffset offsetstamp = *ensure_pdata<timestampoffset>(column);
+            result = time{offsetstamp.stamp.hour, offsetstamp.stamp.min, offsetstamp.stamp.sec};
             return;
         }
     }
@@ -4272,7 +4272,7 @@ inline void result::result_impl::get_ref_impl<timestamp>(short column, timestamp
     {
     case SQL_C_DATE:
     {
-        date d = *ensure_pdata<date>(column);
+        const date d = *ensure_pdata<date>(column);
         result = timestamp{d.year, d.month, d.day, 0, 0, 0, 0};
         return;
     }
@@ -4303,14 +4303,14 @@ result::result_impl::get_ref_impl<timestampoffset>(short column, timestampoffset
     {
     case SQL_C_DATE:
     {
-        date d = *ensure_pdata<date>(column);
-        timestamp stamp = {d.year, d.month, d.day, 0, 0, 0, 0};
+        const date d = *ensure_pdata<date>(column);
+        const timestamp stamp = {d.year, d.month, d.day, 0, 0, 0, 0};
         result = timestampoffset{stamp, 0, 0};
         return;
     }
     case SQL_C_TIMESTAMP:
     {
-        timestamp stamp = *ensure_pdata<timestamp>(column);
+        const timestamp stamp = *ensure_pdata<timestamp>(column);
         result = timestampoffset{stamp, 0, 0};
         return;
     }

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4225,11 +4225,12 @@ inline void result::result_impl::get_ref_impl<date>(short column, date& result) 
     }
     case SQL_C_BINARY:
     {
-      if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET) {
-        timestampoffset offsetstamp = *ensure_pdata<timestampoffset>(column);
-        result = date{offsetstamp.stamp.year, offsetstamp.stamp.month, offsetstamp.stamp.day};
-        return;
-      }
+        if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET)
+        {
+            timestampoffset offsetstamp = *ensure_pdata<timestampoffset>(column);
+            result = date{offsetstamp.stamp.year, offsetstamp.stamp.month, offsetstamp.stamp.day};
+            return;
+        }
     }
     }
     throw type_incompatible_error();
@@ -4252,11 +4253,12 @@ inline void result::result_impl::get_ref_impl<time>(short column, time& result) 
     }
     case SQL_C_BINARY:
     {
-      if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET) {
-        timestampoffset tstwoffset = *ensure_pdata<timestampoffset>(column);
-        result = time{tstwoffset.stamp.hour, tstwoffset.stamp.min, tstwoffset.stamp.sec};
-        return;
-      }
+        if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET)
+        {
+            timestampoffset tstwoffset = *ensure_pdata<timestampoffset>(column);
+            result = time{tstwoffset.stamp.hour, tstwoffset.stamp.min, tstwoffset.stamp.sec};
+            return;
+        }
     }
     }
     throw type_incompatible_error();
@@ -4281,18 +4283,20 @@ inline void result::result_impl::get_ref_impl<timestamp>(short column, timestamp
     }
     case SQL_C_BINARY:
     {
-      if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET) {
-        timestampoffset tstwoffset = *ensure_pdata<timestampoffset>(column);
-        result = tstwoffset.stamp;
-        return;
-      }
+        if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET)
+        {
+            timestampoffset tstwoffset = *ensure_pdata<timestampoffset>(column);
+            result = tstwoffset.stamp;
+            return;
+        }
     }
     }
     throw type_incompatible_error();
 }
 
 template <>
-inline void result::result_impl::get_ref_impl<timestampoffset>(short column, timestampoffset& result) const
+inline void
+result::result_impl::get_ref_impl<timestampoffset>(short column, timestampoffset& result) const
 {
     bound_column& col = bound_columns_[column];
     switch (col.ctype_)
@@ -4312,10 +4316,11 @@ inline void result::result_impl::get_ref_impl<timestampoffset>(short column, tim
     }
     case SQL_C_BINARY:
     {
-      if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET) {
-        result = *ensure_pdata<timestampoffset>(column);
-        return;
-      }
+        if (col.sqltype_ == SQL_SS_TIMESTAMPOFFSET)
+        {
+            result = *ensure_pdata<timestampoffset>(column);
+            return;
+        }
     }
     }
     throw type_incompatible_error();

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -407,9 +407,9 @@ struct timestamp
 /// \brief A type for representing timestamp+offset data.
 struct timestampoffset
 {
-    timestamp    stamp;
-    std::int16_t offset_hour;     ///< Whole hour part of time zone offset
-    std::int16_t offset_minute;   ///< Minutes part of time zome offset
+    timestamp stamp;
+    std::int16_t offset_hour;   ///< Whole hour part of time zone offset
+    std::int16_t offset_minute; ///< Minutes part of time zome offset
 };
 
 #ifdef NANODBC_HAS_STD_VARIANT

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -404,6 +404,14 @@ struct timestamp
     std::int32_t fract; ///< Fractional seconds.
 };
 
+/// \brief A type for representing timestamp+offset data.
+struct timestampoffset
+{
+    timestamp    stamp;
+    std::int16_t offset_hour;     ///< Whole hour part of time zone offset
+    std::int16_t offset_minute;   ///< Minutes part of time zome offset
+};
+
 #ifdef NANODBC_HAS_STD_VARIANT
 /// \brief A class representing a connection or a statement attribute.
 ///

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1325,6 +1325,29 @@ TEST_CASE_METHOD(mssql_fixture, "test_datetimeoffset", "[mssql][datetime]")
     }
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_datetimeoffset2", "[mssql][datetimeoffset]")
+{
+#ifndef SQL_SS_TIMESTAMPOFFSET
+#define SQL_SS_TIMESTAMPOFFSET (-155)
+#endif
+    auto connection = connect();
+    auto result = execute(connection, NANODBC_TEXT("SELECT CONVERT(datetimeoffset, '2006-12-30T13:45:12.345-08:30', 127) AS offsettimestamp;"));
+    REQUIRE(result.column_name(0) == NANODBC_TEXT("offsettimestamp"));
+    REQUIRE(result.column_datatype(0) == SQL_SS_TIMESTAMPOFFSET);
+    REQUIRE(result.column_datatype_name(0) == NANODBC_TEXT("datetimeoffset"));
+    REQUIRE(result.next());
+    auto t = result.get<nanodbc::timestampoffset>(0);
+    REQUIRE(t.stamp.year == 2006);
+    REQUIRE(t.stamp.month == 12);
+    REQUIRE(t.stamp.day == 30);
+    REQUIRE(t.stamp.hour == 13);
+    REQUIRE(t.stamp.min == 45);
+    REQUIRE(t.stamp.sec == 12);
+    REQUIRE(t.stamp.fract > 0);
+    REQUIRE(t.offset_hour == -8);
+    REQUIRE(t.offset_minute == -30);
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_rowversion", "[mssql][rowversion][timestamp]")
 {
     // The rowversion data type is not a date or time data type, but

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1331,7 +1331,10 @@ TEST_CASE_METHOD(mssql_fixture, "test_datetimeoffset2", "[mssql][datetimeoffset]
 #define SQL_SS_TIMESTAMPOFFSET (-155)
 #endif
     auto connection = connect();
-    auto result = execute(connection, NANODBC_TEXT("SELECT CONVERT(datetimeoffset, '2006-12-30T13:45:12.345-08:30', 127) AS offsettimestamp;"));
+    auto result = execute(
+        connection,
+        NANODBC_TEXT("SELECT CONVERT(datetimeoffset, '2006-12-30T13:45:12.345-08:30', 127) AS "
+                     "offsettimestamp;"));
     REQUIRE(result.column_name(0) == NANODBC_TEXT("offsettimestamp"));
     REQUIRE(result.column_datatype(0) == SQL_SS_TIMESTAMPOFFSET);
     REQUIRE(result.column_datatype_name(0) == NANODBC_TEXT("datetimeoffset"));


### PR DESCRIPTION
Hi all:

This closes https://github.com/nanodbc/nanodbc/issues/379.  It's an attempt to implement @mloskot 's suggestions on how to make it possible to support `datetimeoffset` natively.

I could be wrong about this, but If merged, I think this would be a breaking change in the sense that it would no longer be possible to retrieve these columns using the character getters - i left the old unit test (`test_datetimeoffset` vs `test_datetimeoffset2`) to see what happens in CI.  Let me know if you have any suggestions on how to handle this.

Cheers!