### PR TITLE
Let commit honour the connection's rollback flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `transaction::commit()` honours the connection's rollback flag, so an inner rollback is no longer discarded by an outer commit. [`#78`](https://github.com/nanodbc/nanodbc/issues/78)
 - A bound character column the driver under-sized is read again in full instead of coming back truncated. [`#343`](https://github.com/nanodbc/nanodbc/issues/343)
 - Tests cover executing a prepared statement repeatedly and binding a batch with an arithmetic null sentry. [`#56`](https://github.com/nanodbc/nanodbc/issues/56) [`#77`](https://github.com/nanodbc/nanodbc/issues/77)
 - Column buffer casts go through `void*` rather than `reinterpret_cast` and a C-style cast, which analysers report as unsafe. [`#420`](https://github.com/nanodbc/nanodbc/issues/420)

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1771,7 +1771,20 @@ public:
         if (conn_.unref_transaction() == 0 && conn_.connected())
         {
             RETCODE rc = SQL_SUCCESS;
-            NANODBC_CALL_RC(SQLEndTran, rc, SQL_HANDLE_DBC, conn_.native_dbc_handle(), SQL_COMMIT);
+            // Transactions on one connection share a single ODBC transaction, so a
+            // rollback anywhere within it discards all of it. The flag says one was
+            // asked for, and the destructor has always honoured it.
+            if (conn_.rollback())
+            {
+                NANODBC_CALL_RC(
+                    SQLEndTran, rc, SQL_HANDLE_DBC, conn_.native_dbc_handle(), SQL_ROLLBACK);
+                conn_.rollback(false);
+            }
+            else
+            {
+                NANODBC_CALL_RC(
+                    SQLEndTran, rc, SQL_HANDLE_DBC, conn_.native_dbc_handle(), SQL_COMMIT);
+            }
             if (!success(rc))
                 NANODBC_THROW_DATABASE_ERROR(conn_.native_dbc_handle(), SQL_HANDLE_DBC);
         }

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1195,6 +1195,14 @@ TEST_CASE_METHOD(mssql_fixture, "test_bind_arithmetic_null_sentry", "[mssql][bin
     test_bind_arithmetic_null_sentry();
 }
 
+TEST_CASE_METHOD(
+    mssql_fixture,
+    "test_nested_transaction_rollback",
+    "[mssql][transaction][rollback]")
+{
+    test_nested_transaction_rollback();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_result_unbind", "[mssql][result][unbind]")
 {
     test_result_unbind();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -405,6 +405,14 @@ TEST_CASE_METHOD(mysql_fixture, "test_bind_arithmetic_null_sentry", "[mysql][bin
     test_bind_arithmetic_null_sentry();
 }
 
+TEST_CASE_METHOD(
+    mysql_fixture,
+    "test_nested_transaction_rollback",
+    "[mysql][transaction][rollback]")
+{
+    test_nested_transaction_rollback();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_result_unbind", "[mysql][result][unbind]")
 {
     test_result_unbind();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -355,6 +355,14 @@ TEST_CASE_METHOD(postgresql_fixture, "test_bind_arithmetic_null_sentry", "[postg
     test_bind_arithmetic_null_sentry();
 }
 
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_nested_transaction_rollback",
+    "[postgresql][transaction][rollback]")
+{
+    test_nested_transaction_rollback();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_result_unbind", "[postgresql][result][unbind]")
 {
     test_result_unbind();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -473,6 +473,14 @@ TEST_CASE_METHOD(sqlite_fixture, "test_bind_arithmetic_null_sentry", "[sqlite][b
     test_bind_arithmetic_null_sentry();
 }
 
+TEST_CASE_METHOD(
+    sqlite_fixture,
+    "test_nested_transaction_rollback",
+    "[sqlite][transaction][rollback]")
+{
+    test_nested_transaction_rollback();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_result_unbind", "[sqlite][result][unbind]")
 {
     test_result_unbind();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1674,6 +1674,66 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(results.get<int>(1) == 2);
     }
 
+    // Transactions on one connection share a single ODBC transaction, there being no
+    // savepoints underneath, so a rollback anywhere within it discards all of it. An
+    // outer commit cannot rescue work an inner transaction asked to throw away.
+    void test_nested_transaction_rollback()
+    {
+        auto connection = connect();
+        create_table(
+            connection, NANODBC_TEXT("test_nested_transaction_rollback"), NANODBC_TEXT("(i int)"));
+
+        auto const count = [&]()
+        {
+            auto results = execute(
+                connection, NANODBC_TEXT("select count(*) from test_nested_transaction_rollback;"));
+            results.next();
+            return results.template get<int>(0);
+        };
+
+        // Inner rolls back, outer commits: nothing is kept.
+        {
+            nanodbc::transaction outer(connection);
+            {
+                nanodbc::transaction inner(connection);
+                execute(
+                    connection,
+                    NANODBC_TEXT("insert into test_nested_transaction_rollback values (1);"));
+                inner.rollback();
+            }
+            outer.commit();
+        }
+        REQUIRE(count() == 0);
+
+        // Inner commits, outer rolls back: nothing is kept either.
+        {
+            nanodbc::transaction outer(connection);
+            {
+                nanodbc::transaction inner(connection);
+                execute(
+                    connection,
+                    NANODBC_TEXT("insert into test_nested_transaction_rollback values (2);"));
+                inner.commit();
+            }
+            outer.rollback();
+        }
+        REQUIRE(count() == 0);
+
+        // Both commit: the work is kept.
+        {
+            nanodbc::transaction outer(connection);
+            {
+                nanodbc::transaction inner(connection);
+                execute(
+                    connection,
+                    NANODBC_TEXT("insert into test_nested_transaction_rollback values (3);"));
+                inner.commit();
+            }
+            outer.commit();
+        }
+        REQUIRE(count() == 1);
+    }
+
     // A binary column is not bound, so the fetch leaves no indicator behind for it and
     // whether it is null has to be asked of the driver.
     void test_is_null_binary()


### PR DESCRIPTION
Closes #78.

**This changes behaviour, so it deserves a maintainer's eye rather than a rubber stamp.** The argument for it is below.

## What happens today

Transactions on one connection share a single ODBC transaction — there are no savepoints underneath, just a reference count. The destructor has always honoured the connection's rollback flag:

```cpp
if (conn_.transactions() == 0 && conn_.connected())
{
    if (conn_.rollback())
    {
        NANODBC_CALL(SQLEndTran, ..., SQL_ROLLBACK);
        conn_.rollback(false);
    }
    ...
}
```

`commit()` did not look at that flag at all, and issued `SQL_COMMIT` unconditionally.

So an inner transaction that rolled back was overridden by an outer commit:

```
inner rollback + outer commit -> rows = 1    <- the discarded row was written
inner commit  + outer rollback -> rows = 0
```

## Why I treated this as a bug rather than a preference

Two reasons, beyond the reporter's expectation and @mloskot's "the current behaviour looks suspicious":

1. **nanodbc already disagrees with itself.** The destructor honours the flag; `commit()` ignores it. Whether an inner rollback survives depended on whether the outer transaction was committed explicitly or left to go out of scope. That is not a design position, it is an inconsistency.

2. **There are no savepoints, so the alternative is not coherent.** An inner rollback cannot undo only the inner statements — nothing recorded where the inner transaction began. Committing anyway does not "ignore the inner rollback", it writes the rows the caller explicitly asked to discard. Rolling everything back is the only behaviour the underlying mechanism can actually deliver.

After the change:

```
inner rollback + outer commit -> rows = 0    <- the rollback is honoured
inner commit  + outer rollback -> rows = 0
both commit                    -> rows = 1
```

## Testing

`test_nested_transaction_rollback` covers all three combinations against SQLite, MySQL, PostgreSQL and SQL Server. All five suites pass, including the existing transaction tests, which the change leaves untouched.

If you would rather keep the current semantics and document them instead, say so and I will swap the fix for a documentation note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)