### PR TITLE
Test binding objects larger than the reported parameter size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- A regression test covers binding objects past the driver's reported parameter limit, which nothing pinned. [`#5`](https://github.com/nanodbc/nanodbc/issues/5)
 - A bound character column the driver under-sized is read again in full instead of coming back truncated. [`#343`](https://github.com/nanodbc/nanodbc/issues/343)
 - Tests cover executing a prepared statement repeatedly and binding a batch with an arithmetic null sentry. [`#56`](https://github.com/nanodbc/nanodbc/issues/56) [`#77`](https://github.com/nanodbc/nanodbc/issues/77)
 - Column buffer casts go through `void*` rather than `reinterpret_cast` and a C-style cast, which analysers report as unsafe. [`#420`](https://github.com/nanodbc/nanodbc/issues/420)

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -2554,6 +2554,55 @@ TEST_CASE_METHOD(mssql_fixture, "test_procedure_return_value", "[mssql][statemen
     REQUIRE(rv == 42);
 }
 
+// SQLDescribeParam reports a driver limit rather than the column's real capacity for a
+// MAX column, so a value larger than the limit has to be bound as unlimited or the driver
+// refuses it with 22001.
+TEST_CASE_METHOD(mssql_fixture, "test_large_object_parameters", "[mssql][statement][bind]")
+{
+    auto connection = connect();
+    create_table(
+        connection,
+        NANODBC_TEXT("test_large_object_parameters"),
+        NANODBC_TEXT("(id int, b varbinary(max), s varchar(max))"));
+
+    // Past the 8000 bytes SQL Server allows a non-MAX parameter.
+    for (std::size_t const size : {std::size_t{4000}, std::size_t{9000}, std::size_t{100000}})
+    {
+        execute(connection, NANODBC_TEXT("delete from test_large_object_parameters;"));
+
+        std::vector<std::vector<std::uint8_t>> rows{std::vector<std::uint8_t>(size, 0x41)};
+        nanodbc::statement statement(connection);
+        statement.prepare(
+            NANODBC_TEXT("insert into test_large_object_parameters (id, b) values (1, ?);"));
+        statement.bind(0, rows);
+        statement.just_execute();
+
+        auto results = execute(
+            connection,
+            NANODBC_TEXT("select datalength(b) from test_large_object_parameters where id = 1;"));
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == static_cast<int>(size));
+    }
+
+    for (std::size_t const size : {std::size_t{9000}, std::size_t{100000}})
+    {
+        execute(connection, NANODBC_TEXT("delete from test_large_object_parameters;"));
+
+        std::string const value(size, 'x');
+        nanodbc::statement statement(connection);
+        statement.prepare(
+            NANODBC_TEXT("insert into test_large_object_parameters (id, s) values (2, ?);"));
+        statement.bind(0, value.c_str());
+        statement.just_execute();
+
+        auto results = execute(
+            connection,
+            NANODBC_TEXT("select datalength(s) from test_large_object_parameters where id = 2;"));
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == static_cast<int>(size));
+    }
+}
+
 // A character outside the basic multilingual plane is a surrogate pair in UTF-16, so
 // reading one and binding it back tests that both paths carry the pair intact. The
 // value is built by the server, keeping non-ASCII out of this file and out of the


### PR DESCRIPTION
Closes #5.

#5 was fixed by 52d9c46 in 2017 and released in v2.13.0, then left open for nine years. I verified it still works and closed it; this adds the regression test that never existed.

`SQLDescribeParam` reports a driver limit rather than the real capacity of a `MAX` column, so a value past that limit has to be bound as unlimited or SQL Server refuses it with `22001 String data, right truncation`. The library handles it:

```cpp
if (value_size > param_size)
{
    // SQLDescribeParam reports zero for VARBINARY(MAX), meaning
    // SQL_SS_LENGTH_UNLIMITED, and a driver limit for a UDT.
    param_size = SQL_SS_LENGTH_UNLIMITED;
}
```

but nothing pinned it, and it is the sort of thing that could break quietly — the failure only appears past 8000 bytes, which no other test crosses.

`test_large_object_parameters` binds 4000, 9000 and 100000 byte binaries through the `std::vector<std::vector<std::uint8_t>>` form from the original report, plus 9000 and 100000 character strings, and checks `datalength` matches the input exactly:

```
binary n=4000   stored=4000     OK
binary n=9000   stored=9000     OK
binary n=100000 stored=100000   OK
string n=9000   stored=9000     OK
string n=100000 stored=100000   OK
```

SQL Server only, since the 8000 byte boundary and `varbinary(max)` are its own.

## Testing

All five suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)