### PR TITLE
Test prepared statement reuse and the arithmetic null sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - A bound character column the driver under-sized is read again in full instead of coming back truncated. [`#343`](https://github.com/nanodbc/nanodbc/issues/343)
+- Tests cover executing a prepared statement repeatedly and binding a batch with an arithmetic null sentry. [`#56`](https://github.com/nanodbc/nanodbc/issues/56) [`#77`](https://github.com/nanodbc/nanodbc/issues/77)
 - Column buffer casts go through `void*` rather than `reinterpret_cast` and a C-style cast, which analysers report as unsafe. [`#420`](https://github.com/nanodbc/nanodbc/issues/420)
 - A null timestamp read after `unbind()` yields the fallback or raises `null_access_error`, where it once aborted. [`#423`](https://github.com/nanodbc/nanodbc/issues/423)
 - `PARAM_RETURN` documents that it binds a procedure's return value at parameter zero of `{ ? = CALL proc(?) }`. [`#355`](https://github.com/nanodbc/nanodbc/issues/355)

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1182,6 +1182,19 @@ TEST_CASE_METHOD(mssql_fixture, "test_string_aggregate", "[mssql][result][string
     test_string_aggregate();
 }
 
+TEST_CASE_METHOD(
+    mssql_fixture,
+    "test_execute_prepared_statement_repeatedly",
+    "[mssql][statement][prepare]")
+{
+    test_execute_prepared_statement_repeatedly();
+}
+
+TEST_CASE_METHOD(mssql_fixture, "test_bind_arithmetic_null_sentry", "[mssql][bind][null]")
+{
+    test_bind_arithmetic_null_sentry();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_result_unbind", "[mssql][result][unbind]")
 {
     test_result_unbind();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -392,6 +392,19 @@ TEST_CASE_METHOD(mysql_fixture, "test_string_aggregate", "[mysql][result][string
     test_string_aggregate();
 }
 
+TEST_CASE_METHOD(
+    mysql_fixture,
+    "test_execute_prepared_statement_repeatedly",
+    "[mysql][statement][prepare]")
+{
+    test_execute_prepared_statement_repeatedly();
+}
+
+TEST_CASE_METHOD(mysql_fixture, "test_bind_arithmetic_null_sentry", "[mysql][bind][null]")
+{
+    test_bind_arithmetic_null_sentry();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_result_unbind", "[mysql][result][unbind]")
 {
     test_result_unbind();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -342,6 +342,19 @@ TEST_CASE_METHOD(postgresql_fixture, "test_string_aggregate", "[postgresql][resu
     test_string_aggregate();
 }
 
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_execute_prepared_statement_repeatedly",
+    "[postgresql][statement][prepare]")
+{
+    test_execute_prepared_statement_repeatedly();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "test_bind_arithmetic_null_sentry", "[postgresql][bind][null]")
+{
+    test_bind_arithmetic_null_sentry();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_result_unbind", "[postgresql][result][unbind]")
 {
     test_result_unbind();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -460,6 +460,19 @@ TEST_CASE_METHOD(sqlite_fixture, "test_string_aggregate", "[sqlite][result][stri
     test_string_aggregate();
 }
 
+TEST_CASE_METHOD(
+    sqlite_fixture,
+    "test_execute_prepared_statement_repeatedly",
+    "[sqlite][statement][prepare]")
+{
+    test_execute_prepared_statement_repeatedly();
+}
+
+TEST_CASE_METHOD(sqlite_fixture, "test_bind_arithmetic_null_sentry", "[sqlite][bind][null]")
+{
+    test_bind_arithmetic_null_sentry();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_result_unbind", "[sqlite][result][unbind]")
 {
     test_result_unbind();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1612,6 +1612,68 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(by_name.get<nanodbc::string>(NANODBC_TEXT("joined")).size() == expected);
     }
 
+    // Preparing once and executing many times is the point of preparing at all. The
+    // parameters are described when the statement is prepared, so re-binding between
+    // executions must not describe them again.
+    void test_execute_prepared_statement_repeatedly()
+    {
+        auto connection = connect();
+        create_table(
+            connection,
+            NANODBC_TEXT("test_execute_prepared_statement_repeatedly"),
+            NANODBC_TEXT("(k int)"));
+        execute(
+            connection,
+            NANODBC_TEXT(
+                "insert into test_execute_prepared_statement_repeatedly (k) values "
+                "(1), (2), (3), (4);"));
+
+        nanodbc::statement statement(connection);
+        statement.prepare(
+            NANODBC_TEXT("delete from test_execute_prepared_statement_repeatedly where k = ?;"));
+
+        for (int key = 1; key <= 3; ++key)
+        {
+            statement.bind(0, &key);
+            statement.just_execute();
+        }
+
+        auto results = execute(
+            connection,
+            NANODBC_TEXT("select count(*) from test_execute_prepared_statement_repeatedly;"));
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 1);
+    }
+
+    // A sentry marks which of a batch of values are null, and is read whether or not the
+    // separate nulls array was also given. The two were once entangled, so that passing a
+    // sentry without a nulls array marked nothing.
+    void test_bind_arithmetic_null_sentry()
+    {
+        auto connection = connect();
+        create_table(
+            connection, NANODBC_TEXT("test_bind_arithmetic_null_sentry"), NANODBC_TEXT("(i int)"));
+
+        int const values[] = {10, -1, 30, -1, 50};
+        int const sentry = -1;
+        std::size_t const batch = 5;
+
+        nanodbc::statement statement(connection);
+        statement.prepare(
+            NANODBC_TEXT("insert into test_bind_arithmetic_null_sentry (i) values (?);"));
+        statement.bind(0, values, batch, &sentry);
+        transact(statement, static_cast<long>(batch));
+
+        auto results = execute(
+            connection,
+            NANODBC_TEXT(
+                "select count(*), sum(case when i is null then 1 else 0 end) "
+                "from test_bind_arithmetic_null_sentry;"));
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 5);
+        REQUIRE(results.get<int>(1) == 2);
+    }
+
     // A binary column is not bound, so the fetch leaves no indicator behind for it and
     // whether it is null has to be asked of the driver.
     void test_is_null_binary()


### PR DESCRIPTION
Closes #56 and #77. Both are old reports that no longer reproduce and were never covered by a test.

## #56 — executing a prepared statement more than once

Reported in 2014, with a later comment confirming it still happened. The claim was that after one execution the next `bind()` failed with `HY010 Function sequence error` out of `SQLDescribeParam`.

It works now, on every driver available here:

```
sqlite    execute #1 OK  #2 OK  #3 OK   rows left = 1
mssql     execute #1 OK  #2 OK  #3 OK   rows left = 1
postgres  execute #1 OK  #2 OK  #3 OK   rows left = 1
mysql     execute #1 OK  #2 OK  #3 OK   rows left = 1
```

Preparing once and executing many times is the whole point of preparing, so it is worth a test regardless of when it started working.

## #77 — the null sentry ignored when `nulls` is null

The report was that the sentry comparison could not take effect, because the sentry and the `nulls` array were tested together in one condition. They are now separate branches with the sentry taken first:

```cpp
if (null_sentry)      { ... compare each value against the sentry ... }
else if (nulls)       { ... }
else                  { ... all present ... }
```

A batch of `{10, -1, 30, -1, 50}` with a sentry of `-1` and no `nulls` array stores five rows of which exactly two are null.

This one is worth pinning specifically. The arithmetic sentry path had no coverage, which is how it broke unnoticed once before.

## Testing

Both tests run against SQLite, MySQL, PostgreSQL and SQL Server. All five suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)