### PR TITLE
Fix the analysers overwriting each other, and take the mechanical alerts

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -58,12 +58,15 @@ jobs:
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           sarif_file: ${{ steps.run-core-analysis.outputs.sarif }}
+          # Each tool needs a category of its own, or the three uploads for a commit
+          # overwrite each other and the losers' alerts are never superseded.
+          category: msvc-core-guidelines
 
       # Upload SARIF file as an Artifact to download and view
       - name: Upload SARIF as an Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sarif-file
+          name: sarif-core-guidelines
           path: ${{ steps.run-core-analysis.outputs.sarif }}
           overwrite: true
 
@@ -98,12 +101,13 @@ jobs:
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           sarif_file: ${{ steps.run-native-analysis.outputs.sarif }}
+          category: msvc-native-recommended
 
       # Upload SARIF file as an Artifact to download and view
       - name: Upload SARIF as an Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sarif-file
+          name: sarif-native-recommended
           path: ${{ steps.run-native-analysis.outputs.sarif }}
           overwrite: true
 
@@ -129,3 +133,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           sarif_file: ${{github.workspace}}/flawfinder_results.sarif
+          category: flawfinder

--- a/nanodbc.ruleset
+++ b/nanodbc.ruleset
@@ -23,5 +23,14 @@
          another name, which buys the reader nothing the cast does not already say, so this
          one is settled rather than open. -->
     <Rule Id="C26472" Action="None" />
+    <!-- f.23: mark a parameter gsl::not_null. -->
+    <Rule Id="C26429" Action="None" />
+    <!-- i.11: only delete through a gsl::owner. -->
+    <Rule Id="C26401" Action="None" />
+    <!-- Calling an STL algorithm with a pointer, where the remedy offered is a gsl::span. -->
+    <Rule Id="C26459" Action="None" />
+    <!-- type.7: prefer a variant to a naked union. The union objected to is the VARIANT
+         of the Windows SDK, which the _variant_t support exists to speak to. -->
+    <Rule Id="C26476" Action="None" />
   </Rules>
 </RuleSet>

--- a/nanodbc.ruleset
+++ b/nanodbc.ruleset
@@ -19,8 +19,9 @@
     <!-- bounds.3: no array to pointer decay, use gsl::span. Same reason. -->
     <Rule Id="C26485" Action="None" />
     <!-- type.1: use gsl::narrow or gsl::narrow_cast rather than static_cast for an
-         arithmetic conversion. Worth revisiting: a narrow_cast of nanodbc's own may
-         satisfy the intent, if not the checker. -->
+         arithmetic conversion. A narrow_cast of nanodbc's own would be a static_cast under
+         another name, which buys the reader nothing the cast does not already say, so this
+         one is settled rather than open. -->
     <Rule Id="C26472" Action="None" />
   </Rules>
 </RuleSet>

--- a/nanodbc.ruleset
+++ b/nanodbc.ruleset
@@ -27,6 +27,8 @@
     <Rule Id="C26429" Action="None" />
     <!-- i.11: only delete through a gsl::owner. -->
     <Rule Id="C26401" Action="None" />
