### PR TITLE
Do not render a null date or timestamp as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Column buffer casts go through `void*` rather than `reinterpret_cast` and a C-style cast, which analysers report as unsafe. [`#420`](https://github.com/nanodbc/nanodbc/issues/420)
+- A null timestamp read after `unbind()` yields the fallback or raises `null_access_error`, where it once aborted. [`#423`](https://github.com/nanodbc/nanodbc/issues/423)
 
 ## v2.17.0
 

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4125,6 +4125,10 @@ public:
         if (is_null(column))
             throw null_access_error();
         get_ref_impl<T>(column, result);
+
+        // An unbound column's null is only known once SQLGetData has run.
+        if (is_null(column))
+            throw null_access_error();
     }
 
 #ifdef NANODBC_HAS_STD_OPTIONAL
@@ -4138,6 +4142,10 @@ public:
             return;
         }
         get_ref_impl<std::remove_reference_t<decltype(*result)>>(column, *result);
+
+        // An unbound column's null is only known once SQLGetData has run.
+        if (is_null(column))
+            opt_reset(result);
     }
 #endif
 
@@ -4175,6 +4183,10 @@ public:
         if (is_null(column))
             throw null_access_error();
         get_ref_impl<T>(column, result);
+
+        // An unbound column's null is only known once SQLGetData has run.
+        if (is_null(column))
+            throw null_access_error();
     }
 
 #ifdef NANODBC_HAS_STD_OPTIONAL
@@ -4188,6 +4200,10 @@ public:
             return;
         }
         get_ref_impl<std::remove_reference_t<decltype(*result)>>(column, *result);
+
+        // An unbound column's null is only known once SQLGetData has run.
+        if (is_null(column))
+            opt_reset(result);
     }
 #endif
 
