### PR TITLE
Speed up CI, and stop the analyzers reporting on tests

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -47,8 +47,9 @@ jobs:
           buildConfiguration: ${{ env.config }}
           # Ruleset file that will determine what checks will be run
           ruleset: CppCoreCheckRules.ruleset
-          # Paths to ignore analysis of CMake targets and includes
-          ignoredPaths: ${{ github.workspace }}/test/catch
+          # Paths to ignore analysis of CMake targets and includes. The tests are not
+          # shipped to anyone, and their findings drown out the library's.
+          ignoredPaths: ${{ github.workspace }}/test
 
       # Upload SARIF file to GitHub Code Scanning Alerts
       - name: Upload SARIF to GitHub
@@ -84,8 +85,9 @@ jobs:
           buildConfiguration: ${{ env.config }}
           # Ruleset file that will determine what checks will be run
           ruleset: NativeRecommendedRules.ruleset
-          # Paths to ignore analysis of CMake targets and includes
-          ignoredPaths: ${{ github.workspace }}/test/catch
+          # Paths to ignore analysis of CMake targets and includes. The tests are not
+          # shipped to anyone, and their findings drown out the library's.
+          ignoredPaths: ${{ github.workspace }}/test
 
       # Upload SARIF file to GitHub Code Scanning Alerts
       - name: Upload SARIF to GitHub
@@ -115,7 +117,7 @@ jobs:
       - name: flawfinder_scan
         uses: david-a-wheeler/flawfinder@c4216b74cf2639ffa98503768bd6e4299b5440c9 # master, the action has no tagged releases
         with:
-          arguments: "--sarif ./"
+          arguments: "--sarif --exclude './test/*' ./"
           output: "flawfinder_results.sarif"
 
       - name: Upload analysis results to GitHub Security tab

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -47,9 +47,10 @@ jobs:
           buildConfiguration: ${{ env.config }}
           # Ruleset file that will determine what checks will be run
           ruleset: CppCoreCheckRules.ruleset
-          # Paths to ignore analysis of CMake targets and includes. The tests are not
-          # shipped to anyone, and their findings drown out the library's.
-          ignoredPaths: ${{ github.workspace }}/test
+          # Paths to ignore analysis of CMake targets and includes. Neither the tests nor
+          # the examples are shipped to anyone, and their findings drown out the library's.
+          # The list is ";" separated.
+          ignoredPaths: ${{ github.workspace }}/test;${{ github.workspace }}/example
 
       # Upload SARIF file to GitHub Code Scanning Alerts
       - name: Upload SARIF to GitHub
@@ -85,9 +86,10 @@ jobs:
           buildConfiguration: ${{ env.config }}
           # Ruleset file that will determine what checks will be run
           ruleset: NativeRecommendedRules.ruleset
-          # Paths to ignore analysis of CMake targets and includes. The tests are not
-          # shipped to anyone, and their findings drown out the library's.
-          ignoredPaths: ${{ github.workspace }}/test
+          # Paths to ignore analysis of CMake targets and includes. Neither the tests nor
+          # the examples are shipped to anyone, and their findings drown out the library's.
+          # The list is ";" separated.
+          ignoredPaths: ${{ github.workspace }}/test;${{ github.workspace }}/example
 
       # Upload SARIF file to GitHub Code Scanning Alerts
       - name: Upload SARIF to GitHub
@@ -117,7 +119,7 @@ jobs:
       - name: flawfinder_scan
         uses: david-a-wheeler/flawfinder@c4216b74cf2639ffa98503768bd6e4299b5440c9 # master, the action has no tagged releases
         with:
-          arguments: "--sarif --exclude './test/*' ./"
+          arguments: "--sarif --exclude './test/*' --exclude './example/*' ./"
           output: "flawfinder_results.sarif"
 
       - name: Upload analysis results to GitHub Security tab

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -64,23 +64,30 @@ jobs:
       CC: gcc-${{ matrix.gcc }}
       CXX: g++-${{ matrix.gcc }}
       DEBIAN_FRONTEND: noninteractive
+      CCACHE_DIR: /ccache
     steps:
       - name: Install
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            ca-certificates cmake g++-${{ matrix.gcc }} git make unixodbc-dev
+            ca-certificates ccache cmake g++-${{ matrix.gcc }} git make unixodbc-dev
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Restore compiled objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /ccache
+          key: ccache-gcc${{ matrix.gcc }}-std${{ matrix.cxxstd }}-${{ github.sha }}
+          restore-keys: ccache-gcc${{ matrix.gcc }}-std${{ matrix.cxxstd }}-
       - name: Check
         run: |
           ${CXX} --version
           cmake --version
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }}
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
         run: |
