### PR TITLE
More coverage, and a bug it found

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4170,7 +4170,8 @@ public:
         short const column = this->column(column_name);
         if (is_null(column))
         {
-            NANODBC_ASSERT(is_bound(column));
+            // Not asserted to be bound: an unbound column reports itself null here too, and
+            // MySQL sets the indicator to SQL_NULL_DATA from SQLBindCol regardless.
             result = fallback;
             return;
         }

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -2489,4 +2489,38 @@ TEST_CASE_METHOD(mssql_fixture, "test_output_parameters", "[mssql][statement][bi
 
     REQUIRE(out == 42);
     REQUIRE(inout == 101);
+
+    // A return value is bound in a direction of its own, which maps onto the same
+    // SQL_PARAM_OUTPUT.
+    nanodbc::statement returning(connection);
+    returning.prepare(NANODBC_TEXT("{ ? = CALL ") + name + NANODBC_TEXT("(?, ?, ?) }"));
+    int rv = 0;
+    int const in2 = 1;
+    int out2 = 0;
+    int inout2 = 0;
+    returning.bind(0, &rv, nanodbc::statement::PARAM_RETURN);
+    returning.bind(1, &in2);
+    returning.bind(2, &out2, nanodbc::statement::PARAM_OUT);
+    returning.bind(3, &inout2, nanodbc::statement::PARAM_INOUT);
+    returning.just_execute();
+    REQUIRE(out2 == 2);
+}
+
+// An NVARCHAR column is bound wide, so reading one as a character takes the wide arm of
+// the string column path.
+TEST_CASE_METHOD(mssql_fixture, "test_wide_bound_column_as_character", "[mssql][result][unicode]")
+{
+    auto connection = connect();
+    create_table(
+        connection,
+        NANODBC_TEXT("test_wide_bound_column_as_character"),
+        NANODBC_TEXT("(s nvarchar(10))"));
+    execute(
+        connection,
+        NANODBC_TEXT("insert into test_wide_bound_column_as_character (s) values (N'9');"));
+
+    auto results =
+        execute(connection, NANODBC_TEXT("select s from test_wide_bound_column_as_character;"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<char>(0) == '9');
 }

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -2549,3 +2549,43 @@ TEST_CASE_METHOD(mssql_fixture, "test_bind_unnamed_sql_type", "[mssql][result][t
     REQUIRE(results.next());
     REQUIRE(!results.get<nanodbc::string>(0).empty());
 }
+
+// The two ways a table valued parameter column can be told which of its values are null: a
+// sentry for the numeric columns, and a flag per value for the binary one.
+TEST_CASE_METHOD(
+    mssql_table_valued_parameter_fixture,
+    "test_table_valued_parameter_null_marking",
+    "[mssql][table_valued_paramter]")
+{
+    auto conn = connect();
+    auto stmt = nanodbc::statement(conn);
+    stmt.prepare(NANODBC_TEXT("{ CALL tvp_test(?, ?, ?) }"));
+    stmt.bind(0, &p0_);
+
+    // A flag set marks that value null; the rest are given their length.
+    std::vector<char> nulls(static_cast<std::size_t>(num_rows_), 0);
+    nulls[0] = 1;
+
+    auto p1 = nanodbc::table_valued_parameter(stmt, 1, num_rows_);
+    p1.bind(0, p1_col0_.data(), p1_col0_.size());
+    // The first value as its own sentry, so that row's col1 arrives null.
+    p1.bind(1, p1_col1_.data(), p1_col1_.size(), &p1_col1_.front());
+    p1.bind_strings(2, p1_col2_);
+    p1.bind_strings(3, p1_col3_);
+    p1.bind(4, p1_col4_, reinterpret_cast<bool const*>(nulls.data()));
+    p1.close();
+    stmt.bind(2, p2_.c_str());
+
+    auto results = stmt.execute();
+    int sentry_nulls = 0;
+    int flagged_nulls = 0;
+    while (results.next())
+    {
+        if (results.is_null(2))
+            ++sentry_nulls;
+        if (results.is_null(5))
+            ++flagged_nulls;
+    }
+    REQUIRE(sentry_nulls == 1);
+    REQUIRE(flagged_nulls == 1);
+}

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -2524,3 +2524,28 @@ TEST_CASE_METHOD(mssql_fixture, "test_wide_bound_column_as_character", "[mssql][
     REQUIRE(results.next());
     REQUIRE(results.get<char>(0) == '9');
 }
+
+TEST_CASE_METHOD(mssql_fixture, "test_null_long_text_fallback", "[mssql][result][null]")
+{
+    test_null_long_text_fallback();
+}
+
+// A column whose SQL type the binding switch does not name falls to its default arm, which
+// binds it as text. uniqueidentifier is one such.
+TEST_CASE_METHOD(mssql_fixture, "test_bind_unnamed_sql_type", "[mssql][result][types]")
+{
+    auto connection = connect();
+    create_table(
+        connection,
+        NANODBC_TEXT("test_bind_unnamed_sql_type"),
+        NANODBC_TEXT("(g uniqueidentifier)"));
+    execute(
+        connection,
+        NANODBC_TEXT(
+            "insert into test_bind_unnamed_sql_type (g) values "
+            "('6F9619FF-8B86-D011-B42D-00C04FC964FF');"));
+
+    auto results = execute(connection, NANODBC_TEXT("select g from test_bind_unnamed_sql_type;"));
+    REQUIRE(results.next());
+    REQUIRE(!results.get<nanodbc::string>(0).empty());
+}

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -570,3 +570,8 @@ TEST_CASE_METHOD(mysql_fixture, "test_binary_read_shapes", "[mysql][result][bina
 {
     test_binary_read_shapes();
 }
+
+TEST_CASE_METHOD(mysql_fixture, "test_null_long_text_fallback", "[mysql][result][null]")
+{
+    test_null_long_text_fallback();
+}

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -628,3 +628,8 @@ TEST_CASE_METHOD(postgresql_fixture, "test_binary_read_shapes", "[postgresql][re
 {
     test_binary_read_shapes();
 }
+
+TEST_CASE_METHOD(postgresql_fixture, "test_null_long_text_fallback", "[postgresql][result][null]")
+{
+    test_null_long_text_fallback();
+}

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -620,3 +620,8 @@ TEST_CASE_METHOD(sqlite_fixture, "test_binary_read_shapes", "[sqlite][result][bi
 {
     test_binary_read_shapes();
 }
+
+TEST_CASE_METHOD(sqlite_fixture, "test_null_long_text_fallback", "[sqlite][result][null]")
+{
+    test_null_long_text_fallback();
+}

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -920,6 +920,31 @@ struct test_case_fixture : public base_test_fixture
 
     // Binary reads take a different path per shape: a short column is bound and copied out
     // of the row buffer, a long one is fetched in chunks, and a null one reports itself.
+    // A long text column is unbound, so whether it is null is only known once it has been
+    // read: the fallback is chosen after the read rather than before it.
+    void test_null_long_text_fallback()
+    {
+        nanodbc::connection connection = connect();
+        create_table(
+            connection,
+            NANODBC_TEXT("test_null_long_text_fallback"),
+            NANODBC_TEXT("(id int, t ") + get_text_type_name() + NANODBC_TEXT(")"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_null_long_text_fallback (id, t) values (1, null);"));
+
+        auto results =
+            execute(connection, NANODBC_TEXT("select id, t from test_null_long_text_fallback;"));
+        REQUIRE(results.next());
+        // Not is_null() first: an unbound column reports what the fetch knew, and a read is
+        // what settles it.
+        REQUIRE(
+            results.get<nanodbc::string>(1, NANODBC_TEXT("fallback")) == NANODBC_TEXT("fallback"));
+        REQUIRE(
+            results.get<nanodbc::string>(NANODBC_TEXT("t"), NANODBC_TEXT("fallback")) ==
+            NANODBC_TEXT("fallback"));
+    }
+
     void test_binary_read_shapes()
     {
         nanodbc::connection connection = connect();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -869,6 +869,11 @@ struct test_case_fixture : public base_test_fixture
             connection.disconnect();
             REQUIRE(!connection.connected());
         }
+        {
+            // A login timeout is passed to the driver as an attribute, where zero is not.
+            nanodbc::connection connection(name, NANODBC_TEXT(""), NANODBC_TEXT(""), 5);
+            REQUIRE(connection.connected());
+        }
     }
 
     // get_ref_impl dispatches on the C type the driver bound the column as, which follows
@@ -1081,6 +1086,14 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(results.get<double>(5) == 2.5);
         REQUIRE(results.get<float>(5) == 2.5f);
 
+        // Rendering as text is a conversion per type, and only the widths from 32 bits up
+        // have one: a smallint read as a string is refused rather than rendered.
+        REQUIRE(results.get<nanodbc::string>(2) == NANODBC_TEXT("70000"));
+        REQUIRE(results.get<nanodbc::string>(3) == NANODBC_TEXT("5000000000"));
+        REQUIRE(!results.get<nanodbc::string>(4).empty());
+        REQUIRE(!results.get<nanodbc::string>(5).empty());
+        REQUIRE_THROWS_AS(results.get<nanodbc::string>(0), nanodbc::type_incompatible_error);
+
         // A bound character column read as a character goes through the string column path;
         // a long one would be unbound and read with SQLGetData instead.
         REQUIRE(results.get<char>(6) == '9');
@@ -1113,6 +1126,7 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(reals.next());
         REQUIRE(reals.get<float>(0) == 1.5f);
         REQUIRE(reals.get<double>(0) == 1.5);
+        REQUIRE(!reals.get<nanodbc::string>(0).empty());
     }
 
     void test_bind_every_form()
@@ -2852,6 +2866,16 @@ PRIMARY KEY(t2_fid)
             nanodbc::implementation_row_descriptor ird(s);
             REQUIRE(ird.count() == 3);
             REQUIRE(ird.count() == ird.count());
+
+            // The descriptor can also be taken from a result, and reports how it was
+            // allocated. Both describe the same statement, so both count the same columns.
+            {
+                auto r = nanodbc::execute(c, sql);
+                nanodbc::implementation_row_descriptor from_result(r);
+                REQUIRE(from_result.count() == ird.count());
+                REQUIRE(from_result.alloc_type() != 0);
+            }
+            REQUIRE(ird.alloc_type() != 0);
             for (short i = 0; i < ird.count(); i++)
             {
                 if (vendor_ == database_vendor::mysql)

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -972,6 +972,17 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(results.get<std::vector<std::uint8_t>>(1, std::vector<std::uint8_t>{}).empty());
         REQUIRE(results.get<std::vector<std::uint8_t>>(2, std::vector<std::uint8_t>{}).empty());
 
+        // By name as well as by position: the fallback for an unbound column is decided
+        // after the read rather than before it, on a path of its own.
+        REQUIRE(
+            results
+                .get<std::vector<std::uint8_t>>(NANODBC_TEXT("long_b"), std::vector<std::uint8_t>{})
+                .empty());
+        REQUIRE(results
+                    .get<std::vector<std::uint8_t>>(
+                        NANODBC_TEXT("small_b"), std::vector<std::uint8_t>{})
+                    .empty());
+
         REQUIRE(!results.next());
     }
 


### PR DESCRIPTION
Continues from #479, which left line coverage at 90.03%. Now 91.06%, with function coverage at 95.31%.

## A bug the tests found

`result::get(column_name, fallback)` asserted `is_bound(column)` before handing back the fallback. A blob or long text column is not bound, so a debug build called `abort` where the by-index overload returned the fallback quietly. That overload carries the same assertion commented out, with a note about MySQL setting `SQL_NULL_DATA` from `SQLBindCol` — the fix was never carried across. The two agree now.

It surfaced as a SIGABRT the first time a test read a null blob back by name.

## What the tests reach

- Every C type a column can be bound as, the unsigned ones coming from MySQL, which is the only backend here whose integers can be `UNSIGNED`.
- Rendering numbers as text, which exists only for the widths from 32 bits up: a `smallint` read as a string is refused, and that is pinned in both directions.
- Binary reads in each shape — bound and copied, fetched in chunks, or null — by position and by name.
- Parameter metadata asked before anything has described it, which is the path that fetches rather than looks up.
- The output and return directions of a bound parameter, and a row descriptor taken from a result rather than a statement.

## Backend differences recorded along the way

PostgreSQL will not take an integer for a `boolean` column, and its ANSI driver rejects `SQL_C_WCHAR` outright. `wide_string` is `wstring` under MSVC, `u16string` elsewhere and `u32string` under iODBC, so the sentry values are widened from ASCII rather than written as literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)