@@ -4906,6 +4922,12 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
     case SQL_C_DATE:
     {
         const date d = *ensure_pdata<date>(column);
+        // An unbound column reports null only once SQLGetData has run, and a null leaves
+        // the buffer zeroed, whose month and day are then out of range. Rendering that is
+        // not portable: the Microsoft CRT ends the process rather than return from
+        // strftime. The caller tests for the null again after this returns.
+        if (is_null(column))
+            return;
         std::tm st{};
         st.tm_year = d.year - 1900;
         st.tm_mon = d.month - 1;
@@ -4950,6 +4972,12 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
     case SQL_C_TIMESTAMP:
     {
         const timestamp stamp = *ensure_pdata<timestamp>(column);
+        // An unbound column reports null only once SQLGetData has run, and a null leaves
+        // the buffer zeroed, whose month and day are then out of range. Rendering that is
+        // not portable: the Microsoft CRT ends the process rather than return from
+        // strftime. The caller tests for the null again after this returns.
+        if (is_null(column))
+            return;
         std::tm st{};
         st.tm_year = stamp.year - 1900;
         st.tm_mon = stamp.month - 1;

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1177,6 +1177,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_execute_direct_batch_ops", "[mssql][statem
     test_execute_direct_batch_ops();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_null_timestamp_after_unbind", "[mssql][result][unbind][null]")
+{
+    test_null_timestamp_after_unbind();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_result_unbind", "[mssql][result][unbind]")
 {
     test_result_unbind();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -387,6 +387,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_execute_direct_batch_ops", "[mysql][statem
     test_execute_direct_batch_ops();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_null_timestamp_after_unbind", "[mysql][result][unbind][null]")
+{
+    test_null_timestamp_after_unbind();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_result_unbind", "[mysql][result][unbind]")
 {
     test_result_unbind();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -337,6 +337,14 @@ TEST_CASE_METHOD(
     test_execute_direct_batch_ops();
 }
 
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_null_timestamp_after_unbind",
+    "[postgresql][result][unbind][null]")
+{
+    test_null_timestamp_after_unbind();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_result_unbind", "[postgresql][result][unbind]")
 {
     test_result_unbind();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -455,6 +455,14 @@ TEST_CASE_METHOD(sqlite_fixture, "test_execute_direct_batch_ops", "[sqlite][stat
     test_execute_direct_batch_ops();
 }
 
+TEST_CASE_METHOD(
+    sqlite_fixture,
+    "test_null_timestamp_after_unbind",
+    "[sqlite][result][unbind][null]")
+{
+    test_null_timestamp_after_unbind();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_result_unbind", "[sqlite][result][unbind]")
 {
     test_result_unbind();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1590,21 +1590,44 @@ struct test_case_fixture : public base_test_fixture
             REQUIRE(results.is_null(1));
         }
 
+        // Each case reads the null on a freshly fetched row, so the null is discovered
+        // during the read rather than already recorded from an earlier one. That is the
+        // order that renders a zeroed timestamp, whose month and day are out of range.
+        auto const unbound_row = [&]()
         {
-            // Unbound before the fetch, so the values are read one at a time with
-            // SQLGetData, which some drivers only allow in ascending column order.
             auto results = execute(connection, query);
             results.unbind();
             REQUIRE(results.next());
             REQUIRE(!results.is_bound(1));
+            return results;
+        };
 
+        {
+            // Unbound before the fetch, so the values are read one at a time with
+            // SQLGetData, which some drivers only allow in ascending column order.
+            auto results = unbound_row();
             REQUIRE(results.get<int>(0) == 1);
+        }
 
+        {
+            auto results = unbound_row();
             auto const fallback = NANODBC_TEXT("(null)");
             REQUIRE(results.get<nanodbc::string>(1, fallback) == fallback);
+        }
+
+        {
+            auto results = unbound_row();
             nanodbc::timestamp const epoch{};
             REQUIRE(results.get<nanodbc::timestamp>(1, epoch).year == epoch.year);
+        }
+
+        {
+            auto results = unbound_row();
             REQUIRE_THROWS_AS(results.get<nanodbc::string>(1), nanodbc::null_access_error);
+        }
+
+        {
+            auto results = unbound_row();
             REQUIRE_THROWS_AS(results.get<nanodbc::timestamp>(1), nanodbc::null_access_error);
         }
     }

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1568,6 +1568,47 @@ struct test_case_fixture : public base_test_fixture
         }
     }
 
+    // Unbinding drops the indicator that marked a column null, so is_null() no longer
+    // answers for it. Reading through a fallback still reports the null, and reading
+    // without one raises null_access rather than rendering an uninitialised buffer.
+    void test_null_timestamp_after_unbind()
+    {
+        auto connection = connect();
+        create_table(
+            connection,
+            NANODBC_TEXT("test_null_timestamp_after_unbind"),
+            NANODBC_TEXT("(i int, ts ") + get_timestamp_type_name() + NANODBC_TEXT(")"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_null_timestamp_after_unbind(i, ts) values (1, null);"));
+
+        auto const query = NANODBC_TEXT("select i, ts from test_null_timestamp_after_unbind;");
+
+        {
+            auto results = execute(connection, query);
+            REQUIRE(results.next());
+            REQUIRE(results.is_null(1));
+        }
+
+        {
+            // Unbound before the fetch, so the values are read one at a time with
+            // SQLGetData, which some drivers only allow in ascending column order.
+            auto results = execute(connection, query);
+            results.unbind();
+            REQUIRE(results.next());
+            REQUIRE(!results.is_bound(1));
+
+            REQUIRE(results.get<int>(0) == 1);
+
+            auto const fallback = NANODBC_TEXT("(null)");
+            REQUIRE(results.get<nanodbc::string>(1, fallback) == fallback);
+            nanodbc::timestamp const epoch{};
+            REQUIRE(results.get<nanodbc::timestamp>(1, epoch).year == epoch.year);
+            REQUIRE_THROWS_AS(results.get<nanodbc::string>(1), nanodbc::null_access_error);
+            REQUIRE_THROWS_AS(results.get<nanodbc::timestamp>(1), nanodbc::null_access_error);
+        }
+    }
+
     // A binary column is not bound, so the fetch leaves no indicator behind for it and
     // whether it is null has to be asked of the driver.
     void test_is_null_binary()


### PR DESCRIPTION
Closes #423.

Reading a null timestamp column as a string after `unbind()` ends the process on Windows. This started as a test and became a fix when Windows CI crashed on it — see the comment below for how that unfolded.

## The bug

An unbound column reports its null only once `SQLGetData` has run, so `get_ref_impl` reads first and the caller tests for the null afterwards:

```cpp
get_ref_impl<T>(column, result);

// for unbound columns, null indicator is determined by SQLGetData call
if (is_null(column))
    result = fallback;
```

A null leaves the buffer zeroed, and a zeroed `date` or `timestamp` has month 0 and day 0, reaching `strftime` as `tm_mon = -1` and `tm_mday = 0`. glibc renders that quietly, which is why Linux never showed it. The Microsoft CRT calls the invalid parameter handler, which `__fastfail`s with `0xc0000409` and ends the process before the caller's null check ever runs.

That matches the report exactly: Win10/Win11, MSVC 2022, "system library assertion failure" out of `strftime`.

## The fix

- Both `strftime` cases return before rendering when the read turned out to be null.
- The `get_ref` overloads without a fallback now test for the null again after the read and raise `null_access_error`, as their documentation already promises. Previously they returned whatever had been rendered. The fallback overloads have always tested twice; this makes the pair consistent.

## The test

`test_null_timestamp_after_unbind` runs against SQLite, MySQL, PostgreSQL and SQL Server. Each case reads the null on a freshly fetched row, so the null is discovered *during* the read rather than already recorded by an earlier call — that ordering is what triggers the crash.

Two constraints the test respects, both driver behaviour rather than nanodbc's:

- Columns are unbound **before** the fetch. Unbinding a row the driver has already delivered into bound buffers and then asking for column 0 gets `07009 Invalid Descriptor Index` from SQL Server.
- Columns are read in ascending order, for the same reason.

`is_null()` after `unbind()` still returns false, the documented limitation the issue also mentions; the test asserts the bound case separately rather than pretending otherwise.

## Testing

All five suites pass locally. Windows CI is the real check here, since that is the only platform that crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)