### PR TITLE
Test a procedure's return value and document PARAM_RETURN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Column buffer casts go through `void*` rather than `reinterpret_cast` and a C-style cast, which analysers report as unsafe. [`#420`](https://github.com/nanodbc/nanodbc/issues/420)
+- `PARAM_RETURN` documents that it binds a procedure's return value at parameter zero of `{ ? = CALL proc(?) }`. [`#355`](https://github.com/nanodbc/nanodbc/issues/355)
 
 ## v2.17.0
 

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -907,7 +907,8 @@ public:
         PARAM_IN,    ///< Binding an input parameter.
         PARAM_OUT,   ///< Binding an output parameter.
         PARAM_INOUT, ///< Binding an input/output parameter.
-        PARAM_RETURN ///< Binding a return parameter.
+        PARAM_RETURN ///< Binding a procedure's return value, at parameter zero of a
+                     ///< `{ ? = CALL proc(?) }` escape sequence.
     };
 
 public:

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -2506,6 +2506,36 @@ TEST_CASE_METHOD(mssql_fixture, "test_output_parameters", "[mssql][statement][bi
     REQUIRE(out2 == 2);
 }
 
+// A procedure's RETURN value is not an output parameter; it is bound at position zero
+// of a "{ ? = CALL ... }" escape sequence with PARAM_RETURN.
+TEST_CASE_METHOD(mssql_fixture, "test_procedure_return_value", "[mssql][statement][bind]")
+{
+    auto connection = connect();
+    nanodbc::string const name = NANODBC_TEXT("test_procedure_return_value_proc");
+    try
+    {
+        execute(connection, NANODBC_TEXT("DROP PROCEDURE ") + name);
+    }
+    catch (...)
+    {
+    }
+    execute(
+        connection,
+        NANODBC_TEXT("CREATE PROCEDURE ") + name +
+            NANODBC_TEXT(" @in INT AS BEGIN RETURN @in * 3; END;"));
+
+    nanodbc::statement statement(connection);
+    statement.prepare(NANODBC_TEXT("{ ? = CALL ") + name + NANODBC_TEXT("(?) }"));
+
+    int rv = 0;
+    int const in = 14;
+    statement.bind(0, &rv, nanodbc::statement::PARAM_RETURN);
+    statement.bind(1, &in);
+    statement.just_execute();
+
+    REQUIRE(rv == 42);
+}
+
 // An NVARCHAR column is bound wide, so reading one as a character takes the wide arm of
 // the string column path.
 TEST_CASE_METHOD(mssql_fixture, "test_wide_bound_column_as_character", "[mssql][result][unicode]")


### PR DESCRIPTION
Closes #355.

The question was how to get a stored procedure's **return value**, as distinct from an output parameter, and what `PARAM_RETURN` is for. The answer is that it works today — it just was not tested or documented.

`test_output_parameters` already bound `PARAM_RETURN`, but never asserted what came back, and the procedure it called had no `RETURN` statement at all, so a broken binding would have passed. This adds a procedure that returns a computed value:

```sql
CREATE PROCEDURE test_procedure_return_value_proc @in INT AS BEGIN RETURN @in * 3; END;
```

bound as `{ ? = CALL proc(?) }` with the return at parameter zero, and asserts `rv == 42` for an input of 14.

The enumerator's documentation now says where the value is bound, which is the part the issue found unclear:

```cpp
PARAM_RETURN ///< Binding a procedure's return value, at parameter zero of a
             ///< `{ ? = CALL proc(?) }` escape sequence.
```

## Testing

All five suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)