### PR TITLE
fix setting query timeout

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1792,7 +1792,7 @@ public:
         // so only raise the error if a non-default timeout was requested.
         try
         {
-            this->set_attribute(SQL_ATTR_QUERY_TIMEOUT, 0, &timeout);
+            this->set_attribute(SQL_ATTR_QUERY_TIMEOUT, 0, (void*)(std::intptr_t)timeout);
         }
         catch (...)
         {


### PR DESCRIPTION
`SQLSetStmtAttr` expects data as pointer, no pointer to data for `SQL_ATTR_QUERY_TIMEOUT`.

## What does this PR do?

Fix a bug

## What are related issues/pull requests?

None

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
