### PR TITLE
Test the current compilers instead of retired ones

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -42,139 +42,71 @@ jobs:
           check-path: ${{ matrix.path['check'] }}
           exclude-regex: ${{ matrix.path['ignore'] }}
 
+  # GCC 13 through 16, the current release and the three before it. Ubuntu 26.04 is the
+  # only image carrying that range, and its runner is still a preview, so it is used as a
+  # container on a stable runner instead.
   build-gcc:
     needs: [check-format]
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # TODO: Compilation with GCC 12 fails with errors related to char8_t conversions
-          #- { cxxstd: '20', cxx: g++-12, cc: gcc-12, os: ubuntu-22.04 }
-          #- { cxxstd: '17', cxx: g++-12, cc: gcc-12, os: ubuntu-22.04 }
-          #- { cxxstd: '14', cxx: g++-12, cc: gcc-12, os: ubuntu-22.04 }
-          #- { cxxstd: '17', cxx: g++-11, cc: gcc-11, os: ubuntu-22.04 }
-          - { cxxstd: "14", cxx: g++-11, cc: gcc-11, os: ubuntu-22.04 }
-          - { cxxstd: "17", cxx: g++-10, cc: gcc-10, os: ubuntu-22.04 }
-          - { cxxstd: "14", cxx: g++-10, cc: gcc-10, os: ubuntu-22.04 }
-          - { cxxstd: "17", cxx: g++-9, cc: gcc-9, os: ubuntu-22.04 }
-          - { cxxstd: "14", cxx: g++-9, cc: gcc-9, os: ubuntu-22.04 }
-
-    name: build-${{ matrix.cc }}-std-${{ matrix.cxxstd }}
-
-    runs-on: ${{ matrix.os }}
-
+        gcc: [16, 15, 14, 13]
+        cxxstd: ["20", "17", "14"]
+    name: build-gcc-${{ matrix.gcc }}-std-${{ matrix.cxxstd }}
+    runs-on: ubuntu-latest
+    container: ubuntu:26.04
     env:
-      CC: ${{ matrix.cc }}
-      CXX: ${{ matrix.cxx }}
-
+      CC: gcc-${{ matrix.gcc }}
+      CXX: g++-${{ matrix.gcc }}
+      DEBIAN_FRONTEND: noninteractive
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install
         run: |
-          sudo apt-get update
-          sudo apt-get install -y curl make ${{ matrix.cxx }}
-      - name: Install CMake
-        run: |
-          curl -OL https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-linux-x86_64.tar.gz
-          tar -xf cmake-3.27.1-linux-x86_64.tar.gz
-          echo "${PWD}/cmake-3.27.1-linux-x86_64/bin" >> $GITHUB_PATH
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates cmake g++-${{ matrix.gcc }} git make unixodbc-dev
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check
         run: |
-          echo && type g++ && which g++ && g++ --version
-          echo CC=${CC} && echo CXX=${CXX} && type ${CXX} && which ${CXX} && ${CXX} --version
-          echo && type cmake && which cmake && cmake --version
+          ${CXX} --version
+          cmake --version
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }}
       - name: Build
         run: |
           cmake --build ${GITHUB_WORKSPACE}/build
 
+  # Clang 19 through 22, on the same basis as the GCC matrix above.
   build-clang:
     needs: [check-format]
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - {
-              cxxstd: "20",
-              cxx: clang++-14,
-              cc: clang-14,
-              os: ubuntu-22.04,
-              pkg: "libc++-14-dev libc++abi-14-dev",
-            }
-          - {
-              cxxstd: "17",
-              cxx: clang++-14,
-              cc: clang-14,
-              os: ubuntu-22.04,
-              pkg: "libc++-14-dev libc++abi-14-dev",
-            }
-          - {
-              cxxstd: "14",
-              cxx: clang++-14,
-              cc: clang-14,
-              os: ubuntu-22.04,
-              pkg: "libc++-14-dev libc++abi-14-dev",
-            }
-          - {
-              cxxstd: "20",
-              cxx: clang++-13,
-              cc: clang-13,
-              os: ubuntu-22.04,
-              pkg: "libc++-13-dev libc++abi-13-dev",
-            }
-          - {
-              cxxstd: "17",
-              cxx: clang++-13,
-              cc: clang-13,
-              os: ubuntu-22.04,
-              pkg: "libc++-13-dev libc++abi-13-dev",
-            }
-          - {
-              cxxstd: "14",
-              cxx: clang++-13,
-              cc: clang-13,
-              os: ubuntu-22.04,
-              pkg: "libc++-13-dev libc++abi-13-dev",
-            }
-
-    name: build-${{ matrix.cc }}-std-${{ matrix.cxxstd }}
-
-    runs-on: ${{ matrix.os }}
-
-    container: ${{matrix.container}}
-
+        clang: [22, 21, 20, 19]
+        cxxstd: ["20", "17", "14"]
+    name: build-clang-${{ matrix.clang }}-std-${{ matrix.cxxstd }}
+    runs-on: ubuntu-latest
+    container: ubuntu:26.04
     env:
-      CC: ${{ matrix.cc }}
-      CXX: ${{ matrix.cxx }}
-
+      CC: clang-${{ matrix.clang }}
+      CXX: clang++-${{ matrix.clang }}
+      DEBIAN_FRONTEND: noninteractive
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Setup container
-        if: matrix.container
-        run: |
-          apt-get update
-          apt-get install -y git python sudo unixodbc-dev
       - name: Install
         run: |
