### PR TITLE
Fix MS Access/Excel/CSV ODBC driver support

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2453,8 +2453,12 @@ public:
             &nullable);
         if (!success(rc))
         {
-            param_descr_data_.erase(param_index);
-            NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
+            // Fallback to binding as VARCHAR if SQLDescribeParam fails.
+            // This is necessary to support ODBC drivers that don't implement SQLDescribeParam,
+            // such as Microsoft Access, Excel, and CSV drivers.
+            param_descr_data_[param_index].type_ = SQL_VARCHAR;
+            param_descr_data_[param_index].size_ = 255;
+            param_descr_data_[param_index].scale_ = 0;
         }
     }
 


### PR DESCRIPTION
Microsoft non-SQL ODBC drivers do not implement SQLDescribeParam, causing parameter binding to fail. This adds a fallback to SQL_VARCHAR with size 255 when SQLDescribeParam fails, allowing these drivers to work with nanodbc.

## What does this PR do?

Instead of directly failing when the driver does not support SQLDescribeParam, this provides a fallback value.  This behavior mimics that of R-DBI

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

