### PR TITLE
Dedupe CI runs, and finish #398's get_info() return types

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -20,6 +20,12 @@ env:
   build: "${{ github.workspace }}/build"
   config: "Debug"
 
+# One run per workflow per ref. A new push cancels the run it superseded, except on main,
+# where each merge should be allowed to finish reporting.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   core:
     name: CppCoreCheckRules

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - ml/*
     paths:
       - "**.cpp"
       - "**.h"
@@ -20,6 +19,12 @@ on:
       - "**.h"
       - "**/CMakeLists.txt"
       - ".github/workflows/ci-linux.yml"
+
+# One run per workflow per ref. A new push cancels the run it superseded, except on main,
+# where each merge should be allowed to finish reporting.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   check-format:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -20,6 +20,12 @@ on:
       - "**/CMakeLists.txt"
       - ".github/workflows/ci-windows.yml"
 
+# One run per workflow per ref. A new push cancels the run it superseded, except on main,
+# where each merge should be allowed to finish reporting.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,6 +14,12 @@ on:
     paths:
       - "doc/**"
       - "nanodbc/**"
+# One run per workflow per ref. A new push cancels the run it superseded, except on main,
+# where each merge should be allowed to finish reporting.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,12 @@ on:
       - main
   pull_request:
 
+# One run per workflow per ref. A new push cancels the run it superseded, except on main,
+# where each merge should be allowed to finish reporting.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   # source code format checked before builds by ci-{linux,windows}.yml
 

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1664,9 +1664,9 @@ string connection::connection_impl::database_name() const
 }
 
 template string connection::get_info(short info_type) const;
-template unsigned short connection::get_info(short info_type) const;
-template uint32_t connection::get_info(short info_type) const;
-template uint64_t connection::get_info(short info_type) const;
+template SQLUSMALLINT connection::get_info(short info_type) const;
+template SQLUINTEGER connection::get_info(short info_type) const;
+template SQLULEN connection::get_info(short info_type) const;
 
 } // namespace nanodbc
 

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1664,9 +1664,17 @@ string connection::connection_impl::database_name() const
 }
 
 template string connection::get_info(short info_type) const;
-template SQLUSMALLINT connection::get_info(short info_type) const;
-template SQLUINTEGER connection::get_info(short info_type) const;
-template SQLULEN connection::get_info(short info_type) const;
+
+// SQLUSMALLINT, SQLUINTEGER and SQLULEN are spelled with different underlying types from
+// one platform to the next, and the fixed width names callers reach for do not always
+// agree with them: here SQLULEN is unsigned long while uint64_t is unsigned long long, so
+// naming one leaves the other undefined at link time. The four fundamental unsigned types
+// are always distinct from each other and between them cover every spelling of these three
+// on every platform, so every correct way of asking links.
+template unsigned short connection::get_info(short info_type) const;
+template unsigned int connection::get_info(short info_type) const;
+template unsigned long connection::get_info(short info_type) const;
+template unsigned long long connection::get_info(short info_type) const;
 
 } // namespace nanodbc
 

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1435,22 +1435,21 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(!connection.get_info<nanodbc::string>(SQL_ODBC_VER).empty());
 
         // Test SQLUSMALLINT results
-        REQUIRE(connection.get_info<unsigned short>(SQL_NON_NULLABLE_COLUMNS) == SQL_NNC_NON_NULL);
+        REQUIRE(connection.get_info<SQLUSMALLINT>(SQL_NON_NULLABLE_COLUMNS) == SQL_NNC_NON_NULL);
 
-        // Test SQUINTEGER results
-        REQUIRE(connection.get_info<uint32_t>(SQL_ODBC_INTERFACE_CONFORMANCE) > 0);
+        // Test SQLUINTEGER results
+        REQUIRE(connection.get_info<SQLUINTEGER>(SQL_ODBC_INTERFACE_CONFORMANCE) > 0);
 
