### PR TITLE
Test long text at the chunk boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- A test reads long text at the sizes either side of the chunk the driver is asked for, where a piece could be dropped or repeated. [`#22`](https://github.com/nanodbc/nanodbc/issues/22)
 - `transaction::commit()` honours the connection's rollback flag, so an inner rollback is no longer discarded by an outer commit. [`#78`](https://github.com/nanodbc/nanodbc/issues/78)
 - A regression test covers binding objects past the driver's reported parameter limit, which nothing pinned. [`#5`](https://github.com/nanodbc/nanodbc/issues/5)
 - A bound character column the driver under-sized is read again in full instead of coming back truncated. [`#343`](https://github.com/nanodbc/nanodbc/issues/343)

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1203,6 +1203,11 @@ TEST_CASE_METHOD(
     test_nested_transaction_rollback();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_long_text_chunk_boundaries", "[mssql][result][string]")
+{
+    test_long_text_chunk_boundaries();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_result_unbind", "[mssql][result][unbind]")
 {
     test_result_unbind();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -413,6 +413,11 @@ TEST_CASE_METHOD(
     test_nested_transaction_rollback();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_long_text_chunk_boundaries", "[mysql][result][string]")
+{
+    test_long_text_chunk_boundaries();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_result_unbind", "[mysql][result][unbind]")
 {
     test_result_unbind();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -363,6 +363,14 @@ TEST_CASE_METHOD(
     test_nested_transaction_rollback();
 }
 
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_long_text_chunk_boundaries",
+    "[postgresql][result][string]")
+{
+    test_long_text_chunk_boundaries();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_result_unbind", "[postgresql][result][unbind]")
 {
     test_result_unbind();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -481,6 +481,11 @@ TEST_CASE_METHOD(
     test_nested_transaction_rollback();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_long_text_chunk_boundaries", "[sqlite][result][string]")
+{
+    test_long_text_chunk_boundaries();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_result_unbind", "[sqlite][result][unbind]")
 {
     test_result_unbind();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1734,6 +1734,51 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(count() == 1);
     }
 
+    // A long column is read in fixed-size pieces with repeated SQLGetData calls, 1024
+    // bytes at a time narrow and 512 characters wide. Lengths either side of both are
+    // where a piece gets dropped, repeated or double counted.
+    void test_long_text_chunk_boundaries()
+    {
+        auto connection = connect();
+        create_table(
+            connection,
+            NANODBC_TEXT("test_long_text_chunk_boundaries"),
+            NANODBC_TEXT("(id int, t ") + get_text_type_name() + NANODBC_TEXT(")"));
+
+        for (std::size_t const length :
+             {std::size_t{511},
+              std::size_t{512},
+              std::size_t{513},
+              std::size_t{1023},
+              std::size_t{1024},
+              std::size_t{1025},
+              std::size_t{5000}})
+        {
+            execute(connection, NANODBC_TEXT("delete from test_long_text_chunk_boundaries;"));
+
+            // Repeating rather than uniform, so a repeated piece shows up as a mismatch
+            // instead of blending in.
+            nanodbc::string value;
+            value.reserve(length);
+            for (std::size_t i = 0; i < length; ++i)
+                value.push_back(
+                    static_cast<nanodbc::string::value_type>(NANODBC_TEXT("abcdefghij")[i % 10]));
+
+            nanodbc::statement statement(connection);
+            statement.prepare(
+                NANODBC_TEXT("insert into test_long_text_chunk_boundaries (id, t) values (1, ?);"));
+            statement.bind(0, value.c_str());
+            statement.just_execute();
+
+            auto results =
+                execute(connection, NANODBC_TEXT("select t from test_long_text_chunk_boundaries;"));
+            REQUIRE(results.next());
+            auto const read_back = results.template get<nanodbc::string>(0);
+            REQUIRE(read_back.size() == length);
+            REQUIRE(read_back == value);
+        }
+    }
+
     // A binary column is not bound, so the fetch leaves no indicator behind for it and
     // whether it is null has to be asked of the driver.
     void test_is_null_binary()


### PR DESCRIPTION
Closes #22.

#22 reported a MariaDB `LONGTEXT` coming back with a piece repeated — "result was splitted into two chunks. First chunk was duplicated". It does not reproduce on current main, and nothing pinned the behaviour, so this adds the test.

A long column is read in fixed-size pieces with repeated `SQLGetData` calls, **1024 bytes** at a time on the narrow path and **512 characters** on the wide one. A value whose length lands on or near one of those boundaries is exactly where a piece gets dropped, repeated, or double counted — which matches the symptom.

`test_blob` already reads a value long enough to need several pieces, but only incidentally and at no particular length, and it inserts through statement text rather than a bound parameter.

`test_long_text_chunk_boundaries` reads **511, 512, 513, 1023, 1024, 1025 and 5000** characters, binds as a parameter, and compares the whole value rather than just its length. The content repeats `abcdefghij` so a duplicated piece shows up as a mismatch instead of blending into uniform filler.

Verified against MariaDB directly with the reporter's shape — a `longtext` column at each of those lengths — all matching exactly.

## Testing

Runs against SQLite, MySQL, PostgreSQL and SQL Server. All five suites pass.

Also run under `NANODBC_ENABLE_UNICODE=ON`, where it passes on all four — though PostgreSQL needs `Driver={PostgreSQL Unicode}` rather than the ANSI driver `docker-compose.yml` currently uses, since the ANSI one rejects a wide bind with `HYC00 Unrecognized C_parameter type`. That is a configuration matter rather than anything this PR changes, but it is worth knowing for #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)