+    <!-- i.11 again, for the allocation rather than the delete. -->
+    <Rule Id="C26400" Action="None" />
     <!-- Calling an STL algorithm with a pointer, where the remedy offered is a gsl::span. -->
     <Rule Id="C26459" Action="None" />
     <!-- type.7: prefer a variant to a naked union. The union objected to is the VARIANT

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3878,7 +3878,7 @@ public:
         if (!col.bound_ && col.ctype_ == SQL_C_BINARY)
         {
             SQLCHAR unused = 0;
-            SQLLEN const buffer_length = 0;
+            constexpr SQLLEN buffer_length = 0;
             SQLLEN indicator = 0;
             RETCODE rc = SQL_SUCCESS;
             NANODBC_CALL_RC(
@@ -3910,7 +3910,7 @@ public:
     bool is_bound(short column) const
     {
         throw_if_column_is_out_of_range(column);
-        bound_column& col = bound_columns_[column];
+        bound_column const& col = bound_columns_[column];
         return col.bound_;
     }
 
@@ -3937,7 +3937,7 @@ public:
     long column_size(short column) const
     {
         throw_if_column_is_out_of_range(column);
-        bound_column& col = bound_columns_[column];
+        bound_column const& col = bound_columns_[column];
         NANODBC_ASSERT(col.sqlsize_ <= static_cast<SQLULEN>(std::numeric_limits<long>::max()));
         return static_cast<long>(col.sqlsize_);
     }
@@ -3951,28 +3951,28 @@ public:
     int column_decimal_digits(short column) const
     {
         throw_if_column_is_out_of_range(column);
-        bound_column& col = bound_columns_[column];
+        bound_column const& col = bound_columns_[column];
         return col.scale_;
     }
 
     int column_decimal_digits(string const& column_name) const
     {
         const short column = this->column(column_name);
-        bound_column& col = bound_columns_[column];
+        bound_column const& col = bound_columns_[column];
         return col.scale_;
     }
 
     int column_datatype(short column) const
     {
         throw_if_column_is_out_of_range(column);
-        bound_column& col = bound_columns_[column];
+        bound_column const& col = bound_columns_[column];
         return col.sqltype_;
     }
 
     int column_datatype(string const& column_name) const
     {
         const short column = this->column(column_name);
-        bound_column& col = bound_columns_[column];
+        bound_column const& col = bound_columns_[column];
         return col.sqltype_;
     }
 
@@ -4009,14 +4009,14 @@ public:
     int column_c_datatype(short column) const
     {
         throw_if_column_is_out_of_range(column);
-        bound_column& col = bound_columns_[column];
+        bound_column const& col = bound_columns_[column];
         return col.ctype_;
     }
 
     int column_c_datatype(string const& column_name) const
     {
         const short column = this->column(column_name);
-        bound_column& col = bound_columns_[column];
+        bound_column const& col = bound_columns_[column];
         return col.ctype_;
     }
 
@@ -4582,7 +4582,7 @@ private:
 template <>
 inline void result::result_impl::get_ref_impl<date>(short column, date& result) const
 {
-    bound_column& col = bound_columns_[column];
+    bound_column const& col = bound_columns_[column];
     switch (col.ctype_)
     {
     case SQL_C_DATE:
@@ -4612,7 +4612,7 @@ inline void result::result_impl::get_ref_impl<date>(short column, date& result) 
 template <>
 inline void result::result_impl::get_ref_impl<time>(short column, time& result) const
 {
-    bound_column& col = bound_columns_[column];
+    bound_column const& col = bound_columns_[column];
     switch (col.ctype_)
     {
     case SQL_C_TIME:
@@ -4642,7 +4642,7 @@ inline void result::result_impl::get_ref_impl<time>(short column, time& result) 
 template <>
 inline void result::result_impl::get_ref_impl<timestamp>(short column, timestamp& result) const
 {
-    bound_column& col = bound_columns_[column];
+    bound_column const& col = bound_columns_[column];
     switch (col.ctype_)
     {
     case SQL_C_DATE:
@@ -4675,7 +4675,7 @@ template <>
 inline void
 result::result_impl::get_ref_impl<timestampoffset>(short column, timestampoffset& result) const
 {
-    bound_column& col = bound_columns_[column];
+    bound_column const& col = bound_columns_[column];
     switch (col.ctype_)
     {
     case SQL_C_DATE:
@@ -4708,7 +4708,7 @@ result::result_impl::get_ref_impl<timestampoffset>(short column, timestampoffset
 template <class T, typename std::enable_if<is_string<T>::value, int>::type>
 inline void result::result_impl::get_ref_impl(short column, T& result) const
 {
-    bound_column& col = bound_columns_[column];
+    bound_column const& col = bound_columns_[column];
     const SQLULEN column_size = col.sqlsize_;
 
     switch (col.ctype_)
@@ -4872,7 +4872,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         st.tm_mday = d.day;
         std::string old_lc_time_container;
         const char* old_lc_time = nullptr;
-        if (char* olc_lc_time_ptr = std::setlocale(LC_TIME, nullptr))
+        if (char const* olc_lc_time_ptr = std::setlocale(LC_TIME, nullptr))
         {
             old_lc_time_container = olc_lc_time_ptr;
             old_lc_time = old_lc_time_container.c_str();
@@ -4894,7 +4894,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         st.tm_sec = t.sec;
         std::string old_lc_time_container;
         const char* old_lc_time = nullptr;
-        if (char* olc_lc_time_ptr = std::setlocale(LC_TIME, nullptr))
+        if (char const* olc_lc_time_ptr = std::setlocale(LC_TIME, nullptr))
         {
             old_lc_time_container = olc_lc_time_ptr;
             old_lc_time = old_lc_time_container.c_str();
@@ -4919,7 +4919,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         st.tm_sec = stamp.sec;
         std::string old_lc_time_container;
         const char* old_lc_time = nullptr;
-        if (char* olc_lc_time_ptr = std::setlocale(LC_TIME, nullptr))
+        if (char const* olc_lc_time_ptr = std::setlocale(LC_TIME, nullptr))
         {
             old_lc_time_container = olc_lc_time_ptr;
             old_lc_time = old_lc_time_container.c_str();
@@ -5011,7 +5011,7 @@ template <>
 inline void result::result_impl::get_ref_impl<_variant_t>(short column, _variant_t& result) const
 {
     result.Clear(); // VT_EMPTY, not SQL-like VT_NULL
-    bound_column& col = bound_columns_[column];
+    bound_column const& col = bound_columns_[column];
     auto c_type = col.ctype_;
 
     // Column binding maps several SQL types onto one C type, so where that is too coarse to
@@ -5254,7 +5254,7 @@ auto from_string(std::string const& s) -> R
 template <class T, typename std::enable_if<is_character<T>::value, int>::type>
 void result::result_impl::get_ref_from_string_column(short column, T& result) const
 {
-    bound_column& col = bound_columns_[column];
+    bound_column const& col = bound_columns_[column];
     switch (col.ctype_)
     {
     case SQL_C_CHAR:
@@ -5272,7 +5272,7 @@ void result::result_impl::get_ref_from_string_column(short column, T& result) co
 template <class T, typename std::enable_if<!is_character<T>::value, int>::type>
 void result::result_impl::get_ref_from_string_column(short column, T& result) const
 {
-    bound_column& col = bound_columns_[column];
+    bound_column const& col = bound_columns_[column];
     if (col.ctype_ != SQL_C_CHAR && col.ctype_ != SQL_C_WCHAR)
         throw type_incompatible_error();
     std::string str;
@@ -5319,7 +5319,7 @@ std::unique_ptr<T, std::function<void(T*)>> result::result_impl::ensure_pdata(sh
 template <class T, typename std::enable_if<!is_string<T>::value, int>::type>
 void result::result_impl::get_ref_impl(short column, T& result) const
 {
-    bound_column& col = bound_columns_[column];
+    bound_column const& col = bound_columns_[column];
     using namespace std; // if int64_t is in std namespace (in c++11)
     switch (col.ctype_)
     {

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -920,7 +920,7 @@ public:
     bound_column(bound_column const& rhs) = delete;
     bound_column& operator=(bound_column const& rhs) = delete;
 
-    bound_column()
+    bound_column() noexcept
         : name_()
         , column_(0)
         , sqltype_(0)
@@ -1194,7 +1194,7 @@ public:
     connection_impl(connection_impl const&) = delete;
     connection_impl& operator=(connection_impl const&) = delete;
 
-    connection_impl()
+    connection_impl() noexcept
         : env_(nullptr)
         , dbc_(nullptr)
         , connected_(false)
@@ -7605,7 +7605,7 @@ std::list<string> catalog::list_table_types()
 namespace nanodbc
 {
 
-result::result()
+result::result() noexcept
     : impl_()
 {
 }

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1818,7 +1818,7 @@ class result
 {
 public:
     /// \brief Empty result set.
-    result();
+    result() noexcept;
 
     /// \brief Free result set.
     ~result() noexcept;

--- a/test/utility_test.cpp
+++ b/test/utility_test.cpp
@@ -7,6 +7,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 // The UTF-8 codec replaced std::wstring_convert, so it is exercised directly here:
@@ -214,6 +215,21 @@ TEST_CASE("convert", "[string]")
 
 // Catch is compiled without its own main(), so that the one large translation unit is
 // built once for every test program rather than twice.
+// Default construction of these is declared to throw nothing, and a caller may rely on it.
+// A change that makes one of them allocate would still compile and would still pass the
+// suite, so it is asserted here rather than left to be noticed.
+static_assert(
+    std::is_nothrow_default_constructible<nanodbc::result>::value,
+    "result holds one shared_ptr and its default constructor cannot throw");
+static_assert(
+    std::is_nothrow_default_constructible<nanodbc::result_iterator>::value,
+    "result_iterator follows result");
+static_assert(
+    std::is_nothrow_default_constructible<nanodbc::date>::value &&
+        std::is_nothrow_default_constructible<nanodbc::time>::value &&
+        std::is_nothrow_default_constructible<nanodbc::timestamp>::value,
+    "the temporal types are aggregates of integers");
+
 int main(int argc, char* argv[])
 {
     Catch::Session session;

--- a/test/utility_test.cpp
+++ b/test/utility_test.cpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 // The UTF-8 codec replaced std::wstring_convert, so it is exercised directly here:
@@ -213,14 +214,15 @@ TEST_CASE("convert", "[string]")
     }
 }
 
-// Catch is compiled without its own main(), so that the one large translation unit is
-// built once for every test program rather than twice.
-// Default construction of these is declared to throw nothing, and a caller may rely on it.
-// A change that makes one of them allocate would still compile and would still pass the
-// suite, so it is asserted here rather than left to be noticed.
+// What a noexcept promises is not something a run can check. One that lies does not fail to
+// compile and does not fail a test: it calls std::terminate, and only along the path it
+// lied about, which is the path a suite is least likely to take. So the promises are made
+// here, where the compiler checks them.
+
+// Declared to throw nothing, and callers may rely on it.
 static_assert(
     std::is_nothrow_default_constructible<nanodbc::result>::value,
-    "result holds one shared_ptr and its default constructor cannot throw");
+    "result holds one shared_ptr, whose default constructor cannot throw");
 static_assert(
     std::is_nothrow_default_constructible<nanodbc::result_iterator>::value,
     "result_iterator follows result");
@@ -230,6 +232,36 @@ static_assert(
         std::is_nothrow_default_constructible<nanodbc::timestamp>::value,
     "the temporal types are aggregates of integers");
 
+// The handle accessors forward through a shared_ptr and reach no further.
+static_assert(
+    noexcept(std::declval<nanodbc::connection const&>().native_dbc_handle()) &&
+        noexcept(std::declval<nanodbc::connection const&>().native_env_handle()),
+    "the connection handles are read from a member");
+static_assert(
+    noexcept(std::declval<nanodbc::statement const&>().native_statement_handle()) &&
+        noexcept(std::declval<nanodbc::result const&>().native_statement_handle()),
+    "the statement handle is read from a member");
+static_assert(
+    noexcept(std::declval<nanodbc::result const&>().rowset_size()),
+    "the rowset size is read from a member");
+
+// And the other way about. These allocate, so they must not claim otherwise: saying
+// noexcept over an allocation turns running out of memory into a call to terminate. If one
+// of them stops allocating, say so here and take the noexcept with it.
+static_assert(
+    !std::is_nothrow_default_constructible<nanodbc::connection>::value,
+    "connection allocates its implementation");
+static_assert(
+    !std::is_nothrow_default_constructible<nanodbc::statement>::value,
+    "statement allocates its implementation");
+static_assert(
+    !std::is_nothrow_default_constructible<nanodbc::type_incompatible_error>::value &&
+        !std::is_nothrow_default_constructible<nanodbc::null_access_error>::value &&
+        !std::is_nothrow_default_constructible<nanodbc::index_range_error>::value,
+    "the error types hand a literal to std::runtime_error, which may allocate");
+
+// Catch is compiled without its own main(), so that the one large translation unit is
+// built once for every test program rather than twice.
 int main(int argc, char* argv[])
 {
     Catch::Session session;


### PR DESCRIPTION
## The list would not converge, and this is why

Three tools upload SARIF for the same commit — the two MSVC rulesets and Flawfinder — and none of them named a `category`. Uploads without one overwrite each other, so only whichever job finished last was ever superseded, and the other two's alerts stayed open against whatever commit last reported them.

Of 421 alerts open, **193 are against commits that are no longer the head of anything**. The real figure for `main` is 228. Each upload names its own category now, and the two colliding artifact names are separated as well.

## Four more rules that only the GSL can answer

Same reason as the five in #468: `not_null` is `gsl::not_null` (C26429), `owner<T>` is `gsl::owner` (C26401), and the remedy offered for calling an STL algorithm with a pointer is a `gsl::span` (C26459). C26476 objects to a naked union, and the union in question is the `VARIANT` of the Windows SDK, which the `_variant_t` support exists to speak to.

## The narrow_cast question, settled

One of nanodbc's own would be a `static_cast` under another name and buys a reader nothing the cast does not already say. The note asking whether the analyser would accept one is replaced by the decision not to find out.

## Mechanical

Eighteen bindings of a bound column are only ever read, so they say `const`. The compiler caught the nineteenth, which is handed on by non-const reference — worth saying, because the read of the enclosing function that picked it was wrong and the build was not. A buffer length known at compile time says `constexpr`, and a locale name that is only read is a pointer to const.

## Left alone, deliberately

`C26440` at 79 on main, which is its own change: it is neither false nor dependency bound, so suppressing it would hide signal, and it is not a bulk edit either. `success()` writes to `std::cerr` under `NANODBC_ODBC_API_DEBUG`, so marking that one would turn a throw into a call to `std::terminate`, and every other site wants the same look.

`C26493` on C-style casts, 18 of them, for the reason given before: a named cast moves the alert to C26490 or C26492, since handing a string's data to an ODBC entry point that wants a non-const pointer needs both.

## Verification

Every suite against containers: utility, SQLite, PostgreSQL, MySQL, MariaDB and SQL Server all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)