-          sudo apt-get update
-          sudo apt-get purge libc++-dev libc++abi-dev
-          sudo apt-get autoremove
-          sudo apt-get install -y curl make ${{ matrix.cc }} ${{ matrix.pkg }}
-      - name: Install CMake
-        run: |
-          curl -OL https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-linux-x86_64.tar.gz
-          tar -xf cmake-3.27.1-linux-x86_64.tar.gz
-          echo "${PWD}/cmake-3.27.1-linux-x86_64/bin" >> $GITHUB_PATH
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates clang-${{ matrix.clang }} cmake git \
+            libc++-${{ matrix.clang }}-dev libc++abi-${{ matrix.clang }}-dev make unixodbc-dev
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check
         run: |
-          echo && type clang++ && which clang++ && clang++ --version
-          echo CC=${CC} && echo CXX=${CXX} && type ${CXX} && which ${CXX} && ${CXX} --version
-          echo && type cmake && which cmake && cmake --version
+          ${CXX} --version
+          cmake --version
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }}
       - name: Build
         run: |
           cmake --build ${GITHUB_WORKSPACE}/build

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -41,38 +41,23 @@ jobs:
           check-path: ${{ matrix.path['check'] }}
           exclude-regex: ${{ matrix.path['ignore'] }}
 
+  # Visual Studio 2026 and 2022, the two toolsets the runner images provide. No generator
+  # is named, so CMake selects the newest Visual Studio present on each image, which keeps
+  # this working as the images move forward.
   build-msvc:
     needs: [check-format]
     strategy:
       fail-fast: false
       matrix:
+        os: [windows-latest, windows-2022]
+        cxxstd: ["20", "17", "14"]
         include:
-          - {
-              cxxstd: "20",
-              toolset: v143,
-              vs: 2022,
-              architecture: x64,
-              os: windows-2022,
-            }
-          - {
-              cxxstd: "17",
-              toolset: v143,
-              vs: 2022,
-              architecture: x64,
-              os: windows-2022,
-            }
-          - {
-              cxxstd: "14",
-              toolset: v143,
-              vs: 2022,
-              architecture: x64,
-              os: windows-2022,
-            }
-    name: build-vs${{ matrix.vs }}-${{ matrix.toolset }}-std-${{ matrix.cxxstd }}
+          - os: windows-latest
+            vs: 2026
+          - os: windows-2022
+            vs: 2022
+    name: build-vs${{ matrix.vs }}-std-${{ matrix.cxxstd }}
     runs-on: ${{ matrix.os }}
-    env:
-      CC: ${{ matrix.cc }}
-      CXX: ${{ matrix.cxx }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check
@@ -80,10 +65,13 @@ jobs:
           cmake --version
       - name: Configure
         run: |
-          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio ${{ matrix.vs == '2022' && '17' || '16' }} ${{matrix.vs }}" -A ${{ matrix.architecture }} -T ${{ matrix.toolset }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }}
+      - name: Show generator and toolset
+        run: |
+          Select-String -Path ${{ github.workspace }}/build/CMakeCache.txt -Pattern "CMAKE_GENERATOR:|CMAKE_GENERATOR_TOOLSET:|CMAKE_CXX_COMPILER:"
       - name: Build
         run: |
-          cmake --build ${{ github.workspace }}/build
+          cmake --build ${{ github.workspace }}/build --config Release
 
   build-mingw:
     needs: [check-format]


### PR DESCRIPTION
Addresses the first item on the todo list: the commented-out GCC block in `ci-linux.yml`, and what the matrix should cover generally.

## The commented-out block was stale

```yml
# TODO: Compilation with GCC 12 fails with errors related to char8_t conversions
#- { cxxstd: '20', cxx: g++-12, cc: gcc-12, os: ubuntu-22.04 }
```

It does not reproduce. GCC 12 builds nanodbc cleanly at C++14, 17 and 20. The claim is also internally odd: `u8""` only becomes `char8_t` in C++20, so it could not have explained the C++14 and C++17 rows being disabled. The only `u8` literal in the tree is one line in `utility_test.cpp`, already cast around.

So nothing needed fixing — the note had simply gone stale, and it is removed.

## What the matrix covers now

The current release and the three before it, for each compiler, against every standard the library supports:

| | before | after |
|---|---|---|
| GCC | 9, 10, 11 | 13, 14, 15, 16 |
| Clang | 13, 14 | 19, 20, 21, 22 |
| Standards | uneven; some rows 14-only | 14, 17 and 20 for every compiler |

C++14 stays in as the library's minimum. Every one of the 24 combinations was built before this was pushed, so the matrix is known-good rather than hoped-for.

## Two choices worth your review

**Ubuntu 26.04 as a container, not a runner.** It is the only image carrying GCC 13–16 and Clang 19–22, but `ubuntu-26.04` is still flagged *preview* in `actions/runner-images`. Pointing the matrix at a preview runner risks exactly the failure we just cleaned up, where jobs sit queued forever against an image that cannot service them. Running it as `container: ubuntu:26.04` on `ubuntu-latest` gets the same toolchain on a stable runner.

**GCC 16 is a trunk snapshot, not a release.** Ubuntu ships it as `16-20260322-1ubuntu1 ... (experimental) [trunk r16-8246]`. It builds nanodbc cleanly today, so it is a blocking job here, but it tracks a moving target: a snapshot regression would turn the column red for reasons that have nothing to do with this repository. If that happens, either drop the column to 15 or add `continue-on-error: true` to keep it as an early warning. Happy to do the latter pre-emptively if you would rather it never block.

Note the job count goes from 11 to 24. They are compile-only and run in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
