### PR TITLE
Test and document a batch returning several result sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Documented that a batch returns a result set per statement, counts included, and how to reach the rows. [`#247`](https://github.com/nanodbc/nanodbc/issues/247)
 - `transaction::commit()` honours the connection's rollback flag, so an inner rollback is no longer discarded by an outer commit. [`#78`](https://github.com/nanodbc/nanodbc/issues/78)
 - A regression test covers binding objects past the driver's reported parameter limit, which nothing pinned. [`#5`](https://github.com/nanodbc/nanodbc/issues/5)
 - A bound character column the driver under-sized is read again in full instead of coming back truncated. [`#343`](https://github.com/nanodbc/nanodbc/issues/343)

--- a/doc/use.rst
+++ b/doc/use.rst
@@ -75,6 +75,45 @@ In a narrow build, which is the default, text crosses between nanodbc and the dr
 Statement text is the more fragile of the two, because unlike a bound parameter it reaches the driver with neither a length nor a type. Bind values as parameters rather than writing them into statement text.
 
 ******************************************************************************
+Batches and multiple result sets
+******************************************************************************
+
+A batch of statements returns one result set per statement, in order, and the counts from ``INSERT``, ``UPDATE`` and ``DELETE`` count as result sets of their own. ``execute`` hands back the first of them, so a batch that modifies rows before selecting any arrives positioned on a count, which has no columns and no rows to read. Calling ``next()`` on it raises ``24000 Invalid cursor state`` rather than returning the rows the ``SELECT`` produced.
+
+``result::next_result`` moves to the following result set:
+
+.. code-block:: cpp
+
+  #include <nanodbc/nanodbc.h>
+
+  #include <cstdlib>
+  #include <exception>
+  #include <iostream>
+
+  int main() try
+  {
+    nanodbc::connection conn(NANODBC_TEXT("..."));
+    auto results = nanodbc::execute(conn, NANODBC_TEXT(
+      "declare @t table (id int); "
+      "insert into @t values (1), (2); "
+      "select id from @t;"));
+
+    results.next_result(); // past the insert's count, onto the select's rows
+    while (results.next())
+    {
+      std::cout << results.get<int>(0) << std::endl;
+    }
+    return EXIT_SUCCESS;
+  }
+  catch (std::exception const& e)
+  {
+      std::cerr << e.what() << std::endl;
+      return EXIT_FAILURE;
+  }
+
+On SQL Server, ``SET NOCOUNT ON`` withholds the counts instead, leaving the rows as the only result set and removing the need to step over anything.
+
+******************************************************************************
 Examples
 ******************************************************************************
 

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -2664,6 +2664,44 @@ TEST_CASE_METHOD(mssql_fixture, "test_non_bmp_round_trip", "[mssql][unicode][bin
 #endif
 }
 
+// A batch of statements returns a result set for each, and the counts from INSERT come
+// before the rows from SELECT. Reading the batch as though it returned only the rows
+// reaches for a result set that has none.
+TEST_CASE_METHOD(mssql_fixture, "test_batch_with_table_variable", "[mssql][result][batch]")
+{
+    auto connection = connect();
+    nanodbc::string const batch = NANODBC_TEXT(
+        "declare @t table (id int, name varchar(20)); "
+        "insert into @t values (1, 'one'), (2, 'two'); "
+        "select id, name from @t;");
+
+    // The insert's count arrives first, with no columns to read.
+    {
+        auto results = execute(connection, batch);
+        REQUIRE(results.columns() == 0);
+        REQUIRE_THROWS_AS(results.next(), nanodbc::database_error);
+
+        REQUIRE(results.next_result());
+        REQUIRE(results.columns() == 2);
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 1);
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 2);
+        REQUIRE(!results.next());
+    }
+
+    // SET NOCOUNT ON withholds the counts, leaving the rows as the only result set.
+    {
+        auto results = execute(connection, NANODBC_TEXT("set nocount on; ") + batch);
+        REQUIRE(results.columns() == 2);
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 1);
+        REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("one"));
+        REQUIRE(results.next());
+        REQUIRE(!results.next());
+    }
+}
+
 // An NVARCHAR column is bound wide, so reading one as a character takes the wide arm of
 // the string column path.
 TEST_CASE_METHOD(mssql_fixture, "test_wide_bound_column_as_character", "[mssql][result][unicode]")


### PR DESCRIPTION
Closes #247.

The report was that a query declaring a table variable "does not work", and asked whether complicated queries are unsupported. They are supported — the batch just does not return what the caller expects first.

A batch returns one result set per statement, and the counts from `INSERT`, `UPDATE` and `DELETE` are result sets in their own right. `execute` hands back the first of them, so this batch:

```sql
declare @t table (id int, name varchar(20));
insert into @t values (1, 'one'), (2, 'two');
select id, name from @t;
```

arrives positioned on the insert's count, which has no columns. Reproduced:

```
plain batch          : columns=0  threw while fetching: 24000 [SQL Server]Invalid cursor state
   next_result -> columns=2 rows=2
with SET NOCOUNT ON  : columns=2 rows=2
```

So the `24000` is not a failure to run the query; it is reading a result set that has no rows to give.

Two ways past it, both covered by `test_batch_with_table_variable`:

- `result::next_result()` steps over the count onto the select's rows.
- `SET NOCOUNT ON` withholds the counts, leaving the rows as the only result set.

`test_multi_statement_insert_select` already exercises `next_result` for an INSERT + SELECT pair, but not this shape, and not the error a caller actually meets when they do not know to call it.

## Documentation

`doc/use.rst` gains a short section, because neither route is discoverable from the error message. I left the README alone deliberately — it covers building and contributing rather than usage, so there is nothing there to keep in sync with this.

## Testing

All five suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)