### PR TITLE
Remove `std::char_traits` usage

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -334,8 +334,14 @@ constexpr std::size_t size(const T (&array)[N]) noexcept
 template <std::size_t N>
 inline std::size_t size(NANODBC_SQLCHAR const (&array)[N]) noexcept
 {
-    auto const n = std::char_traits<NANODBC_SQLCHAR>::length(array);
+    std::size_t len = 0;
+    NANODBC_SQLCHAR const* s = array;
+    for (; *s != '\0'; ++s)
+        ++len;
+
+    std::size_t const n = len;
     NANODBC_ASSERT(n < N);
+
     return n < N ? n : N - 1;
 }
 
@@ -4982,9 +4988,9 @@ std::list<datasource> list_datasources()
                 "incompatible SQLCHAR and string::value_type");
 
             datasource dsn;
-            dsn.name = string(&name[0], &name[std::char_traits<NANODBC_SQLCHAR>::length(name)]);
+            dsn.name = string(&name[0], &name[size(name)]);
             dsn.driver =
-                string(&driver[0], &driver[std::char_traits<NANODBC_SQLCHAR>::length(driver)]);
+                string(&driver[0], &driver[size(driver)]);
 
             dsns.push_back(std::move(dsn));
             direction = SQL_FETCH_NEXT;
@@ -5035,7 +5041,7 @@ std::list<driver> list_drivers()
                 "incompatible SQLCHAR and string::value_type");
 
             driver drv;
-            drv.name = string(&descr[0], &descr[std::char_traits<NANODBC_SQLCHAR>::length(descr)]);
+            drv.name = string(&descr[0], &descr[size(descr)]);
 
             // Split "Key1=Value1\0Key2=Value2\0\0" into list of key-value pairs
             auto beg = &attrs[0];
@@ -5930,7 +5936,7 @@ implementation_row_descriptor::sql_get_descr_field::operator string() const
     NANODBC_ASSERT(len % sizeof(NANODBC_SQLCHAR) == 0);
     len = len / sizeof(NANODBC_SQLCHAR);
 
-    NANODBC_ASSERT(len <= std::char_traits<NANODBC_SQLCHAR>::length(value));
+    NANODBC_ASSERT(len <= size(value));
     return {&value[0], &value[len]};
 }
 

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4989,8 +4989,7 @@ std::list<datasource> list_datasources()
 
             datasource dsn;
             dsn.name = string(&name[0], &name[size(name)]);
-            dsn.driver =
-                string(&driver[0], &driver[size(driver)]);
+            dsn.driver = string(&driver[0], &driver[size(driver)]);
 
             dsns.push_back(std::move(dsn));
             direction = SQL_FETCH_NEXT;


### PR DESCRIPTION
## What does this PR do?
Instead of using `std::char_traits`, calculate string byte count ourselves.
Upstreams our version of a fix https://github.com/ClickHouse/nanodbc/commit/69a9376d033e1fcf483a08e2feb9f09399cf56b6

https://releases.llvm.org/19.1.0/projects/libcxx/docs/ReleaseNotes.html#deprecations-and-removals
>The base template for std::char_traits has been removed in LLVM 19

## What are related issues/pull requests?
https://github.com/nanodbc/nanodbc/issues/387

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* DBMS name/version:
* ODBC connection string:
* OS and Compiler:
