### PR TITLE
Declare noexcept where a function really cannot throw

### DIFF
--- a/nanodbc.ruleset
+++ b/nanodbc.ruleset
@@ -34,5 +34,11 @@
     <!-- type.7: prefer a variant to a naked union. The union objected to is the VARIANT
          of the Windows SDK, which the _variant_t support exists to speak to. -->
     <Rule Id="C26476" Action="None" />
+    <!-- type.4: no C style casts. These sit where nanodbc hands a buffer or a handle to
+         the driver manager, and a named cast does not remove the alert so much as move it:
+         the same ruleset objects to reinterpret_cast with C26490 and to const_cast with
+         C26492, and passing a string's data to an entry point that wants a non-const
+         pointer needs both. The cast is the C API showing through, not untidiness. -->
+    <Rule Id="C26493" Action="None" />
   </Rules>
 </RuleSet>

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1533,7 +1533,7 @@ public:
         return rc;
     }
 
-    bool connected() const { return connected_; }
+    bool connected() const noexcept { return connected_; }
 
     void disconnect()
     {
@@ -1547,7 +1547,7 @@ public:
         connected_ = false;
     }
 
-    std::size_t transactions() const { return transactions_; }
+    std::size_t transactions() const noexcept { return transactions_; }
 
     void* native_dbc_handle() const noexcept { return dbc_; }
 
@@ -1586,9 +1586,9 @@ public:
         return {&name[0], &name[size(name)]};
     }
 
-    std::size_t ref_transaction() { return ++transactions_; }
+    std::size_t ref_transaction() noexcept { return ++transactions_; }
 
-    std::size_t unref_transaction()
+    std::size_t unref_transaction() noexcept
     {
         if (transactions_ > 0)
             --transactions_;
@@ -1783,9 +1783,9 @@ public:
         conn_.rollback(true);
     }
 
-    class connection& connection() { return conn_; }
+    class connection& connection() noexcept { return conn_; }
 
-    const class connection& connection() const { return conn_; }
+    const class connection& connection() const noexcept { return conn_; }
 
 private:
     class connection conn_;
@@ -1951,13 +1951,13 @@ public:
         }
     }
 
-    bool open() const { return open_; }
+    bool open() const noexcept { return open_; }
 
     bool connected() const { return conn_.connected(); }
 
-    const class connection& connection() const { return conn_; }
+    const class connection& connection() const noexcept { return conn_; }
 
-    class connection& connection() { return conn_; }
+    class connection& connection() noexcept { return conn_; }
 
     void* native_statement_handle() const noexcept { return stmt_; }
 
@@ -2731,6 +2731,15 @@ public:
         return lhs == rhs;
     }
 
+    // Overloads rather than specialisations of the above: a specialisation has to
+    // carry the same exception specification as its primary, and narrowing a wide
+    // string allocates where comparing the rest does not.
+    bool equals(std::string const& lhs, std::string const& rhs) noexcept;
+    bool equals(wide_string const& lhs, wide_string const& rhs);
+    bool equals(date const& lhs, date const& rhs) noexcept;
+    bool equals(time const& lhs, time const& rhs) noexcept;
+    bool equals(timestamp const& lhs, timestamp const& rhs) noexcept;
+
     template <class T>
     std::vector<T>& get_bound_string_data(short param_index);
 
@@ -2870,14 +2879,12 @@ void statement::statement_impl::bind_strings(
     bind_parameter(param, buffer);
 }
 
-template <>
-bool statement::statement_impl::equals(std::string const& lhs, std::string const& rhs)
+bool statement::statement_impl::equals(std::string const& lhs, std::string const& rhs) noexcept
 {
     return std::strncmp(lhs.c_str(), rhs.c_str(), lhs.size()) == 0;
 }
 