-          cmake --build ${GITHUB_WORKSPACE}/build
+          cmake --build ${GITHUB_WORKSPACE}/build --parallel
 
   # Clang 19 through 22, on the same basis as the GCC matrix above.
   build-clang:
@@ -97,24 +104,31 @@ jobs:
       CC: clang-${{ matrix.clang }}
       CXX: clang++-${{ matrix.clang }}
       DEBIAN_FRONTEND: noninteractive
+      CCACHE_DIR: /ccache
     steps:
       - name: Install
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            ca-certificates clang-${{ matrix.clang }} cmake git \
+            ca-certificates ccache clang-${{ matrix.clang }} cmake git \
             libc++-${{ matrix.clang }}-dev libc++abi-${{ matrix.clang }}-dev make unixodbc-dev
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Restore compiled objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /ccache
+          key: ccache-clang${{ matrix.clang }}-std${{ matrix.cxxstd }}-${{ github.sha }}
+          restore-keys: ccache-clang${{ matrix.clang }}-std${{ matrix.cxxstd }}-
       - name: Check
         run: |
           ${CXX} --version
           cmake --version
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }}
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
         run: |
-          cmake --build ${GITHUB_WORKSPACE}/build
+          cmake --build ${GITHUB_WORKSPACE}/build --parallel
 
   test-utility:
     runs-on: ubuntu-latest
@@ -123,13 +137,19 @@ jobs:
       - name: Install
         run: |
           sudo apt-get update
-          sudo apt-get install -y unixodbc-dev
+          sudo apt-get install -y ccache unixodbc-dev
+      - name: Restore compiled objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.ccache
+          key: ccache-utility-${{ github.sha }}
+          restore-keys: ccache-utility-
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
         run: |
-          cmake --build ${GITHUB_WORKSPACE}/build --target utility_tests
+          cmake --build ${GITHUB_WORKSPACE}/build --parallel --target utility_tests
       - name: Test
         run: |
           ctest --test-dir ${GITHUB_WORKSPACE}/build --output-on-failure --no-tests=error -R utility_tests
@@ -161,13 +181,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install
         run: |
-          sudo apt-get install -y unixodbc-dev odbc-postgresql
+          sudo apt-get install -y ccache unixodbc-dev odbc-postgresql
+      - name: Restore compiled objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.ccache
+          key: ccache-postgresql-${{ github.sha }}
+          restore-keys: ccache-postgresql-
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
         run: |
-          cmake --build ${GITHUB_WORKSPACE}/build --target postgresql_tests
+          cmake --build ${GITHUB_WORKSPACE}/build --parallel --target postgresql_tests
       - name: Test
         run: |
           export NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL ANSI};Server=localhost;Port=5432;Database=nanodbc;UID=postgres;PWD=postgres"
@@ -190,14 +216,20 @@ jobs:
           apt-get update
           curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
           curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list > /etc/apt/sources.list.d/mssql-release.list
-          ACCEPT_EULA=Y apt-get install -y unixodbc-dev msodbcsql17
+          ACCEPT_EULA=Y apt-get install -y ccache unixodbc-dev msodbcsql17
         shell: sudo bash {0}
+      - name: Restore compiled objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.ccache
+          key: ccache-mssql-${{ github.sha }}
+          restore-keys: ccache-mssql-
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
         run: |
-          cmake --build ${GITHUB_WORKSPACE}/build --target mssql_tests
+          cmake --build ${GITHUB_WORKSPACE}/build --parallel --target mssql_tests
       - name: Test
         run: |
           export NANODBC_TEST_CONNSTR_MSSQL="Driver={ODBC Driver 17 for SQL Server};Server=localhost;Database=master;UID=sa;PWD=Password!123;"
@@ -209,7 +241,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install
         run: |
-          apt-get install -y unixodbc-dev libsqliteodbc
+          apt-get install -y ccache unixodbc-dev libsqliteodbc
           cat <<EOF > ${GITHUB_WORKSPACE}/.odbcinst.ini
           [SQLite3]
           Description=SQLite 3 ODBC Driver
@@ -220,12 +252,18 @@ jobs:
           sudo odbcinst -i -d -f ${GITHUB_WORKSPACE}/.odbcinst.ini
           cat /etc/odbcinst.ini
         shell: sudo bash {0}
+      - name: Restore compiled objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.ccache
+          key: ccache-sqlite-${{ github.sha }}
+          restore-keys: ccache-sqlite-
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
         run: |
