### PR TITLE
Remove the last two __GNUC__ conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- The last two `__GNUC__` conditions are gone; both were unreachable at C++14, which is the minimum. [`#383`](https://github.com/nanodbc/nanodbc/issues/383)
+
 - Every integer width renders as a string, where only 32 bits and wider did. [`#467`](https://github.com/nanodbc/nanodbc/issues/467)
 - The tests say `SQLWCHAR` rather than `WCHAR`, which is a Windows type and left the suite unbuildable where the ODBC headers do not supply it. [`#439`](https://github.com/nanodbc/nanodbc/issues/439)
 - `SQLBindParameter` is given the bound type's size as the buffer length rather than the parameter's column size, which is a precision and not a byte count. [`#437`](https://github.com/nanodbc/nanodbc/issues/437)

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -56,9 +56,10 @@ struct is_optional<std::optional<T>> : std::true_type
 
 #ifdef NANODBC_ENABLE_BOOST
 #include <boost/locale/encoding_utf.hpp>
-#elif defined(__GNUC__) && (__GNUC__ < 5)
-#include <cwchar>
 #endif
+
+// std::wcslen
+#include <cwchar>
 
 #ifdef __APPLE__
 // silence spurious OS X deprecation warnings

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -239,19 +239,8 @@ typedef unspecified - type null_type;
 #endif
 
 /// \def NANODBC_DEPRECATED
-/// \brief Marks a declaration as deprecated, in whichever way the compiler supports.
-#if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
-// [[deprecated]] is only available in C++14
+/// \brief Marks a declaration as deprecated.
 #define NANODBC_DEPRECATED [[deprecated]]
-#else
-#ifdef __GNUC__
-#define NANODBC_DEPRECATED __attribute__((deprecated))
-#elif defined(_MSC_VER)
-#define NANODBC_DEPRECATED __declspec(deprecated)
-#else
-#define NANODBC_DEPRECATED
-#endif
-#endif
 
 // forward declare
 #ifndef NANODBC_DISABLE_MSSQL_TVP


### PR DESCRIPTION
Closes #383.

Two were left, and neither could be reached.

`NANODBC_DEPRECATED` chose between `__attribute__((deprecated))` and `__declspec(deprecated)` only when `__cplusplus` was below 201402L. C++14 is the minimum the library builds at, so `[[deprecated]]` was always the answer and the whole `#else` was dead.

The other guarded `#include <cwchar>` behind `__GNUC__ < 5`, which no compiler that can build C++14 reports. It is now included unconditionally rather than dropped: `std::wcslen` is used at line 551 and was arriving transitively for everyone the condition was false for. Worth being careful there, because the condition was not false for everyone — **Apple clang reports `__GNUC__` as 4**, so it was the one compiler still taking that branch. That same quirk is what made #214 a bug from 2019 until it was fixed.

## Verification

Built at C++14, 17 and 20 with GCC, and with clang; all five suites pass (42, 1539, 5367, 34971, 1876 assertions). Also built and tested on macOS, since that is the platform the removed branch was actually live on.