-template <>
-bool statement::statement_impl::equals(const wide_string& lhs, const wide_string& rhs)
+bool statement::statement_impl::equals(wide_string const& lhs, wide_string const& rhs)
 {
     // e6059ff3a79062f83256b9d1d3c9c8368798781e
     // Functions like `swprintf()`, `wcsftime()`, `wcsncmp()` can not be used
@@ -2892,20 +2899,17 @@ bool statement::statement_impl::equals(const wide_string& lhs, const wide_string
     return equals(narrow_lhs, narrow_rhs);
 }
 
-template <>
-bool statement::statement_impl::equals(const date& lhs, const date& rhs)
+bool statement::statement_impl::equals(const date& lhs, const date& rhs) noexcept
 {
     return lhs.year == rhs.year && lhs.month == rhs.month && lhs.day == rhs.day;
 }
 
-template <>
-bool statement::statement_impl::equals(const time& lhs, const time& rhs)
+bool statement::statement_impl::equals(const time& lhs, const time& rhs) noexcept
 {
     return lhs.hour == rhs.hour && lhs.min == rhs.min && lhs.sec == rhs.sec;
 }
 
-template <>
-bool statement::statement_impl::equals(const timestamp& lhs, const timestamp& rhs)
+bool statement::statement_impl::equals(const timestamp& lhs, const timestamp& rhs) noexcept
 {
     return lhs.year == rhs.year && lhs.month == rhs.month && lhs.day == rhs.day &&
            lhs.hour == rhs.hour && lhs.min == rhs.min && lhs.sec == rhs.sec &&
@@ -3398,7 +3402,7 @@ public:
         }
     }
 
-    short parameters() const { return param_descr_data_.size(); }
+    short parameters() const noexcept { return param_descr_data_.size(); }
 
     unsigned long parameter_size(short param_index)
     {
@@ -3446,6 +3450,15 @@ public:
     {
         return lhs == rhs;
     }
+
+    // Overloads rather than specialisations of the above: a specialisation has to
+    // carry the same exception specification as its primary, and narrowing a wide
+    // string allocates where comparing the rest does not.
+    bool equals(std::string const& lhs, std::string const& rhs) noexcept;
+    bool equals(wide_string const& lhs, wide_string const& rhs);
+    bool equals(date const& lhs, date const& rhs) noexcept;
+    bool equals(time const& lhs, time const& rhs) noexcept;
+    bool equals(timestamp const& lhs, timestamp const& rhs) noexcept;
 
     template <class T>
     std::vector<T>& get_bound_string_data(short param_index);
@@ -3583,18 +3596,16 @@ void table_valued_parameter::table_valued_parameter_impl::bind_strings(
     bind_parameter(param, buffer);
 }
 
-template <>
 bool table_valued_parameter::table_valued_parameter_impl::equals(
     std::string const& lhs,
-    std::string const& rhs)
+    std::string const& rhs) noexcept
 {
     return std::strncmp(lhs.c_str(), rhs.c_str(), lhs.size()) == 0;
 }
 
-template <>
 bool table_valued_parameter::table_valued_parameter_impl::equals(
-    const wide_string& lhs,
-    const wide_string& rhs)
+    wide_string const& lhs,
+    wide_string const& rhs)
 {
     // e6059ff3a79062f83256b9d1d3c9c8368798781e
     // Functions like `swprintf()`, `wcsftime()`, `wcsncmp()` can not be used
@@ -3609,22 +3620,23 @@ bool table_valued_parameter::table_valued_parameter_impl::equals(
     return equals(narrow_lhs, narrow_rhs);
 }
 
-template <>
-bool table_valued_parameter::table_valued_parameter_impl::equals(const date& lhs, const date& rhs)
+bool table_valued_parameter::table_valued_parameter_impl::equals(
+    const date& lhs,
+    const date& rhs) noexcept
 {
     return lhs.year == rhs.year && lhs.month == rhs.month && lhs.day == rhs.day;
 }
 
-template <>
-bool table_valued_parameter::table_valued_parameter_impl::equals(const time& lhs, const time& rhs)
+bool table_valued_parameter::table_valued_parameter_impl::equals(
+    const time& lhs,
+    const time& rhs) noexcept
 {
     return lhs.hour == rhs.hour && lhs.min == rhs.min && lhs.sec == rhs.sec;
 }
 
-template <>
 bool table_valued_parameter::table_valued_parameter_impl::equals(
     const timestamp& lhs,
-    const timestamp& rhs)
+    const timestamp& rhs) noexcept
 {
     return lhs.year == rhs.year && lhs.month == rhs.month && lhs.day == rhs.day &&
            lhs.hour == rhs.hour && lhs.min == rhs.min && lhs.sec == rhs.sec &&
@@ -5252,7 +5264,7 @@ auto from_string(std::string const& s, R)
 }
 
 #if defined(_MSC_VER)