-          cmake --build ${GITHUB_WORKSPACE}/build --target sqlite_tests
+          cmake --build ${GITHUB_WORKSPACE}/build --parallel --target sqlite_tests
       - name: Test
         run: |
           ctest --test-dir ${GITHUB_WORKSPACE}/build --output-on-failure --no-tests=error -R sqlite_tests

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -77,7 +77,7 @@ jobs:
           Select-String -Path ${{ github.workspace }}/build/CMakeCache.txt -Pattern "CMAKE_GENERATOR:|CMAKE_GENERATOR_TOOLSET:|CMAKE_CXX_COMPILER:"
       - name: Build
         run: |
-          cmake --build ${{ github.workspace }}/build --config Release
+          cmake --build ${{ github.workspace }}/build --config Release --parallel
 
   build-mingw:
     needs: [check-format]
@@ -112,7 +112,7 @@ jobs:
           cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
       - name: Build
         run: |
-          cmake --build ${{ github.workspace }}/build --config Release --target utility_tests
+          cmake --build ${{ github.workspace }}/build --config Release --parallel --target utility_tests
       - name: Test
         run: |
           ctest --test-dir ${{ github.workspace }}/build --build-config Release --output-on-failure --no-tests=error -R utility_tests
@@ -152,7 +152,7 @@ jobs:
           cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
       - name: Build
         run: |
-          cmake --build ${{ github.workspace }}/build --config Release --target mssql_tests
+          cmake --build ${{ github.workspace }}/build --config Release --parallel --target mssql_tests
       - name: Test
         run: |
           $env:NANODBC_TEST_CONNSTR_MSSQL="Driver={ODBC Driver 17 for SQL Server};Server=(localdb)\MSSQLLocalDB;Database=tempdb;UID=sa;PWD=Password!123;"
@@ -183,7 +183,7 @@ jobs:
           cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
       - name: Build
         run: |
-          cmake --build ${{ github.workspace }}/build --config Release --target mysql_tests
+          cmake --build ${{ github.workspace }}/build --config Release --parallel --target mysql_tests
       - name: Test
         run: |
           # Take the driver name from what Chocolatey actually installed, since the
@@ -219,7 +219,7 @@ jobs:
           cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
       - name: Build
         run: |
-          cmake --build ${{ github.workspace }}/build --config Release --target mysql_tests
+          cmake --build ${{ github.workspace }}/build --config Release --parallel --target mysql_tests
       - name: Test
         run: |
           # Take the driver name from what Chocolatey actually installed, since the
@@ -253,7 +253,7 @@ jobs:
           cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
       - name: Build
         run: |
-          cmake --build ${{ github.workspace }}/build --config Release --target postgresql_tests
+          cmake --build ${{ github.workspace }}/build --config Release --parallel --target postgresql_tests
       - name: Test
         run: |
           $env:NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL ANSI(x64)};Server=localhost;Port=5432;Database=nanodbc;UID=postgres;PWD="
@@ -276,7 +276,7 @@ jobs:
           cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
       - name: Build
         run: |
-          cmake --build ${{ github.workspace }}/build --config Release --target sqlite_tests
+          cmake --build ${{ github.workspace }}/build --config Release --parallel --target sqlite_tests
       - name: Test
         run: |
           ctest --test-dir ${{ github.workspace }}/build --build-config Release --output-on-failure --no-tests=error -R sqlite_tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,25 +6,20 @@ endif()
 add_compile_definitions( "$<$<CXX_COMPILER_ID:MSVC>:_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>" )
 
 # Catch2 v3 is vendored as its amalgamated distribution, so the tests still build with no
-# network access. Two libraries from the one source: the amalgamation supplies main() unless
-# CATCH_AMALGAMATED_CUSTOM_MAIN is defined, and the database tests bring their own.
+# network access. It is a large translation unit, so it is compiled once and every test
+# program brings its own main(), rather than building it a second time only to get the
+# main() the amalgamation would otherwise supply.
 add_library(Catch STATIC catch/catch_amalgamated.cpp)
+target_compile_definitions(Catch PRIVATE CATCH_AMALGAMATED_CUSTOM_MAIN)
 target_include_directories(Catch PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(Catch PUBLIC cxx_std_14)
-
-add_library(CatchCustomMain STATIC catch/catch_amalgamated.cpp)
-target_compile_definitions(CatchCustomMain PRIVATE CATCH_AMALGAMATED_CUSTOM_MAIN)
-target_include_directories(CatchCustomMain PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_compile_features(CatchCustomMain PUBLIC cxx_std_14)
 
 # Catch used to be header only, so its code was compiled into each test target and picked
 # up the standard library selection from there. Now that it is compiled on its own it has
 # to be told, or it builds against the default library and fails to link against the rest.
 if(NANODBC_FORCE_LIBCXX)
-  foreach(catch_target Catch CatchCustomMain)
-    target_compile_options(${catch_target} PUBLIC -stdlib=libc++)
-    target_link_options(${catch_target} PUBLIC -stdlib=libc++ -lc++abi)
-  endforeach()
+  target_compile_options(Catch PUBLIC -stdlib=libc++)
+  target_link_options(Catch PUBLIC -stdlib=libc++ -lc++abi)
 endif()
 
 add_custom_target(tests)
@@ -59,7 +54,7 @@ foreach(test_item IN LISTS test_list)
       base_test_fixture.h
       test_case_fixture.h
       )
-  target_link_libraries(${test_name} PRIVATE CatchCustomMain ODBC::ODBC nanodbc)
+  target_link_libraries(${test_name} PRIVATE Catch ODBC::ODBC nanodbc)
 
   target_compile_definitions(${test_name}
     PRIVATE

--- a/test/utility_test.cpp
+++ b/test/utility_test.cpp
@@ -201,3 +201,12 @@ SECTION("narrowing conversion")
     }
 }
 }
