### PR TITLE
Handle SQL_NO_TOTAL when retrieving binary data in chunks

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -5002,7 +5002,9 @@ inline void result::result_impl::get_ref_impl<std::vector<std::uint8_t>>(
                     buffer,                                // TargetValuePtr
                     buffer_size,                           // BufferLength
                     &ValueLenOrInd);                       // StrLen_or_IndPtr
-                if (ValueLenOrInd > 0)
+                if (ValueLenOrInd == SQL_NO_TOTAL)
+                    out.insert(std::end(out), buffer, buffer + buffer_size);
+                else if (ValueLenOrInd > 0)
                 {
                     auto const buffer_size_filled =
                         std::min<std::size_t>(ValueLenOrInd, buffer_size);


### PR DESCRIPTION
Per the ODBC spec ([SQLGetData: Retrieving Data in Parts](https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/getting-long-data)), a driver may set the indicator to `SQL_NO_TOTAL` (−4) on intermediate `SQL_SUCCESS_WITH_INFO` calls when it cannot determine the remaining data length. 

The `SQL_C_CHAR` and `SQL_C_WCHAR` retrieval paths in `get_ref_impl<string_type>` already handle this case e.g.

https://github.com/nanodbc/nanodbc/blob/a18991977807f5f944448b754d42d113913f8151/nanodbc/nanodbc.cpp#L4784-L4785

Downstream issue: https://github.com/r-dbi/odbc/issues/1024

