### PR TITLE
Restore the coverage badge, report coverage on PRs, fix narrating comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,24 @@
 ---
-comment: off
+# Codecov reports on each pull request, so the coverage change is visible before merging
+# rather than only afterwards. The status checks are informational: they report the change
+# without failing the pull request. Once coverage is where it should be, dropping
+# "informational" turns them into gates.
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+  require_changes: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
 
 ignore:
   - "doc"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,8 @@ include( CheckCXXCompilerFlag )
 check_cxx_compiler_flag( "-stdlib=libc++" CXX_COMPILER_SUPPORTS_LIBCXX )
 check_cxx_compiler_flag( "-Werror" CXX_COMPILER_SUPPORTS_WERROR )
 # Coverage is instrumented differently by each compiler, so ask about the flags that will
-# actually be used. Instrumentation also has to reach the link line, or the check fails on
-# the profiling runtime being missing rather than on the flag being unsupported. That is
-# what the previous check did, which quietly forced NANODBC_ENABLE_COVERAGE off however it
-# was set.
+# actually be used. They have to reach the link line as well, or the check fails on the
+# profiling runtime being missing rather than on the flag being unsupported.
 if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
   set( NANODBC_COVERAGE_COMPILE_OPTIONS -fprofile-instr-generate -fcoverage-mapping -O0 -g )
   set( NANODBC_COVERAGE_LINK_OPTIONS -fprofile-instr-generate )
@@ -228,9 +226,9 @@ endif()
 message( STATUS "nanodbc build: Enable test coverage - ${NANODBC_ENABLE_COVERAGE}" )
 
 if( NANODBC_ENABLE_COVERAGE )
-  # Under Clang this is source based coverage: it records which regions of an expression
-  # ran rather than only which lines were reached, and llvm-cov reads the result out of the
-  # binary. Under GCC it is gcov as before.
+  # Clang instruments source based coverage, recording which regions of an expression ran
+  # rather than only which lines were reached; llvm-cov reads the result out of the binary.
+  # GCC instruments gcov.
   target_compile_options( nanodbc PUBLIC ${NANODBC_COVERAGE_COMPILE_OPTIONS} )
   target_link_options( nanodbc PUBLIC ${NANODBC_COVERAGE_LINK_OPTIONS} )
 endif()

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ user information, example usage, propaganda, and detailed source level documenta
 
 ## Build Status
 
-| Branch | Linux                                                                                                                                                                | Windows                                                                                                                                                                  |
-| :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `main` | [![main](https://github.com/nanodbc/nanodbc/actions/workflows/ci-linux.yml/badge.svg?branch=main)](https://github.com/nanodbc/nanodbc/actions/workflows/ci-linux.yml) | [![main](https://github.com/nanodbc/nanodbc/actions/workflows/ci-windows.yml/badge.svg?branch=main)](https://github.com/nanodbc/nanodbc/actions/workflows/ci-windows.yml) |
+| Branch | Linux                                                                                                                                                                | Windows                                                                                                                                                                  | Coverage                                                                                                              |
+| :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------- |
+| `main` | [![main](https://github.com/nanodbc/nanodbc/actions/workflows/ci-linux.yml/badge.svg?branch=main)](https://github.com/nanodbc/nanodbc/actions/workflows/ci-linux.yml) | [![main](https://github.com/nanodbc/nanodbc/actions/workflows/ci-windows.yml/badge.svg?branch=main)](https://github.com/nanodbc/nanodbc/actions/workflows/ci-windows.yml) | [![codecov](https://codecov.io/gh/nanodbc/nanodbc/branch/main/graph/badge.svg)](https://codecov.io/gh/nanodbc/nanodbc) |
+
+Coverage is measured by the `coverage` job in [ci-linux.yml](.github/workflows/ci-linux.yml), which
+instruments the library with llvm-cov and runs the utility, SQLite and PostgreSQL suites. The same
+report is printed into the job summary of every run, so the figure is available there whether or not
+the badge service is reachable.
 
 ## Philosophy
 

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -345,14 +345,14 @@ inline std::size_t size(NANODBC_SQLCHAR const (&array)[N]) noexcept
 
 // Conversion between UTF-8 and the wide encoding the driver manager expects.
 //
-// std::wstring_convert and the std::codecvt facets that used to do this were deprecated in
-// C++17 and removed in C++26. The encoding follows from the width of wide_char_t: four
-// bytes is UTF-32, which is what iODBC takes, and two bytes is UTF-16, which is what every
-// other driver manager takes.
+// std::wstring_convert and the std::codecvt facets are deprecated in C++17 and removed in
+// C++26, so the conversion is done here. The encoding follows from the width of
+// wide_char_t: four bytes is UTF-32, which is what iODBC takes, and two bytes is UTF-16,
+// which is what every other driver manager takes.
 //
-// Malformed input throws std::range_error, as std::wstring_convert did, rather than being
-// silently replaced. A driver handing back text that does not decode is worth hearing
-// about instead of quietly turning into replacement characters.
+// Malformed input throws std::range_error rather than being silently replaced. A driver
+// handing back text that does not decode is worth hearing about instead of quietly turning
+// into replacement characters.
 
 inline void throw_invalid_encoding()
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,9 +14,9 @@ target_compile_definitions(Catch PRIVATE CATCH_AMALGAMATED_CUSTOM_MAIN)
 target_include_directories(Catch PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(Catch PUBLIC cxx_std_14)
 
-# Catch used to be header only, so its code was compiled into each test target and picked
-# up the standard library selection from there. Now that it is compiled on its own it has
-# to be told, or it builds against the default library and fails to link against the rest.
+# Catch is compiled on its own, so it needs the same standard library selection as
+# everything it links with. Left to itself it builds against the default library and the
+# link fails on missing symbols.
 if(NANODBC_FORCE_LIBCXX)
   target_compile_options(Catch PUBLIC -stdlib=libc++)
   target_link_options(Catch PUBLIC -stdlib=libc++ -lc++abi)


### PR DESCRIPTION
Three small things, all about coverage being visible.

## The badge is back

Points at Codecov, which the coverage job uploads to. The README also notes that the same llvm-cov report is printed into the job summary of every run, so the figure is readable from the run itself when the badge service is not.

## Coverage now reports on pull requests

The coverage job already runs on pull requests, so the number was being measured before merge — but `.codecov.yml` had `comment: off`, so nothing was said about it. Codecov now comments with the change and adds project and patch status checks.

Both checks are **informational**: they report the delta without failing the PR. At 50% that seemed the right starting point — a patch target that blocks merges is worth switching on once the figure is somewhere worth defending, and that is a one word change.

## Comments that narrated changes

Three of them described how the code came to be rather than what it does — the coverage feature check in `CMakeLists.txt`, the Catch standard library selection in `test/CMakeLists.txt`, and the UTF-8 codec in `nanodbc.cpp`. Each states the requirement instead.

## One dependency

All of the Codecov behaviour, badge and PR comments alike, needs `CODECOV_TOKEN` set as a repository secret. Without it the upload step does nothing and the badge stays *unknown*. The job summary does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)