+
+// Catch is compiled without its own main(), so that the one large translation unit is
+// built once for every test program rather than twice.
+int main(int argc, char* argv[])
+{
+    Catch::Session session;
+    session.configData().runOrder = Catch::TestRunOrder::Declared;
+    return session.run(argc, argv);
+}


### PR DESCRIPTION
Timed a completed CI Linux run before changing anything, because it was not obvious where the time was going:

| step | total across 35 jobs | share |
|---|---|---|
| **Build** | **2533s** | **66%** |
| Install | 732s | 19% |
| Initialize containers | 310s | 8% |
| everything else | 254s | 7% |
| | **3829s** | |

So the build dominates, not the installs. Three things were making it slower than it needs to be.

## Nothing passed `--parallel`

Not one `cmake --build` in either workflow used `-j`, so every job compiled on a single core while the runner had four. On a container capped at four cores, building everything:

**47s → 17s.** Applied to every build in both workflows.

## Catch was compiled twice

The amalgamated source is a large translation unit, and a second library was built from it purely to obtain the `main()` the amalgamation supplies by default. That second copy is **8 of those 47 seconds**.

It is built once now, without a main, and each test program brings its own. The database tests already had one; the utility tests now have six lines. One `libCatch.a` instead of two.

## Objects were recompiled from scratch every run

Most of the tree does not change between runs, and the vendored Catch never does. With ccache and a cache keyed on compiler and standard:

| | time |
|---|---|
| cold cache | 21s |
| warm cache, nothing changed | **0s** |
| warm cache, `nanodbc.cpp` edited | **1s** |

The cache is about 3 MB per configuration, so 24 build configurations cost roughly 70 MB of the cache allowance.

## On prebuilt images

Worth saying why I did not go there. A prepared image would target the Install and container-start steps, which are 1042s combined — real, but a third of what the build costs, and the trade is not as good as it looks: `container:` images are pulled fresh for every job, and GitHub has no cache for that. You can cache *layers* while **building** an image (`cache-from: type=gha`), but not the pull. So a prepared image swaps ~20s of apt for a larger pull, and an image carrying GCC 13-16 plus Clang 19-22 with libc++ would be several GB. Per-compiler images would be ~500 MB each and might save ~10s a job, against eight images to publish, keep current, and grant registry access for.

ccache attacks a bigger number for far less machinery, so it seemed the better first move. If the Install time still bothers you afterwards, the cheaper next step is caching apt archives, and prebuilt images after that.

## Also: the analyzers no longer report on the tests

Flawfinder scanned the whole tree, and just over half of what it found was test code — **36 of 70 findings**, against 34 in the library. PREfast was already told to skip `test/catch`, which covers the vendored Catch but not the tests around it.

Flawfinder now takes `--exclude './test/*' --exclude './example/*'`, and PREfast ignores both directories (its list is `;` separated). Checked against the working tree: **70 findings become 34, and every one that remains is in `nanodbc/`**.

The examples are excluded on the same reasoning — illustrations, not something anyone links against. That one is mostly about PREfast, which had seventeen annotations in `example/example_unicode_utils.h` alone on a recent run; Flawfinder happens to report nothing there today, so for it the exclusion only keeps future example code from adding noise.

Two things I confirmed rather than assumed, since both would have failed quietly:

- The pinned Flawfinder action installs flawfinder unpinned from PyPI, and `--exclude` only exists from 2.0.20. The action's own source at that commit is 2.0.20, so the flag is there.
- Its entrypoint splits the `arguments` string with `shlex.split`, so the quoting in `--exclude './test/*'` survives as one argument rather than being mangled.

## Verification

All measured on a four core container, matching the runner. Locally: utility 30 in 3, SQLite 924 in 45, PostgreSQL 1091 in 49 against a freshly created database, and one `libCatch.a` where there were two.

Windows is untouched. MSVC needs sccache rather than ccache, and by the numbers it is not where the time is going.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
