### PR TITLE
Close the noexcept chain, and cover two more paths

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1544,9 +1544,9 @@ public:
 
     std::size_t transactions() const { return transactions_; }
 
-    void* native_dbc_handle() const { return dbc_; }
+    void* native_dbc_handle() const noexcept { return dbc_; }
 
-    void* native_env_handle() const { return env_; }
+    void* native_env_handle() const noexcept { return env_; }
 
     template <class T>
     T get_info(short info_type) const
@@ -4603,6 +4603,8 @@ inline void result::result_impl::get_ref_impl<date>(short column, date& result) 
             return;
         }
     }
+    default:
+        break;
     }
     throw type_incompatible_error();
 }
@@ -4631,6 +4633,8 @@ inline void result::result_impl::get_ref_impl<time>(short column, time& result) 
             return;
         }
     }
+    default:
+        break;
     }
     throw type_incompatible_error();
 }
@@ -4661,6 +4665,8 @@ inline void result::result_impl::get_ref_impl<timestamp>(short column, timestamp
             return;
         }
     }
+    default:
+        break;
     }
     throw type_incompatible_error();
 }
@@ -4693,6 +4699,8 @@ result::result_impl::get_ref_impl<timestampoffset>(short column, timestampoffset
             return;
         }
     }
+    default:
+        break;
     }
     throw type_incompatible_error();
 }
@@ -4992,6 +5000,8 @@ inline void result::result_impl::get_ref_impl<std::vector<std::uint8_t>>(
         }
         return;
     }
+    default:
+        break;
     }
     throw type_incompatible_error();
 }
@@ -5253,6 +5263,8 @@ void result::result_impl::get_ref_from_string_column(short column, T& result) co
     case SQL_C_WCHAR:
         result = static_cast<T>(*ensure_pdata<wide_char_t>(column));
         return;
+    default:
+        break;
     }
     throw type_incompatible_error();
 }
@@ -5351,6 +5363,8 @@ void result::result_impl::get_ref_impl(short column, T& result) const
     case SQL_C_UBIGINT:
         result = (T) * (ensure_pdata<uint64_t>(column));
         return;
+    default:
+        break;
     }
     throw type_incompatible_error();
 }
@@ -5686,12 +5700,12 @@ T connection::get_info(short info_type) const
     return impl_->get_info<T>(info_type);
 }
 
-void* connection::native_dbc_handle() const
+void* connection::native_dbc_handle() const noexcept
 {
     return impl_->native_dbc_handle();
 }
 
-void* connection::native_env_handle() const
+void* connection::native_env_handle() const noexcept
 {
     return impl_->native_env_handle();
 }
@@ -5908,7 +5922,7 @@ class connection& statement::connection()
     return impl_->connection();
 }
 
-void* statement::native_statement_handle() const
+void* statement::native_statement_handle() const noexcept
 {
     return impl_->native_statement_handle();
 }
@@ -7625,7 +7639,7 @@ void result::swap(result& rhs) noexcept
     swap(impl_, rhs.impl_);
 }
 
-void* result::native_statement_handle() const
+void* result::native_statement_handle() const noexcept
 {
     return impl_->native_statement_handle();
 }

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -980,7 +980,7 @@ public:
     const class connection& connection() const;
 
     /// \brief Returns the native ODBC statement handle.
-    void* native_statement_handle() const;
+    void* native_statement_handle() const noexcept;
 
     /// \brief Closes the statement and frees all associated resources.
     void close();
@@ -1748,10 +1748,10 @@ public:
     std::size_t transactions() const;
 
     /// \brief Returns the native ODBC database connection handle.
-    void* native_dbc_handle() const;
+    void* native_dbc_handle() const noexcept;
 
     /// \brief Returns the native ODBC environment handle.
-    void* native_env_handle() const;
+    void* native_env_handle() const noexcept;
 
     /// \brief Returns information from the ODBC connection as a string or fixed-size value.
     /// The general information about the driver and data source associated
@@ -1836,7 +1836,7 @@ public:
     void swap(result& rhs) noexcept;
 
     /// \brief Returns the native ODBC statement handle.
-    void* native_statement_handle() const;
+    void* native_statement_handle() const noexcept;
 
     /// \brief The rowset size for this result set.
     long rowset_size() const noexcept;

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -324,6 +324,17 @@ struct base_test_fixture
         }
     }
 
