### PR TITLE
Test binding a string as an output parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Documented that a batch returns a result set per statement, counts included, and how to reach the rows. [`#247`](https://github.com/nanodbc/nanodbc/issues/247)
+- A test covers binding a string as an output parameter, which the driver writes back into the caller's buffer. [`#231`](https://github.com/nanodbc/nanodbc/issues/231)
 - A test reads long text at the sizes either side of the chunk the driver is asked for, where a piece could be dropped or repeated. [`#22`](https://github.com/nanodbc/nanodbc/issues/22)
 - `transaction::commit()` honours the connection's rollback flag, so an inner rollback is no longer discarded by an outer commit. [`#78`](https://github.com/nanodbc/nanodbc/issues/78)
 - A regression test covers binding objects past the driver's reported parameter limit, which nothing pinned. [`#5`](https://github.com/nanodbc/nanodbc/issues/5)

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -2537,6 +2537,40 @@ TEST_CASE_METHOD(mssql_fixture, "test_output_parameters", "[mssql][statement][bi
     REQUIRE(out2 == 2);
 }
 
+// An output parameter of a string type is bound with bind_strings and a direction. The
+// buffer belongs to the caller and the driver writes the value into it, so it has to be
+// writable and large enough for whatever the procedure returns.
+TEST_CASE_METHOD(mssql_fixture, "test_output_string_parameter", "[mssql][statement][bind]")
+{
+    auto connection = connect();
+    nanodbc::string const name = NANODBC_TEXT("test_output_string_parameter_proc");
+    try
+    {
+        execute(connection, NANODBC_TEXT("DROP PROCEDURE ") + name);
+    }
+    catch (...)
+    {
+    }
+    execute(
+        connection,
+        NANODBC_TEXT("CREATE PROCEDURE ") + name +
+            NANODBC_TEXT(
+                " @in varchar(20), @out varchar(50) OUTPUT AS "
+                "BEGIN SET @out = 'hello ' + @in; END;"));
+
+    nanodbc::statement statement(connection);
+    statement.prepare(NANODBC_TEXT("{ call ") + name + NANODBC_TEXT("(?, ?) }"));
+
+    char in[21] = "world";
+    char out[51] = {};
+
+    statement.bind_strings(0, in, sizeof(in), 1);
+    statement.bind_strings(1, out, sizeof(out), 1, nanodbc::statement::PARAM_OUT);
+    statement.just_execute();
+
+    REQUIRE(std::string(out) == "hello world");
+}
+
 // A procedure's RETURN value is not an output parameter; it is bound at position zero
 // of a "{ ? = CALL ... }" escape sequence with PARAM_RETURN.
 TEST_CASE_METHOD(mssql_fixture, "test_procedure_return_value", "[mssql][statement][bind]")


### PR DESCRIPTION
Closes #231.

The question was whether a string can be bound as an output parameter, since every example found used `int`. It can, and it works — but nobody had shown it. @mloskot's reply at the time said the suite had no coverage for procedures and invited contributions, and @lexicalunit suspected the string binding functions might not fully deliver. This settles it.

```cpp
char in[21] = "world";
char out[51] = {};

statement.bind_strings(0, in, sizeof(in), 1);
statement.bind_strings(1, out, sizeof(out), 1, nanodbc::statement::PARAM_OUT);
statement.just_execute();

// out == "hello world"
```

`bind_strings` takes a direction just as the fixed-size `bind` overloads do. The buffer belongs to the caller and the driver writes the value into it, so it has to be **writable** and **large enough** for whatever the procedure returns.

The reporter's worry was well founded, though, and worth writing down rather than glossing over: every `bind_strings` overload takes `T const*`. A caller can therefore pass a string literal or a `const` array for an output parameter, it will compile without complaint, and the driver will write through it. The `const` is not a promise here — nanodbc casts it away so that output parameters can work at all. The test uses a plain array to show the shape that is actually safe.

## Testing

All five suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)