-        // get_info is robust to a SQUINTEGER InfoType being retrieved
-        // as uint64_t
+        // get_info is robust to a SQLUINTEGER InfoType being retrieved as a wider type
         REQUIRE(
-            connection.get_info<uint64_t>(SQL_ODBC_INTERFACE_CONFORMANCE) ==
-            connection.get_info<uint32_t>(SQL_ODBC_INTERFACE_CONFORMANCE));
+            connection.get_info<SQLULEN>(SQL_ODBC_INTERFACE_CONFORMANCE) ==
+            connection.get_info<SQLUINTEGER>(SQL_ODBC_INTERFACE_CONFORMANCE));
 
-        // Test SQUINTEGER bitmask results
-        REQUIRE((connection.get_info<uint32_t>(SQL_CREATE_TABLE) & SQL_CT_CREATE_TABLE));
+        // Test SQLUINTEGER bitmask results
+        REQUIRE((connection.get_info<SQLUINTEGER>(SQL_CREATE_TABLE) & SQL_CT_CREATE_TABLE));
 
         // Test SQLULEN results
-        REQUIRE(connection.get_info<uint64_t>(SQL_DRIVER_HDBC) > 0);
+        REQUIRE(connection.get_info<SQLULEN>(SQL_DRIVER_HDBC) > 0);
     }
 
     void test_implementation_row_descriptor()


### PR DESCRIPTION
Two things, as requested in one PR: the duplicate-CI fix, and #398 rebased and finished.

## Duplicate CI

`ci-linux.yml` triggered on pushes to `ml/*` **and** on pull requests, so every push to a branch under review started two identical runs of the same forty jobs. `ci-windows.yml` never did, because it only builds pushes to `main`. Confirmed on a real commit:

```
32066337855  CI Linux  event=pull_request  queued
32066336301  CI Linux  event=push          queued   ← duplicate
```

The branch pattern is gone; the pull request trigger already covers it.

Every workflow also gains a concurrency group keyed on the ref, so pushing again cancels the run it superseded instead of leaving it to finish against code nobody is looking at. Runs on `main` are exempt, so a merge is never cancelled by the next merge. That should retire the manual cancelling entirely.

## #398, rebased and finished

Original work by @gaborcsardi in #398, kept as their commit. Use the return types `SQLGetInfo` documents rather than fixed width types that happen to match on one platform and not another.

**The original could not compile.** The `SQLUSMALLINT` instantiation read:

```cpp
template SQLUSMALLINT short connection::get_info(short info_type) const;
```

`SQLUSMALLINT` is already `unsigned short`, so that expands to `unsigned short short`. That is almost certainly why the PR's own checklist still has "All CI builds and checks have passed" unticked. Corrected here.

**And the change as written removes instantiations that exist today.** This is the part worth reviewing, because it is the same failure #445 was about, in the opposite direction. The ODBC types are spelled differently per platform, and the fixed width names do not always agree:

| | this platform |
|---|---|
| `SQLUSMALLINT` | `unsigned short` |
| `SQLUINTEGER` | `unsigned int`, same type as `uint32_t` |
| `SQLULEN` | `unsigned long` — **not** `uint64_t`, which is `unsigned long long` |

So naming only the three ODBC types leaves `get_info<uint64_t>` undefined at link time. Verified against a shared library build: before the last commit it fails with `Undefined symbols for architecture arm64`, and `test_get_info` itself exercises `uint64_t` today.

Rather than trade one set of link errors for another, the final commit instantiates the four fundamental unsigned types:

```cpp
template unsigned short connection::get_info(short info_type) const;
template unsigned int connection::get_info(short info_type) const;
template unsigned long connection::get_info(short info_type) const;
template unsigned long long connection::get_info(short info_type) const;
```

Those four are always distinct types, so there is no risk of instantiating one twice, and between them they cover `SQLUSMALLINT`, `SQLUINTEGER` and `SQLULEN` as well as the fixed width names, on every platform. Both spellings link, checked in each direction.

The test now asks in the ODBC types, which is the point of the change.

## Verification

Builds clean; both spellings link against a shared build. Utility 30 in 3, SQLite 924 in 45, PostgreSQL 1091 in 49 against a freshly created database, and `test_get_info` on its own.

Closes #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
