### PR TITLE
Let a batch of one bind NULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
+- A batch of one can bind NULL. The null indicator was withheld from the driver whenever the batch held a single value. [`#220`](https://github.com/nanodbc/nanodbc/issues/220) [`#347`](https://github.com/nanodbc/nanodbc/issues/347)
 - The last two `__GNUC__` conditions are gone; both were unreachable at C++14, which is the minimum. [`#383`](https://github.com/nanodbc/nanodbc/issues/383)
-
 - Every integer width renders as a string, where only 32 bits and wider did. [`#467`](https://github.com/nanodbc/nanodbc/issues/467)
 - The tests say `SQLWCHAR` rather than `WCHAR`, which is a Windows type and left the suite unbuildable where the ODBC headers do not supply it. [`#439`](https://github.com/nanodbc/nanodbc/issues/439)
 - `SQLBindParameter` is given the bound type's size as the buffer length rather than the parameter's column size, which is a precision and not a byte count. [`#437`](https://github.com/nanodbc/nanodbc/issues/437)

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2574,7 +2574,7 @@ public:
             param.scale_,     // decimal digits
             (SQLPOINTER)buffer.values_, // parameter value
             buffer_size,                // buffer length
-            (buffer.size_ <= 1 ? nullptr : bind_len_or_null_[param.index_].data()));
+            bind_len_or_null_[param.index_].data());
 
         if (!success(rc))
             NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
@@ -2782,23 +2782,26 @@ void statement::statement_impl::bind(
     prepare_bind(param_index, batch_size, direction, param);
 
     // prepare_bind starts every indicator out as SQL_NULL_DATA, so only the values that
-    // are not null need marking here.
+    // are not null need marking here. A character value carries its own end, so it is
+    // marked as terminated rather than as being the width of the parameter.
+    auto const present = is_character<T>::value ? static_cast<null_type>(SQL_NTS)
+                                                : static_cast<null_type>(param.size_);
     if (null_sentry)
     {
         for (std::size_t i = 0; i < batch_size; ++i)
             if (!equals(values[i], *null_sentry))
-                bind_len_or_null_[param_index][i] = param.size_;
+                bind_len_or_null_[param_index][i] = present;
     }
     else if (nulls)
     {
         for (std::size_t i = 0; i < batch_size; ++i)
             if (!nulls[i])
-                bind_len_or_null_[param_index][i] = param.size_;
+                bind_len_or_null_[param_index][i] = present;
     }
     else
     {
         for (std::size_t i = 0; i < batch_size; ++i)
-            bind_len_or_null_[param_index][i] = param.size_;
+            bind_len_or_null_[param_index][i] = present;
     }
 
     bound_buffer<T> buffer(values, batch_size);
@@ -3277,7 +3280,7 @@ public:
             param.scale_, // decimal digits
             (SQLPOINTER)buffer.values_, // parameter value
             buffer_size,                // buffer length
-            (buffer.size_ <= 1 ? nullptr : bind_len_or_null_[param.index_].data()));
+            bind_len_or_null_[param.index_].data());
 
         if (!success(rc))
             NANODBC_THROW_DATABASE_ERROR(stmt_impl->native_statement_handle(), SQL_HANDLE_STMT);
@@ -3496,23 +3499,26 @@ void table_valued_parameter::table_valued_parameter_impl::bind(
     prepare_bind(param_index, batch_size, param);
 
     // prepare_bind starts every indicator out as SQL_NULL_DATA, so only the values that
-    // are not null need marking here.
+    // are not null need marking here. A character value carries its own end, so it is
+    // marked as terminated rather than as being the width of the parameter.
+    auto const present = is_character<T>::value ? static_cast<null_type>(SQL_NTS)
+                                                : static_cast<null_type>(param.size_);
     if (null_sentry)
     {
         for (std::size_t i = 0; i < batch_size; ++i)
             if (!equals(values[i], *null_sentry))
-                bind_len_or_null_[param_index][i] = param.size_;
+                bind_len_or_null_[param_index][i] = present;
     }
     else if (nulls)
     {
         for (std::size_t i = 0; i < batch_size; ++i)
             if (!nulls[i])
-                bind_len_or_null_[param_index][i] = param.size_;
+                bind_len_or_null_[param_index][i] = present;
     }
     else
     {
         for (std::size_t i = 0; i < batch_size; ++i)
-            bind_len_or_null_[param_index][i] = param.size_;
+            bind_len_or_null_[param_index][i] = present;
     }
 
     bound_buffer<T> buffer(values, batch_size);

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -2594,3 +2594,8 @@ TEST_CASE_METHOD(mssql_fixture, "test_bind_date_to_timestamp_parameter", "[mssql
 {
     test_bind_date_to_timestamp_parameter();
 }
+
+TEST_CASE_METHOD(mssql_fixture, "test_bind_null_in_single_row_batch", "[mssql][bind][null]")
+{
+    test_bind_null_in_single_row_batch();
+}

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -580,3 +580,8 @@ TEST_CASE_METHOD(mysql_fixture, "test_bind_date_to_timestamp_parameter", "[mysql
 {
     test_bind_date_to_timestamp_parameter();
 }
+
+TEST_CASE_METHOD(mysql_fixture, "test_bind_null_in_single_row_batch", "[mysql][bind][null]")
+{
+    test_bind_null_in_single_row_batch();
+}

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -641,3 +641,11 @@ TEST_CASE_METHOD(
 {
     test_bind_date_to_timestamp_parameter();
 }
+
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_bind_null_in_single_row_batch",
+    "[postgresql][bind][null]")
+{
+    test_bind_null_in_single_row_batch();
+}

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -630,3 +630,8 @@ TEST_CASE_METHOD(sqlite_fixture, "test_bind_date_to_timestamp_parameter", "[sqli
 {
     test_bind_date_to_timestamp_parameter();
 }
+
+TEST_CASE_METHOD(sqlite_fixture, "test_bind_null_in_single_row_batch", "[sqlite][bind][null]")
+{
+    test_bind_null_in_single_row_batch();
+}

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -975,6 +975,42 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(ts.day == d.day);
     }
 
+    // A batch of one is still a batch: the null flags have to reach the driver whatever the
+    // size, and for a long time they did not, so a single row came out holding the value it
+    // was told was null.
+    void test_bind_null_in_single_row_batch()
+    {
+        nanodbc::connection connection = connect();
+
+        for (std::size_t batch : {std::size_t{1}, std::size_t{2}})
+        {
+            create_table(
+                connection,
+                NANODBC_TEXT("test_bind_null_single"),
+                NANODBC_TEXT("(i int, s varchar(20))"));
+
+            std::vector<int> ids(batch, 0);
+            for (std::size_t i = 0; i < batch; ++i)
+                ids[i] = static_cast<int>(i);
+            std::vector<nanodbc::string> strings(batch, NANODBC_TEXT("hello"));
+            std::vector<std::uint8_t> flags(batch, 0);
+            flags[0] = 1; // the first value is null
+
+            nanodbc::statement statement(connection);
+            prepare(
+                statement, NANODBC_TEXT("insert into test_bind_null_single (i, s) values (?, ?);"));
+            statement.bind(0, ids.data(), batch);
+            statement.bind_strings(1, strings, reinterpret_cast<bool const*>(flags.data()));
+            nanodbc::execute(statement, static_cast<long>(batch));
+
+            auto results = execute(
+                connection, NANODBC_TEXT("select count(*), count(s) from test_bind_null_single;"));
+            REQUIRE(results.next());
+            REQUIRE(results.get<int>(0) == static_cast<int>(batch));
+            REQUIRE(results.get<int>(0) - results.get<int>(1) == 1);
+        }
+    }
+
     void test_binary_read_shapes()
     {
         nanodbc::connection connection = connect();


### PR DESCRIPTION
Closes #220 and #347, which are the same bug reported five years apart.

## What was wrong

The null indicator was handed to `SQLBindParameter` only when the batch held more than one value:

```cpp
(buffer.size_ <= 1 ? nullptr : bind_len_or_null_[param.index_].data())
```

So a batch of one could not be told a value was null, and the row arrived holding whatever the buffer contained. #347 saw it as `date/time value out of range: "0000-00-00 00:00:00"` — the driver reading a buffer nobody had filled.

Reproduced on all three backends that can show it:

```
DBMS: PostgreSQL          batch=1  nulls=0  (NULL LOST)    batch=2  nulls=1  (null took)
DBMS: Microsoft SQL Server batch=1  nulls=0  (NULL LOST)   batch=2  nulls=1  (null took)
```

## Why the obvious fix is not enough

@shrektan proposed passing the array unconditionally back in 2019, and was right to be wary of it. A single value bound from `c_str()` carries no null information, and the indicator it was given was the **parameter's width** — so handing the driver that array would have made every bound string as long as its column, which is the same mistake #462 was about.

Character values are marked `SQL_NTS` now, which is what they are: terminated, with their end their own business. Once the indicator is right in every case it can be passed in every case, and the conditional goes.

Both the statement and the table-valued-parameter paths had it.

## Verification

All three backends now keep the null at batch=1 and batch=2. A regression test covers both sizes on all four suites. Full runs: 42, 1539, 5383, 35032, 1882 assertions.