+    nanodbc::string get_bool_type_name()
+    {
+        switch (vendor_)
+        {
+        case database_vendor::sqlserver:
+            return NANODBC_TEXT("bit");
+        default:
+            return NANODBC_TEXT("boolean");
+        }
+    }
+
     nanodbc::string get_timestamp_type_name()
     {
         switch (vendor_)

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1137,6 +1137,16 @@ TEST_CASE_METHOD(mssql_fixture, "test_statement_open_close", "[mssql][statement]
     test_statement_open_close();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_boolean_column", "[mssql][boolean]")
+{
+    test_boolean_column();
+}
+
+TEST_CASE_METHOD(mssql_fixture, "test_bind_null_array", "[mssql][null]")
+{
+    test_bind_null_array();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_bind_null_sentry", "[mssql][statement]")
 {
     test_bind_null_sentry();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -347,6 +347,16 @@ TEST_CASE_METHOD(mysql_fixture, "test_statement_open_close", "[mysql][statement]
     test_statement_open_close();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_boolean_column", "[mysql][boolean]")
+{
+    test_boolean_column();
+}
+
+TEST_CASE_METHOD(mysql_fixture, "test_bind_null_array", "[mysql][null]")
+{
+    test_bind_null_array();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_bind_null_sentry", "[mysql][statement]")
 {
     test_bind_null_sentry();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -288,6 +288,16 @@ TEST_CASE_METHOD(postgresql_fixture, "test_statement_open_close", "[postgresql][
     test_statement_open_close();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "test_boolean_column", "[postgresql][boolean]")
+{
+    test_boolean_column();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "test_bind_null_array", "[postgresql][null]")
+{
+    test_bind_null_array();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_bind_null_sentry", "[postgresql][statement]")
 {
     test_bind_null_sentry();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -420,6 +420,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_statement_open_close", "[sqlite][statemen
     test_statement_open_close();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_bind_null_array", "[sqlite][null]")
+{
+    test_bind_null_array();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_bind_null_sentry", "[sqlite][statement]")
 {
     test_bind_null_sentry();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -935,6 +935,75 @@ struct test_case_fixture : public base_test_fixture
         }
     }
 
+    // The sibling of the sentry: an array of flags saying which of a batch are null. Scalar
+    // and binary values take separate paths to the same place.
+    void test_bind_null_array()
+    {
+        auto connection = connect();
+        create_table(
+            connection,
+            NANODBC_TEXT("test_bind_null_array"),
+            NANODBC_TEXT("(i int, b ") + get_binary_type_name(4) + NANODBC_TEXT(")"));
+
+        std::size_t const batch = 3;
+        int const values[batch] = {10, 20, 30};
+        std::vector<std::vector<std::uint8_t>> const binaries{
+            {0x01, 0x02, 0x03, 0x04}, {0x05, 0x06, 0x07, 0x08}, {0x09, 0x0a, 0x0b, 0x0c}};
+        bool const nulls[batch] = {false, true, false};
+
+        nanodbc::statement statement(connection);
+        prepare(statement, NANODBC_TEXT("insert into test_bind_null_array(i, b) values (?, ?);"));
+        statement.bind(0, values, batch, nulls);
+        statement.bind(1, binaries, nulls);
+        execute(statement, batch);
+
+        auto counted = execute(
+            connection,
+            NANODBC_TEXT(
+                "select count(*) from test_bind_null_array "
+                "where i is null and b is null;"));
+        REQUIRE(counted.next());
+        REQUIRE(counted.get<int>(0) == 1);
+
+        auto rest = execute(
+            connection,
+            NANODBC_TEXT(
+                "select count(*) from test_bind_null_array "
+                "where i is not null and b is not null;"));
+        REQUIRE(rest.next());
+        REQUIRE(rest.get<int>(0) == 2);
+    }
+
+    // A boolean column binds to SQL_C_BIT, which no other column type reaches.
+    void test_boolean_column()
+    {
+        auto connection = connect();
+        create_table(
+            connection,
+            NANODBC_TEXT("test_boolean_column"),
+            NANODBC_TEXT("(i int, b ") + get_bool_type_name() + NANODBC_TEXT(")"));
+
+        nanodbc::statement statement(connection);
+        prepare(statement, NANODBC_TEXT("insert into test_boolean_column(i, b) values (?, ?);"));
+        int index = 1;
+        bool truth = true;
+        statement.bind(0, &index);
+        statement.bind(1, &truth);
+        execute(statement);
+
+        auto results = execute(connection, NANODBC_TEXT("select i, b from test_boolean_column;"));
+        REQUIRE(results.next());
+        REQUIRE(results.get<bool>(1));
+        // The same column answers the integral types.
+        REQUIRE(results.get<int>(1) == 1);
+        REQUIRE(results.get<short>(1) == 1);
+
+        // Reading one as text is left alone here: rendering a string has no case for the C
+        // types the drivers bind a boolean to, so it reports the types are incompatible
+        // rather than answering. That is worth its own change.
+        REQUIRE(!results.next());
+    }
+
     void test_catalog_columns()
     {
         nanodbc::connection connection = connect();


### PR DESCRIPTION
Second pass over the code scanning list, with tests for the paths it touches.

## The review comment on #468

> The function is declared 'noexcept' but calls function 'native_statement_handle()' which may throw exceptions (f.6).

Right, and #468 only marked the implementation side. The public `connection::native_dbc_handle`, `connection::native_env_handle`, `statement::native_statement_handle` and `result::native_statement_handle` are trivial forwarders through a `shared_ptr` and cannot throw, so they now say so and the chain is closed. The callers were already declared `noexcept` and were already honest; the analyser could not see it because nothing they called was marked.

`success()` stays unmarked, as before: under `NANODBC_ODBC_API_DEBUG` it writes to `std::cerr`.

## Switches, C26818

Seven switches fall out to a `throw type_incompatible_error()`. They say `default` now, which changes nothing and saves a reader working out whether falling out of them was meant.

## Coverage, 80.0% to 80.4%

Two paths the suite had never taken, both of them things this pull request or the last one touched:

- **Binding a batch with an array of flags** saying which values are null. It is the sibling of the null sentry and arrives at the same place by another route, for scalars and for binary.
- **A boolean column**, which is the only way to reach the `SQL_C_BIT` binding.

## Found, and deliberately not fixed here

Reading a boolean column **as text** reports that the types are incompatible rather than answering, on SQL Server, MySQL and MariaDB alike: rendering a string has no case for the C types the drivers bind a boolean to. Every other numeric type renders. That is a change of behaviour rather than a cleanup, so it wants its own change and its own thought about what `get<string>` on a boolean should say.

## Verification

Every suite against containers: utility, SQLite, PostgreSQL, MySQL, MariaDB and SQL Server all pass. The alert count is measured by the Analysis job, PREfast being MSVC only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)