### PR TITLE
Measure coverage with llvm-cov, and make the option work at all

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,5 +4,5 @@ comment: off
 ignore:
   - "doc"
   - "example"
-  - "test/catch"
+  - "test"
   - "utility"

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -154,6 +154,93 @@ jobs:
         run: |
           ctest --test-dir ${GITHUB_WORKSPACE}/build --output-on-failure --no-tests=error -R utility_tests
 
+  # Coverage of the library, driven by the suites that can run here: the utility tests, the
+  # SQLite tests and the PostgreSQL tests. Clang records which regions of an expression ran,
+  # not merely which lines were reached, so the percentages are stricter than gcov's.
+  coverage:
+    runs-on: ubuntu-latest
+    services:
+      postgresql:
+        image: postgres:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: nanodbc
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install
+        run: |
+          sudo apt-get update
+          # libclang-rt-dev carries the profiling runtime, without which the instrumented
+          # build does not link. libc++ is installed because NANODBC_FORCE_LIBCXX turns
+          # itself on wherever clang accepts -stdlib=libc++, whether or not its headers
+          # are actually present.
+          sudo apt-get install -y ccache clang libclang-rt-dev libc++-dev libc++abi-dev llvm \
+            unixodbc-dev odbc-postgresql libsqliteodbc
+          sudo odbcinst -i -d -f /usr/share/sqliteodbc/unixodbc.ini
+      - name: Restore compiled objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.ccache
+          key: ccache-coverage-${{ github.sha }}
+          restore-keys: ccache-coverage-
+      - name: Configure
+        run: |
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build \
+            -DCMAKE_BUILD_TYPE=Debug -DNANODBC_ENABLE_COVERAGE=ON \
+            -DNANODBC_BUILD_EXAMPLES=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        env:
+          CC: clang
+          CXX: clang++
+      - name: Build
+        run: cmake --build ${GITHUB_WORKSPACE}/build --parallel
+      - name: Run the suites
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/profraw"
+          export NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL ANSI};Server=localhost;Port=5432;Database=nanodbc;UID=postgres;PWD=postgres"
+          for suite in utility sqlite postgresql; do
+            LLVM_PROFILE_FILE="${GITHUB_WORKSPACE}/profraw/${suite}-%p.profraw" \
+              "${GITHUB_WORKSPACE}/build/test/${suite}_tests"
+          done
+      - name: Report
+        run: |
+          llvm-profdata merge -sparse ${GITHUB_WORKSPACE}/profraw/*.profraw \
+            -o ${GITHUB_WORKSPACE}/coverage.profdata
+          # llvm-cov takes the first binary positionally and the rest after -object.
+          binaries=("${GITHUB_WORKSPACE}/build/test/utility_tests"
+                    -object "${GITHUB_WORKSPACE}/build/test/sqlite_tests"
+                    -object "${GITHUB_WORKSPACE}/build/test/postgresql_tests")
+          llvm-cov export -format=lcov "${binaries[@]}" \
+            -instr-profile="${GITHUB_WORKSPACE}/coverage.profdata" \
+            "${GITHUB_WORKSPACE}/nanodbc/" > "${GITHUB_WORKSPACE}/coverage.lcov"
+          {
+            echo '## Coverage'
+            echo
+            echo '```'
+            llvm-cov report "${binaries[@]}" \
+              -instr-profile="${GITHUB_WORKSPACE}/coverage.profdata" "${GITHUB_WORKSPACE}/nanodbc/"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+      - name: Upload the lcov report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-lcov
+          path: coverage.lcov
+          overwrite: true
+      - name: Send to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
   test-postgresql:
     runs-on: ubuntu-latest
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,21 @@ option( NANODBC_ENABLE_WORKAROUND_NODATA "Enable SQL_NO_DATA workaround (see Iss
 include( CheckCXXCompilerFlag )
 check_cxx_compiler_flag( "-stdlib=libc++" CXX_COMPILER_SUPPORTS_LIBCXX )
 check_cxx_compiler_flag( "-Werror" CXX_COMPILER_SUPPORTS_WERROR )
-check_cxx_compiler_flag( "--coverage -O0" CXX_COMPILER_SUPPORTS_COVERAGE )
+# Coverage is instrumented differently by each compiler, so ask about the flags that will
+# actually be used. Instrumentation also has to reach the link line, or the check fails on
+# the profiling runtime being missing rather than on the flag being unsupported. That is
+# what the previous check did, which quietly forced NANODBC_ENABLE_COVERAGE off however it
+# was set.
+if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
+  set( NANODBC_COVERAGE_COMPILE_OPTIONS -fprofile-instr-generate -fcoverage-mapping -O0 -g )
+  set( NANODBC_COVERAGE_LINK_OPTIONS -fprofile-instr-generate )
+else()
+  set( NANODBC_COVERAGE_COMPILE_OPTIONS --coverage -O0 -g )
+  set( NANODBC_COVERAGE_LINK_OPTIONS --coverage )
+endif()
+set( CMAKE_REQUIRED_LINK_OPTIONS ${NANODBC_COVERAGE_LINK_OPTIONS} )
+check_cxx_compiler_flag( "${NANODBC_COVERAGE_COMPILE_OPTIONS}" CXX_COMPILER_SUPPORTS_COVERAGE )
+unset( CMAKE_REQUIRED_LINK_OPTIONS )
 
 include( CMakeDependentOption )
 cmake_dependent_option( NANODBC_FORCE_LIBCXX "Force the use of libc++ (default on if compiler supports it)" ON "CXX_COMPILER_SUPPORTS_LIBCXX" OFF )
@@ -214,9 +228,11 @@ endif()
 message( STATUS "nanodbc build: Enable test coverage - ${NANODBC_ENABLE_COVERAGE}" )
 
 if( NANODBC_ENABLE_COVERAGE )
-  target_compile_options( nanodbc PUBLIC --coverage -O0 )
-  find_library( gcov gcov )
-  target_link_libraries( nanodbc PUBLIC gcov )
+  # Under Clang this is source based coverage: it records which regions of an expression
+  # ran rather than only which lines were reached, and llvm-cov reads the result out of the
+  # binary. Under GCC it is gcov as before.
+  target_compile_options( nanodbc PUBLIC ${NANODBC_COVERAGE_COMPILE_OPTIONS} )
+  target_link_options( nanodbc PUBLIC ${NANODBC_COVERAGE_LINK_OPTIONS} )
 endif()
 
 # #######################################


### PR DESCRIPTION
The coverage item. Two things here: the option never worked, and now there is a job that uses it.

## `NANODBC_ENABLE_COVERAGE` did nothing

Setting it to `ON` produced an ordinary, uninstrumented build. The option is gated on a feature check:

```cmake
check_cxx_compiler_flag( "--coverage -O0" CXX_COMPILER_SUPPORTS_COVERAGE )
```

which puts the flag on the compile line but not the link line, so the test program failed to link against the profiling runtime. The check reported the flag as unsupported, `cmake_dependent_option` forced the option off, and the only sign was one line of output saying `Enable test coverage - OFF` while you had just asked for `ON`. That failed on AppleClang and on Linux clang alike.

The check now asks about the flags each compiler will actually use, and puts them on the link line as well.

## llvm-cov rather than gcov

Under Clang the build is instrumented with `-fprofile-instr-generate -fcoverage-mapping`, which is source based: it records which *regions* of an expression ran, not just which lines were reached. The figures are stricter than gcov's and the tooling reads the mapping straight out of the binary, so there is nothing to keep in sync. GCC keeps gcov.

## The job

Runs the utility, SQLite and PostgreSQL suites, merges the profiles with `llvm-profdata`, and produces an lcov report which is:

- attached to the run as an artifact,
- printed into the **job summary**, so the number is readable without leaving GitHub or depending on any third party,
- sent to **Codecov**, which is what puts a badge back on the README.

**Codecov needs `CODECOV_TOKEN` as a repository secret** before it records anything. That is why I have not restored the badge in this PR: an unconfigured badge reads *unknown*, which is the state you were complaining about. Once the secret is set and a run has uploaded, the badge is a one line change and I am happy to make it.

On Coverity: the badge and its note went in #451, and the `coverity_scan` branch is still there, last touched **February 2018**. Deleting a branch is not something I will do without asking, so say the word.

## The baseline

From those three suites, against the library only:

| | covered |
|---|---|
| Lines | **50.4%** |
| Regions | **43.2%** |
| Functions | **52.8%** |

That is the starting point for the 100% item. MSSQL and MySQL are not in the merge yet, so the real figure is somewhat higher than this; adding them is a follow up.

## Two packages worth calling out

Both fail in ways that do not name the cause, and both cost me a rehearsal to find:

- **`libclang-rt-dev`** carries the profiling runtime. Without it the instrumented build fails to link, and because that is exactly what the feature check trips over, the symptom is "coverage is unsupported" rather than "a package is missing".
- **`libc++-dev`** is needed because `NANODBC_FORCE_LIBCXX` turns itself on wherever clang *accepts* `-stdlib=libc++`, whether or not its headers are installed. Without it the build fails on `fatal error: 'cstddef' file not found`, which reads like a broken toolchain.

## Verification

The whole job was rehearsed in an `ubuntu:24.04` container, not just reasoned about: coverage reported ON, build clean, utility 30 in 3 and SQLite 867 in 45 passing, profiles merged, lcov exported, report produced. Locally with PostgreSQL added, the merged report is the 50.4% above. A normal build is unaffected and still reports coverage as OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