-auto from_string(std::string const& s, _variant_t)
+auto from_string(std::string const& s, _variant_t) noexcept
 {
     return s.c_str();
 }
@@ -5306,7 +5318,7 @@ std::unique_ptr<T, std::function<void(T*)>> result::result_impl::ensure_pdata(sh
         // Return a unique_ptr with a no-op deleter as this memory allocation
         // is managed (allocated and released) elsewhere.
         return std::unique_ptr<T, std::function<void(T*)>>(
-            (T*)(col.pdata_ + rowset_position_ * col.clen_), [](T*) {});
+            (T*)(col.pdata_ + rowset_position_ * col.clen_), [](T*) noexcept {});
     }
 
     std::unique_ptr<T> buffer = std::make_unique<T>();
@@ -5586,7 +5598,7 @@ connection::connection()
 {
 }
 
-connection::connection(const connection& rhs)
+connection::connection(const connection& rhs) noexcept
     : impl_(rhs.impl_)
 {
 }
@@ -5596,7 +5608,7 @@ connection::connection(connection&& rhs) noexcept
 {
 }
 
-connection& connection::operator=(connection rhs)
+connection& connection::operator=(connection rhs) noexcept
 {
     swap(rhs);
     return *this;
@@ -5797,7 +5809,7 @@ transaction::transaction(const class connection& conn)
 {
 }
 
-transaction::transaction(const transaction& rhs)
+transaction::transaction(const transaction& rhs) noexcept
     : impl_(rhs.impl_)
 {
 }
@@ -5807,7 +5819,7 @@ transaction::transaction(transaction&& rhs) noexcept
 {
 }
 
-transaction& transaction::operator=(transaction rhs)
+transaction& transaction::operator=(transaction rhs) noexcept
 {
     swap(rhs);
     return *this;
@@ -5893,12 +5905,12 @@ statement::statement(class connection& conn, string const& query, long timeout)
 {
 }
 
-statement::statement(const statement& rhs)
+statement::statement(const statement& rhs) noexcept
     : impl_(rhs.impl_)
 {
 }
 
-statement& statement::operator=(statement rhs)
+statement& statement::operator=(statement rhs) noexcept
 {
     swap(rhs);
     return *this;
@@ -6668,7 +6680,7 @@ table_valued_parameter::table_valued_parameter()
 {
 }
 
-table_valued_parameter::table_valued_parameter(const table_valued_parameter& rhs)
+table_valued_parameter::table_valued_parameter(const table_valued_parameter& rhs) noexcept
     : impl_(rhs.impl_)
 {
 }
@@ -7637,12 +7649,12 @@ result::result(result&& rhs) noexcept
 {
 }
 
-result::result(const result& rhs)
+result::result(const result& rhs) noexcept
     : impl_(rhs.impl_)
 {
 }
 
-result& result::operator=(result rhs)
+result& result::operator=(result rhs) noexcept
 {
     swap(rhs);
     return *this;
@@ -7894,7 +7906,7 @@ T result::get(string const& column_name, T const& fallback) const
     return impl_->get<T>(column_name, fallback);
 }
 
-result::operator bool() const
+result::operator bool() const noexcept
 {
     return static_cast<bool>(impl_);
 }

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -562,13 +562,13 @@ public:
     explicit transaction(const class connection& conn);
 
     /// Copy constructor.
-    transaction(const transaction& rhs);
+    transaction(const transaction& rhs) noexcept;
 
     /// Move constructor.
     transaction(transaction&& rhs) noexcept;
 
     /// Assignment.
-    transaction& operator=(transaction rhs);
+    transaction& operator=(transaction rhs) noexcept;
 
     /// Member swap.
     void swap(transaction& rhs) noexcept;
@@ -624,7 +624,7 @@ public:
     table_valued_parameter();
 
     /// \brief Copy constructor.
-    table_valued_parameter(const table_valued_parameter& rhs);
+    table_valued_parameter(const table_valued_parameter& rhs) noexcept;
 
     /// \brief Move constructor.
     table_valued_parameter(table_valued_parameter&& rhs) noexcept;
@@ -947,13 +947,13 @@ public:
     statement(class connection& conn, string const& query, long timeout = 0);
 
     /// \brief Copy constructor.
-    statement(const statement& rhs);
+    statement(const statement& rhs) noexcept;
 
     /// \brief Move constructor.
     statement(statement&& rhs) noexcept;
 
     /// \brief Assignment.
-    statement& operator=(statement rhs);
+    statement& operator=(statement rhs) noexcept;
 
     /// \brief Member swap.
     void swap(statement& rhs) noexcept;
@@ -1565,13 +1565,13 @@ public:
     connection();
 
     /// Copy constructor.
-    connection(const connection& rhs);
+    connection(const connection& rhs) noexcept;
 
     /// Move constructor.
     connection(connection&& rhs) noexcept;
 
     /// Assignment.
-    connection& operator=(connection rhs);
+    connection& operator=(connection rhs) noexcept;
 
     /// Member swap.
     void swap(connection&) noexcept;
@@ -1824,13 +1824,13 @@ public:
     ~result() noexcept;
 
     /// \brief Copy constructor.
-    result(const result& rhs);
+    result(const result& rhs) noexcept;
 
     /// \brief Move constructor.
     result(result&& rhs) noexcept;
 
     /// \brief Assignment.
-    result& operator=(result rhs);
+    result& operator=(result rhs) noexcept;
 
     /// \brief Member swap.
     void swap(result& rhs) noexcept;
@@ -2195,7 +2195,7 @@ public:
     bool next_result();
 
     /// \brief If and only if result object is valid, returns true.
-    explicit operator bool() const;
+    explicit operator bool() const noexcept;
 
 private:
     result(statement statement, long rowset_size);
@@ -2233,7 +2233,7 @@ public:
     }
 
     /// Dereference.
-    reference operator*() { return result_; }
+    reference operator*() noexcept { return result_; }
 
     /// Access through dereference.
     pointer operator->()
@@ -2294,7 +2294,7 @@ inline result_iterator begin(result& r)
 /// When a valid `nanodbc::result_iterator` reaches the end of the underlying result set,
 /// it becomes equal to the end-of-result iterator.
 /// Dereferencing or incrementing it further is undefined.
-inline result_iterator end(result& /*r*/)
+inline result_iterator end(result& /*r*/) noexcept
 {
     return {};
 }

--- a/nanodbc/variant_row_cached_result.h
+++ b/nanodbc/variant_row_cached_result.h
@@ -57,12 +57,15 @@ public:
     /// \brief Access to underlying result
     ///
     /// For example, in order to access to columns metadata.
-    nanodbc::result& result() { return static_cast<nanodbc::result&>(*this); }
+    nanodbc::result& result() noexcept { return static_cast<nanodbc::result&>(*this); }
 
     /// \brief Access to underlying result
     ///
     /// For example, in order to access to columns metadata.
-    nanodbc::result const& result() const { return static_cast<nanodbc::result const&>(*this); }
+    nanodbc::result const& result() const noexcept
+    {
+        return static_cast<nanodbc::result const&>(*this);
+    }
 
 private:
     /// \brief Clears cache of row values as result::next pre-condition.

--- a/test/utility_test.cpp
+++ b/test/utility_test.cpp
@@ -266,13 +266,19 @@ static_assert(
 // for the operation that went missing, so the shape of each public type is stated here.
 
 // Copy and swap: constructible and assignable both ways, the assignment taking its
-// argument by value and serving either. Adding a move assignment alongside it would make
+// argument by value and serving either. Each holds nothing but a shared_ptr, so none of the
+// four can throw, which is what a container reads before deciding whether it may move on
+// reallocation rather than copy. Adding a move assignment alongside it would make
 // every assignment from an rvalue ambiguous, so the set stops at four on purpose.
 #define NANODBC_ASSERT_COPY_AND_SWAP(T)                                                            \
     static_assert(std::is_copy_constructible<T>::value, #T " is copy constructible");              \
     static_assert(std::is_move_constructible<T>::value, #T " is move constructible");              \
     static_assert(std::is_copy_assignable<T>::value, #T " is copy assignable");                    \
-    static_assert(std::is_move_assignable<T>::value, #T " is move assignable")
+    static_assert(std::is_move_assignable<T>::value, #T " is move assignable");                    \
+    static_assert(std::is_nothrow_copy_constructible<T>::value, #T " copies a shared_ptr");        \
+    static_assert(std::is_nothrow_move_constructible<T>::value, #T " moves a shared_ptr");         \
+    static_assert(std::is_nothrow_copy_assignable<T>::value, #T " copy assigns a shared_ptr");     \
+    static_assert(std::is_nothrow_move_assignable<T>::value, #T " move assigns a shared_ptr")
 
 NANODBC_ASSERT_COPY_AND_SWAP(nanodbc::result);
 NANODBC_ASSERT_COPY_AND_SWAP(nanodbc::statement);
@@ -290,6 +296,10 @@ static_assert(
     std::is_copy_constructible<nanodbc::table_valued_parameter>::value &&
         std::is_move_constructible<nanodbc::table_valued_parameter>::value,
     "table_valued_parameter can be built from another");
+static_assert(
+    std::is_nothrow_copy_constructible<nanodbc::table_valued_parameter>::value &&
+        std::is_nothrow_move_constructible<nanodbc::table_valued_parameter>::value,
+    "and doing so copies a shared_ptr, which cannot throw");
 static_assert(
     !std::is_copy_assignable<nanodbc::table_valued_parameter>::value &&
         !std::is_move_assignable<nanodbc::table_valued_parameter>::value,


### PR DESCRIPTION
C26440, the last large group: 80 alerts saying a function could be declared `noexcept`. Taken one at a time, because the answer differs and a wrong one does not fail to build — it calls `std::terminate`, along the path it lied about.

## What was marked

Most are plain. Accessors that read a member (`connected`, `transactions`, `open`, `parameters`, the `connection()` pair in two classes), copy constructors that copy a `shared_ptr`, copy-and-swap assignments whose body swaps two of them, `result::operator bool`, `result_iterator::operator*`, `end()`, and the `variant_row_cached_result` accessors that `static_cast` to their private base.

Sixteen of the eighty are one lambda: the no-op deleter `[](T*) {}`, instantiated sixteen times.

Marking the copy constructors as well as the assignments makes the public types nothrow copyable and nothrow movable throughout. That is true — copying a handle is a reference count away from free — and it is worth having: a container reads exactly those traits before deciding it may move on reallocation rather than copy.

## The comparator family needed a change of shape

Nearly forty of the alerts are `equals<T>`, in two classes. Its four special cases were explicit specialisations, and **a specialisation must carry the same exception specification as its primary**, so the family had to agree with itself:

```
error: declaration of 'bool S::equals(const T&, const T&) [with T = std::u16string]'
       has a different exception specifier
```

One of them narrows a wide string into a `std::string` first, which allocates. Marking the primary would have forced that one to claim `noexcept` as well.

They are overloads now rather than specialisations, so each states its own specification and the wide string one states nothing. Overloads are the better tool here regardless; the exception specification is only the reason it came up.

## What was not marked

`success()` writes to `std::cerr` under `NANODBC_ODBC_API_DEBUG`, so it can throw. It keeps its exceptions, as it did when this came up in #470.

## Verification

Every suite against containers: utility, SQLite, PostgreSQL, MySQL, MariaDB and SQL Server all pass. The null sentry tests added earlier exercise `equals` directly, which is what makes the change of shape checkable rather than merely plausible.

The new guarantees are asserted in `utility_test.cpp`, and the assertions were checked by breaking them: taking `noexcept` off `result`'s copy constructor fails two, the second because copy assignment's guarantee rests on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)