### PR TITLE
Fix the documentation build warnings and bring the README back in line

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,5 +30,3 @@ jobs:
       - name: Build Documentation
         run: make html
         working-directory: ./doc
-    # TODO: Parse warnings
-    # TODO: Deploy to gh-pages without removing existing folders with docs of historical releases

--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ user information, example usage, propaganda, and detailed source level documenta
 
 ## Build Status
 
-| Branch | Linux/OSX                                                                                                                                                             | Windows                                                                                                                                                                   | Coverage                                                                                                               | Coverity                                     |
-| :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------------------------------------- | :------------------------------------------- |
-| `main` | [![main](https://github.com/nanodbc/nanodbc/actions/workflows/ci-linux.yml/badge.svg?branch=main)](https://github.com/nanodbc/nanodbc/actions/workflows/ci-linux.yml) | [![main](https://github.com/nanodbc/nanodbc/actions/workflows/ci-windows.yml/badge.svg?branch=main)](https://github.com/nanodbc/nanodbc/actions/workflows/ci-windows.yml) | [![codecov](https://codecov.io/gh/nanodbc/nanodbc/branch/main/graph/badge.svg)](https://codecov.io/gh/nanodbc/nanodbc) | [![coverity_scan][coverity-badge]][coverity] |
-
-> **Note:** The Coverity status uses the [coverity_scan][nanodbc-coverity] branch.
-> When `main` has had a significant amount of work pushed to it,
-> merge those changes into `coverity_scan` as well to keep the status up to date.
+| Branch | Linux                                                                                                                                                                | Windows                                                                                                                                                                  |
+| :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main` | [![main](https://github.com/nanodbc/nanodbc/actions/workflows/ci-linux.yml/badge.svg?branch=main)](https://github.com/nanodbc/nanodbc/actions/workflows/ci-linux.yml) | [![main](https://github.com/nanodbc/nanodbc/actions/workflows/ci-windows.yml/badge.svg?branch=main)](https://github.com/nanodbc/nanodbc/actions/workflows/ci-windows.yml) |
 
 ## Philosophy
 
@@ -67,8 +63,8 @@ section like the following.
 ```ini
 [sqlite]
 Description             = SQLite3 ODBC Driver
-Setup                   = /usr/lib/libsqlite3odbc-0.93.dylib
-Driver                  = /usr/lib/libsqlite3odbc-0.93.dylib
+Setup                   = /usr/lib/libsqlite3odbc.dylib
+Driver                  = /usr/lib/libsqlite3odbc.dylib
 Threading               = 2
 ```
 
@@ -111,18 +107,21 @@ Use the standard CMake option `-DBUILD_SHARED_LIBS=ON` to build nanodbc as share
 If you need to use the `NANODBC_ENABLE_BOOST=ON` option, you will have to configure your
 environment to use [Boost][boost].
 
-| CMake&nbsp;Option                  | Possible&nbsp;Values | Details                                                                                                                                                    |
-| ---------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NANODBC_DISABLE_ASYNC`            | `OFF` or `ON`        | Disable all async features. May resolve build issues in older ODBC versions.                                                                               |
-| `NANODBC_DISABLE_EXAMPLES`         | `OFF` or `ON`        | Do not build examples.                                                                                                                                     |
-| `NANODBC_DISABLE_INSTALL`          | `OFF` or `ON`        | Do not generate install target.                                                                                                                            |
-| `NANODBC_DISABLE_LIBCXX`           | `OFF` or `ON`        | Do not use libc++, if available on the system.                                                                                                             |
-| `NANODBC_DISABLE_TESTS`            | `OFF` or `ON`        | Do not build tests.                                                                                                                                        |
+| CMake&nbsp;Option                  | Possible&nbsp;Values | Details |
+| -----------------------------------| ---------------------| ------- |
+| `NANODBC_BUILD_EXAMPLES`           | `OFF` or `ON`        | Build examples. On by default when nanodbc is the top level project. |
+| `NANODBC_BUILD_TESTS`              | `OFF` or `ON`        | Build tests. On by default when nanodbc is the top level project. |
+| `NANODBC_DISABLE_ASYNC`            | `OFF` or `ON`        | Disable all async features. May resolve build issues in older ODBC versions. |
+| `NANODBC_DISABLE_MSSQL_TVP`        | `OFF` or `ON`        | Do not use MSSQL table-valued parameters. |
 | `NANODBC_ENABLE_BOOST`             | `OFF` or `ON`        | Use Boost for Unicode string convertions (requires [Boost.Locale][boost-locale]). Workaround to issue [#24](https://github.com/nanodbc/nanodbc/issues/24). |
-| `NANODBC_ENABLE_UNICODE`           | `OFF` or `ON`        | Enable Unicode support. `nanodbc::string` becomes `std::u16string` or `std::u32string`.                                                                    |
-| `NANODBC_ENABLE_WORKAROUND_NODATA` | `OFF` or `ON`        | Enable `SQL_NO_DATA` workaround to issue [#43](https://github.com/nanodbc/nanodbc/issues/43).                                                              |
+| `NANODBC_ENABLE_COVERAGE`          | `OFF` or `ON`        | Enable code coverage analysis. Requires tests to be built. |
+| `NANODBC_ENABLE_UNICODE`           | `OFF` or `ON`        | Enable Unicode support. `nanodbc::string` becomes `std::u16string` or `std::u32string`. |
+| `NANODBC_ENABLE_WORKAROUND_NODATA` | `OFF` or `ON`        | Enable `SQL_NO_DATA` workaround to issue [#43](https://github.com/nanodbc/nanodbc/issues/43). |
+| `NANODBC_FORCE_LIBCXX`             | `OFF` or `ON`        | Force the use of libc++. On by default if the compiler supports it. |
+| `NANODBC_FORCE_WARNINGS_AS_ERROR`  | `OFF` or `ON`        | Treat compiler warnings as errors when building nanodbc. |
+| `NANODBC_GENERATE_INSTALL`         | `OFF` or `ON`        | Generate the install target. On by default when nanodbc is the top level project. |
 | `NANODBC_OVERALLOCATE_CHAR`        | `OFF` or `ON`        | Overallocate auto-bound n/var/char buffers to accomodate retrieving Unicode data in VARCHAR columns [#219](https://github.com/nanodbc/nanodbc/issues/219). |
-| `NANODBC_ODBC_VERSION`             | `SQL_OV_ODBC3[...]`  | Forces ODBC version to use. Default is `SQL_OV_ODBC3_80` if available, otherwise `SQL_OV_ODBC3`.                                                           |
+| `NANODBC_ODBC_VERSION`             | `SQL_OV_ODBC3[...]`  | Forces ODBC version to use. Default is `SQL_OV_ODBC3_80` if available, otherwise `SQL_OV_ODBC3`. |
 
 ### Note About iODBC
 
@@ -221,20 +220,26 @@ The good news is that adding tests is easy!
 
 The tests structure:
 
-- `tests/base_test_fixture.h` includes a set of common test cases.
-- `tests/<database>_test.cpp` is a source code for an independent test program that includes both,
+- `test/base_test_fixture.h` provides the helpers the fixtures share, such as connecting,
+  creating and dropping tables, and reporting which backend is under test.
+- `test/test_case_fixture.h` holds the test cases that run against every backend.
+- `test/<database>_test.cpp` is a source code for an independent test program that includes both,
   common and database-specific test cases.
 
 To add new test case:
 
-1. In `tests/base_test_fixture.h` file, add a new test case method to `base_test_fixture`
+1. In `test/test_case_fixture.h` file, add a new test case method to `test_case_fixture`
    class (e.g. `void my_feature_test()`).
-2. In each `tests/<database>_test.cpp` file, copy and paste the `TEST_CASE_METHOD` boilerplate,
+2. In each `test/<database>_test.cpp` file, copy and paste the `TEST_CASE_METHOD` boilerplate,
    updating name, tags, etc.
 
 If a feature requires a database-specific test case for each database, then skip the
-`tests/base_test_fixture.h` step and write a dedicated test case directly in
-`tests/<database>_test.cpp` file.
+`test/test_case_fixture.h` step and write a dedicated test case directly in
+`test/<database>_test.cpp` file.
+
+The SQLite and utility tests need no server, so they are the quickest way to check a change
+locally. `docker-compose.yml` brings up PostgreSQL, MySQL and SQL Server for the rest; see
+[Quick Setup for Testing or Development Environments](#quick-setup-for-testing-or-development-environments).
 
 ## Publish and Release Process
 
@@ -264,20 +269,6 @@ Next, switch to `gh-pages` branch, build latest documentation, commit and push.
 
 Finally, announce the new release to the public.
 
-## Future work
-
-### Good to Have / Want Someday
-
-- Refactor tests to follow BDD pattern.
-- Update codebase to use more C++14 idioms and patterns.
-- Write more tests with the goal to have much higher code coverage.
-- More tests for a large variety of drivers. Include performance tests.
-- Clean up `bind_*` family of functions, reduce any duplication.
-- Improve documentation: The main website and API docs should be more responsive.
-- Provide more examples in documentation, more details, and point out any gotchas.
-- Versioned generated source level API documentation for `master` and previous releases.
-- Add "HOWTO Build" documentation for Windows, OS X, and Linux.
-
 ---
 
 [MIT][mit] &copy; [lexicalunit, mloskot][authors] and [contributors][contributors].
@@ -287,7 +278,6 @@ Finally, announce the new release to the public.
 [contributors]: https://github.com/nanodbc/nanodbc/graphs/contributors
 [nanodbc]: http://nanodbc.io
 [nanodbc-banner]: https://cloud.githubusercontent.com/assets/1903876/11858632/cc0e21e6-a428-11e5-9a84-39fa27984914.png
-[nanodbc-coverity]: https://github.com/nanodbc/nanodbc/tree/coverity_scan
 [nanodbc-new-issue]: https://github.com/nanodbc/nanodbc/issues/new
 [boost]: http://www.boost.org/
 [boost-locale]: http://www.boost.org/doc/libs/release/libs/locale/
@@ -307,5 +297,3 @@ Finally, announce the new release to the public.
 [sqlite]: https://www.sqlite.org/
 [sqliteodbc]: http://www.ch-werner.de/sqliteodbc/
 [unixodbc]: http://www.unixodbc.org/
-[coverity]: https://scan.coverity.com/projects/nanodbc-nanodbc
-[coverity-badge]: https://scan.coverity.com/projects/7437/badge.svg

--- a/doc/build.py
+++ b/doc/build.py
@@ -32,6 +32,7 @@ def build_docs(**kwargs):
         XML_OUTPUT        = {doxyxml_dir}
         MACRO_EXPANSION   = YES
         PREDEFINED        = DOXYGEN=1
+        HIDE_FRIEND_COMPOUNDS = YES
         """.encode()
     cmd = ["doxygen", "-"]
     p = Popen(cmd, stdin=PIPE)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,7 +43,12 @@ doc_dir = os.path.dirname(os.path.realpath(__file__))
 src_dir = os.path.join(os.path.dirname(doc_dir), "nanodbc")
 breathe_projects_source = {"nanodbc": (src_dir, ["nanodbc.h"])}
 breathe_implementation_filename_extensions = [".cpp"]
-breathe_doxygen_config_options = {"DOXYGEN": "1"}
+breathe_doxygen_config_options = {
+    "PREDEFINED": "DOXYGEN=1",
+    # Friend declarations name implementation classes and are not part of the API.
+    # Sphinx's C++ domain cannot parse them either, so leave them out of the XML.
+    "HIDE_FRIEND_COMPOUNDS": "YES",
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -80,7 +85,7 @@ release = "2.15.0"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -238,6 +238,8 @@ typedef unspecified - type string;
 typedef unspecified - type null_type;
 #endif
 
+/// \def NANODBC_DEPRECATED
+/// \brief Marks a declaration as deprecated, in whichever way the compiler supports.
 #if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
 // [[deprecated]] is only available in C++14
 #define NANODBC_DEPRECATED [[deprecated]]
@@ -292,6 +294,8 @@ class type_incompatible_error : public std::runtime_error
 {
 public:
     type_incompatible_error();
+
+    /// \brief Returns the message describing the incompatibility.
     char const* what() const noexcept override;
 };
 
@@ -301,6 +305,8 @@ class null_access_error : public std::runtime_error
 {
 public:
     null_access_error();
+
+    /// \brief Returns the message describing the null access.
     char const* what() const noexcept override;
 };
 
@@ -310,6 +316,8 @@ class index_range_error : public std::runtime_error
 {
 public:
     index_range_error();
+
+    /// \brief Returns the message describing the out of range index.
     char const* what() const noexcept override;
 };
 
@@ -318,7 +326,11 @@ public:
 class programming_error : public std::runtime_error
 {
 public:
+    /// \brief Creates a programming error with the given message.
+    /// \param info The message describing the error.
     explicit programming_error(std::string const& info);
+
+    /// \brief Returns the message describing the error.
     char const* what() const noexcept override;
 };
 
@@ -332,8 +344,14 @@ public:
     /// \param handle_type The native ODBC handle type code for the given handle.
     /// \param info Additional info that will be appended to the beginning of the error message.
     database_error(void* handle, short handle_type, std::string const& info = "");
+
+    /// \brief Returns the full message, including the driver's own text.
     char const* what() const noexcept override;
+
+    /// \brief Returns the native error code reported by the driver.
     long native() const noexcept;
+
+    /// \brief Returns the five character SQLSTATE reported by the driver.
     std::string const& state() const noexcept;
 
 private:
@@ -365,12 +383,16 @@ private:
 /// number of rows in a rowset of a result.
 struct batch_ops
 {
-    long parameter_array_length;
-    long rowset_size;
+    long parameter_array_length; ///< Number of parameter values bound per execution.
+    long rowset_size;            ///< Number of rows fetched into a rowset at a time.
 
+    /// \brief Creates lengths of -1, meaning neither has been chosen.
     batch_ops() noexcept
         : parameter_array_length(-1L)
         , rowset_size(-1L){};
+
+    /// \brief Creates both lengths with the same value.
+    /// \param all_length Value used for the parameter array length and the rowset size.
     batch_ops(const long all_length) noexcept
         : parameter_array_length(all_length)
         , rowset_size(all_length){};
@@ -407,7 +429,7 @@ struct timestamp
 /// \brief A type for representing timestamp+offset data.
 struct timestampoffset
 {
-    timestamp stamp;
+    timestamp stamp;            ///< Date and time, in the offset's local terms.
     std::int16_t offset_hour;   ///< Whole hour part of time zone offset
     std::int16_t offset_minute; ///< Minutes part of time zome offset
 };
@@ -435,30 +457,48 @@ public:
 #endif
     attribute() = delete;
     attribute& operator=(attribute const&) = delete;
+
+    /// \brief Copy constructor.
     attribute(attribute const& other) noexcept;
+
+    /// \brief Creates an attribute from the three arguments the ODBC call takes.
+    /// \param attribute The Attribute argument of SQLSetConnectAttr or SQLSetStmtAttr.
+    /// \param string_length The StringLength argument.
+    /// \param resource The value the ValuePtr argument should refer to.
     attribute(long const& attribute, long const& string_length, variant const& resource) noexcept;
 
 protected:
+    /// \brief Points value_ptr_ at the resource, according to which type it holds.
     void extractValuePtr();
 
-    long attribute_;
-    long string_length_;
-    variant resource_;
-    void* value_ptr_;
+    long attribute_;     ///< The Attribute argument of the ODBC call.
+    long string_length_; ///< The StringLength argument of the ODBC call.
+    variant resource_;   ///< Owns the value that value_ptr_ refers to.
+    void* value_ptr_;    ///< The ValuePtr argument of the ODBC call.
 };
 #else
+/// \brief A class representing a connection or a statement attribute.
+///
+/// This is the variant-free form, used where std::variant is unavailable. The caller owns
+/// whatever value_ptr refers to and must keep it alive for as long as the attribute is used.
+///
+/// See https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlsetconnectattr-function
 class attribute
 {
 public:
+    /// \brief Creates an attribute from the three arguments the ODBC call takes.
+    /// \param attribute The Attribute argument of SQLSetConnectAttr or SQLSetStmtAttr.
+    /// \param string_length The StringLength argument.
+    /// \param value_ptr The ValuePtr argument, as an integer or a pointer.
     attribute(long const& attribute, long const& string_length, std::uintptr_t value_ptr) noexcept
         : attribute_(attribute)
         , string_length_(string_length)
         , value_ptr_((void*)value_ptr){};
 
 protected:
-    long attribute_;
-    long string_length_;
-    void* value_ptr_;
+    long attribute_;     ///< The Attribute argument of the ODBC call.
+    long string_length_; ///< The StringLength argument of the ODBC call.
+    void* value_ptr_;    ///< The ValuePtr argument of the ODBC call.
 };
 #endif
 
@@ -483,9 +523,11 @@ using is_character = std::integral_constant<
     std::is_same<typename std::decay<T>::type, std::string::value_type>::value ||
         std::is_same<typename std::decay<T>::type, wide_char_t>::value>;
 
+/// \brief Enables an overload only for the string types nanodbc binds as strings.
 template <typename T>
 using enable_if_string = typename std::enable_if<is_string<T>::value>::type;
 
+/// \brief Enables an overload only for the character types nanodbc binds as strings.
 template <typename T>
 using enable_if_character = typename std::enable_if<is_character<T>::value>::type;
 
@@ -578,14 +620,35 @@ private:
 class table_valued_parameter
 {
 public:
+    /// \brief Creates a table-valued parameter that is not yet open.
     table_valued_parameter();
+
+    /// \brief Copy constructor.
     table_valued_parameter(const table_valued_parameter& rhs);
+
+    /// \brief Move constructor.
     table_valued_parameter(table_valued_parameter&& rhs) noexcept;
+
+    /// \brief Creates a table-valued parameter and opens it on the given statement.
+    /// \see open()
     table_valued_parameter(statement& stmt, short param_index, size_t row_count);
 
+    /// \brief Closes the parameter, if it is still open.
     ~table_valued_parameter() noexcept;
 
+    /// \brief Opens the parameter on a statement, ready for values to be bound to it.
+    ///
+    /// Only one table-valued parameter may be open on a statement at a time, and it must be
+    /// closed before other parameters of that statement are bound.
+    ///
+    /// \param stmt The prepared statement carrying the parameter marker.
+    /// \param param_index Zero-based index of parameter marker (placeholder position).
+    /// \param row_count Number of rows that will be bound.
+    /// \throws database_error
     void open(statement& stmt, short param_index, std::size_t row_count);
+
+    /// \brief Finishes the parameter, so the statement can be executed or bound further.
+    /// \throws database_error
     void close();
 
     /// \addtogroup bind_multi Binding multiple non-string values
@@ -752,8 +815,23 @@ public:
         bind_strings(param_index, param_values, ValueSize, BatchSize, nulls);
     }
 
+    /// @}
+
+    /// \brief Binds a null value to the given column of every row.
+    /// \param param_index Zero-based index of the column within the parameter.
+    /// \throws database_error
     void bind_null(short param_index);
 
+    /// \brief Sets descriptions for columns of the table-valued parameter.
+    ///
+    /// Describing a column up front avoids the call to SQLDescribeParam that binding would
+    /// otherwise make. A description is re-used across binds until the parameter is closed.
+    ///
+    /// \param idx Vector of zero-based indices of the columns being described.
+    /// \param type Vector of (short integer) types.
+    /// \param size Vector of (unsigned long) sizes.
+    /// \param scale Vector of (short integer) decimal precision / scale.
+    /// \throws programming_error
     void describe_parameters(
         const std::vector<short>& idx,
         const std::vector<short>& type,
@@ -854,6 +932,11 @@ public:
     /// \see open(), prepare()
     explicit statement(class connection& conn);
 
+    /// \brief Constructs a statement object and associates it to the given connection,
+    ///        applying the given ODBC statement attributes.
+    /// \param conn The connection to use.
+    /// \param attributes Statement attributes to set before the statement is used.
+    /// \see open(), prepare()
     explicit statement(class connection& conn, std::list<attribute> const& attributes);
 
     /// \brief Constructs and prepares a statement using the given connection and query.
@@ -1415,7 +1498,6 @@ public:
         const std::vector<unsigned long>& size,
         const std::vector<short>& scale);
 
-    /// @}
 private:
     typedef std::function<bool(std::size_t)> null_predicate_type;
     friend class nanodbc::result;
@@ -2701,6 +2783,7 @@ struct driver
     std::list<attribute> attributes; ///< List of driver attributes.
 };
 
+/// \brief A data source name registered with the driver manager.
 struct datasource
 {
     nanodbc::string name;   ///< DSN name.


### PR DESCRIPTION
Three of the todo items: the documentation.yml TODOs, the stale "Good to Have / Want Someday" section, and the README audit.

## Documentation build: 50 warnings to 3

The "Parse warnings" TODO turned out to cover four separate faults, only one of which was actually about missing documentation.

**`conf.py` never passed `DOXYGEN=1` to the preprocessor.** It was handed to doxygen as a configuration tag, which doxygen does not recognise and duly ignored (`ignoring unsupported tag 'DOXYGEN'`). So doxygen parsed the `#ifndef DOXYGEN` side of the header — the side without documentation — which is why `string`, `wide_string`, `wide_char_t` and `null_type` all reported as undocumented while their documented counterparts sat unread in the branch next door. Fixing this one line cleared several warnings on its own.

**`language = None`** is not a valid language code; Sphinx warned and fell back to English.

**A doxygen group was opened and never closed.** `table_valued_parameter`'s `bind_strings` group opened at line 662 and its closing `@}` was ~670 lines later, inside `statement`. Everything declared in between — including the whole `binding` group — was nested inside it, and doxygen refused the result. The group is closed where it ends now, and the stray close that had been standing in for it is gone. The markers balance.

**The genuine gaps**, now filled: the exception accessors (`what()`, `native()`, `state()`), `batch_ops`, `timestampoffset::stamp`, both forms of `attribute`, the `enable_if` aliases, `NANODBC_DEPRECATED`, the `table_valued_parameter` lifecycle plus `bind_null` and `describe_parameters`, a `statement` constructor, and `datasource`.

**Three warnings remain**, all Sphinx failing to parse `friend` declarations. Every friend in the header is a private implementation detail, but doxygen emits friends regardless of `EXTRACT_PRIVATE`, and `HIDE_FRIEND_COMPOUNDS` does not reach them — I checked, 43 friend members still land in the XML with it set. Removing them would mean guarding nineteen declarations with `#ifndef DOXYGEN`. That did not seem worth it for three warnings on a build that already succeeds, but say the word and I will.

## README

**The CMake option table was materially wrong.** Four documented options do not exist:

| README said | actually |
|---|---|
| `NANODBC_DISABLE_EXAMPLES` | `NANODBC_BUILD_EXAMPLES` |
| `NANODBC_DISABLE_INSTALL` | `NANODBC_GENERATE_INSTALL` |
| `NANODBC_DISABLE_LIBCXX` | `NANODBC_FORCE_LIBCXX` |
| `NANODBC_DISABLE_TESTS` | `NANODBC_BUILD_TESTS` |

The rename also inverted their sense, so anyone following the README was passing flags that did nothing at all. Three real options — `NANODBC_DISABLE_MSSQL_TVP`, `NANODBC_ENABLE_COVERAGE`, `NANODBC_FORCE_WARNINGS_AS_ERROR` — were missing. The table matches `CMakeLists.txt` now.

**The tests section** pointed at a `tests/` directory that is called `test/`, and told contributors to add test cases to `base_test_fixture.h`, which holds the shared helpers; the cases live in `test_case_fixture.h`. Corrected, and it now mentions that SQLite and utility tests need no server.

**Badges.** On the ci-linux badge showing failing: it was reading a *cancelled* run. Cleaning up the queue during the last PR cancelled two superseded runs on `main`, and the badge reports the most recent run whatever its conclusion. The merge of #446 has since replaced it with a passing run, so that badge is green again — my doing, and self-corrected.

The other two are removed rather than fixed:

- **Coverity** tracked `coverity_scan`, a branch whose last commit is from **February 2018**, for a service no longer in use.
- **codecov** could only ever read *unknown*, because nothing has ever uploaded coverage — there is no codecov step in any workflow. The `NANODBC_ENABLE_COVERAGE` option exists but no job sets it.

A coverage badge can come back once there is a coverage solution behind it, which is a separate todo item.

**The odbcinst.ini example** no longer names a specific driver build.

**"Good to Have / Want Someday"** is removed, as requested.

## Verification

Docs built in a container at each step to count the warnings. Library builds clean at C++14; SQLite tests pass, 920 assertions in 45 cases. Markdown lint reports only the pre-existing MD060 table-alignment issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
