### PR TITLE
Declare a date or time parameter bound as text as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- A date or time parameter bound as text is declared as text, so the server reads it rather than the driver, which read fewer spellings. [`#248`](https://github.com/nanodbc/nanodbc/issues/248)
 - Documented the ODBC literal format a date or timestamp string parameter must use, and covered it with a test. [`#248`](https://github.com/nanodbc/nanodbc/issues/248)
 - A test covers reading a generated identity back from an INSERT through the OUTPUT clause. [`#193`](https://github.com/nanodbc/nanodbc/issues/193)
 - Documented that a batch returns a result set per statement, counts included, and how to reach the rows. [`#247`](https://github.com/nanodbc/nanodbc/issues/247)

--- a/doc/use.rst
+++ b/doc/use.rst
@@ -117,9 +117,11 @@ On SQL Server, ``SET NOCOUNT ON`` withholds the counts instead, leaving the rows
 Dates and times as strings
 ******************************************************************************
 
-A string bound to a date, time or timestamp parameter has to be written the way ODBC spells those literals, which is ``yyyy-mm-dd``, ``hh:mm:ss`` and ``yyyy-mm-dd hh:mm:ss[.f...]``. The separator between date and time is a **space**, and there is no place for a time zone offset.
+ODBC spells its date and time literals ``yyyy-mm-dd``, ``hh:mm:ss`` and ``yyyy-mm-dd hh:mm:ss[.f...]``, with a space between date and time and no place for a time zone offset. A driver asked to parse a string as a timestamp accepts little else: given the ISO 8601 ``2020-09-03T15:27:38-02:00``, the PostgreSQL driver used to store ``2020-09-03 00:00:00`` and report success, the ``T`` having stopped it reading the time, with nothing in the return code or the diagnostics to say so.
 
-ISO 8601 looks close enough to pass and does not. Given ``2020-09-03T15:27:38-02:00``, the PostgreSQL driver stores ``2020-09-03 00:00:00`` and reports success: the ``T`` stops it reading the time, and nothing in the return code or the diagnostics says so. Writing the same value as ``2020-09-03 15:27:38`` stores it correctly, and the offset is ignored either way.
+nanodbc now declares such a parameter as text, which leaves the reading to the server rather than the driver. Servers accept both spellings, so either form stores the time, and a time zone offset is applied or ignored according to the column's own type rather than being dropped on the way.
+
+What the server will accept is still the server's business. SQL Server, for one, rejects an offset on a ``datetime`` column — but it says so, rather than silently keeping the date alone.
 
 Binding a ``nanodbc::timestamp`` avoids the question entirely, since it carries its fields rather than a spelling of them.
 

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2448,6 +2448,29 @@ public:
         return static_cast<short>(param_type);
     }
 
+    // Whether a parameter takes a date, a time, or both.
+    static bool is_datetime_param_type(SQLSMALLINT type) noexcept
+    {
+        switch (type)
+        {
+        case SQL_DATE:
+        case SQL_TYPE_DATE:
+        case SQL_TIME:
+        case SQL_TYPE_TIME:
+        case SQL_TIMESTAMP:
+        case SQL_TYPE_TIMESTAMP:
+#ifdef SQL_SS_TIME2
+        case SQL_SS_TIME2:
+#endif
+#ifdef SQL_SS_TIMESTAMPOFFSET
+        case SQL_SS_TIMESTAMPOFFSET:
+#endif
+            return true;
+        default:
+            return false;
+        }
+    }
+
     static SQLSMALLINT param_type_from_direction(param_direction direction)
     {
         switch (direction)
@@ -2574,6 +2597,21 @@ public:
         if (buffer_size == 0)
             buffer_size = (std::char_traits<T>::length(buffer.values_) + 1) * sizeof(T);
 
+        // Text bound to a date or time parameter is left for the server to read rather
+        // than the driver. A driver reads a narrower set of spellings than the server it
+        // speaks to and reports success either way, so an ISO 8601 timestamp can lose its
+        // time without a word said. The value is unchanged; only the type it is declared
+        // as differs.
+        auto parameter_type = param.type_;
+        auto parameter_size = param.size_;
+        auto parameter_scale = param.scale_;
+        if (is_datetime_param_type(parameter_type))
+        {
+            parameter_type = SQL_VARCHAR;
+            parameter_size = buffer_size / sizeof(T);
+            parameter_scale = 0;
+        }
+
         RETCODE rc = SQL_SUCCESS;
         NANODBC_CALL_RC(
             SQLBindParameter,
@@ -2582,9 +2620,9 @@ public:
             param.index_ + 1, // parameter number
             param.iotype_,    // input or output type
             buffer.ctype_,    // value type
-            param.type_,      // parameter type
-            param.size_,      // column size ignored for many types, but needed for strings
-            param.scale_,     // decimal digits
+            parameter_type,   // parameter type
+            parameter_size,   // column size ignored for many types, but needed for strings
+            parameter_scale,  // decimal digits
             (SQLPOINTER)buffer.values_, // parameter value
             buffer_size,                // buffer length
             bind_len_or_null_[param.index_].data());

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -318,6 +318,14 @@ TEST_CASE_METHOD(mssql_fixture, "test_insert_output_identity", "[mssql][result][
 
 TEST_CASE_METHOD(
     mssql_fixture,
+    "test_bind_iso8601_timestamp_as_string",
+    "[mssql][statement][bind][timestamp]")
+{
+    test_bind_iso8601_timestamp_as_string();
+}
+
+TEST_CASE_METHOD(
+    mssql_fixture,
     "test_bind_timestamp_as_string",
     "[mssql][statement][bind][timestamp]")
 {

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -150,6 +150,14 @@ TEST_CASE_METHOD(mysql_fixture, "test_std_optional", "[mysql][optional]")
 
 TEST_CASE_METHOD(
     mysql_fixture,
+    "test_bind_iso8601_timestamp_as_string",
+    "[mysql][statement][bind][timestamp]")
+{
+    test_bind_iso8601_timestamp_as_string();
+}
+
+TEST_CASE_METHOD(
+    mysql_fixture,
     "test_bind_timestamp_as_string",
     "[mysql][statement][bind][timestamp]")
 {

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -55,6 +55,14 @@ TEST_CASE_METHOD(postgresql_fixture, "test_datasources", "[postgresql][datasourc
 
 TEST_CASE_METHOD(
     postgresql_fixture,
+    "test_bind_iso8601_timestamp_as_string",
+    "[postgresql][statement][bind][timestamp]")
+{
+    test_bind_iso8601_timestamp_as_string();
+}
+
+TEST_CASE_METHOD(
+    postgresql_fixture,
     "test_bind_timestamp_as_string",
     "[postgresql][statement][bind][timestamp]")
 {

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1529,6 +1529,38 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(rows == 4);
     }
 
+    // The same value written the ISO 8601 way, which a driver asked to parse it as a
+    // timestamp reads only the date from. Declaring the parameter as text instead leaves
+    // the reading to the server, which understands both spellings.
+    void test_bind_iso8601_timestamp_as_string()
+    {
+        auto connection = connect();
+        create_table(
+            connection,
+            NANODBC_TEXT("test_bind_iso8601_timestamp_as_string"),
+            NANODBC_TEXT("(id int, ts ") + get_timestamp_type_name() + NANODBC_TEXT(")"));
+
+        auto const value = NANODBC_TEXT("2020-09-03T15:27:38");
+
+        nanodbc::statement statement(connection);
+        statement.prepare(NANODBC_TEXT(
+            "insert into test_bind_iso8601_timestamp_as_string (id, ts) values (1, ?);"));
+        statement.bind(0, value);
+        statement.just_execute();
+
+        auto results = execute(
+            connection, NANODBC_TEXT("select ts from test_bind_iso8601_timestamp_as_string;"));
+        REQUIRE(results.next());
+
+        auto const stamp = results.template get<nanodbc::timestamp>(0);
+        REQUIRE(stamp.year == 2020);
+        REQUIRE(stamp.month == 9);
+        REQUIRE(stamp.day == 3);
+        REQUIRE(stamp.hour == 15);
+        REQUIRE(stamp.min == 27);
+        REQUIRE(stamp.sec == 38);
+    }
+
     // A string bound to a timestamp parameter has to be in the ODBC literal format,
     // "yyyy-mm-dd hh:mm:ss", with a space. An ISO 8601 "T" in its place is accepted
     // without complaint by at least one driver, which then stores midnight.


### PR DESCRIPTION
**Stacked on #502** — review that one first; this targets its branch so the diff stays honest. If you would rather have one PR, say so and I will squash them.

This is the "make it just work" change we discussed. It is a **behaviour change to the bind path**, which is why it is flagged rather than quietly landed.

## The idea

`bind_parameter` passes whatever `SQLDescribeParam` reported as the `ParameterType`. For a **character** value bound to a **date/time/timestamp** parameter, it now passes `SQL_VARCHAR` instead:

```cpp
if (is_datetime_param_type(parameter_type))
{
    parameter_type = SQL_VARCHAR;
    parameter_size = buffer_size / sizeof(T);
    parameter_scale = 0;
}
```

That hands the parsing to the **server** rather than the **driver**. The bytes sent are unchanged; only their declared type differs. No new API, no date parser, nothing outside `SQLBindParameter` — it stays inside the "no features unsupported by existing ODBC API calls" line in the README.

Only the character `bind_parameter` is touched. `bind_null` has no value to parse and the table-valued path is a different mechanism, so both are left alone. Binding a `nanodbc::timestamp` is untouched and still goes as `SQL_TYPE_TIMESTAMP`.

## Measured, not assumed

Every driver available here, binding `2020-09-03T15:27:38-02:00`:

| backend | before | after |
|---|---|---|
| **postgres** | `00:00:00` — silent loss | `17:27:38` — correct, offset applied |
| **mssql** | error on the `T` form | `15:27:38` — accepted |
| mysql | already correct | unchanged |
| sqlite | text kept verbatim | unchanged — it has no date type to parse into |

Never worse anywhere I can test. The offset now reaches the server, which applies or ignores it according to the column's own type instead of it being dropped in transit.

## What this does not do

- **Oracle is untested**, and is the likeliest to want an explicit conversion rather than an implicit cast. It also has form here (#202, #190, #204). #487 would let us check.
- SQL Server still refuses an offset on a `datetime` column. That is now a clear error rather than a silent truncation, which I would call the right outcome rather than a remaining bug.
- SQLite cannot benefit: it has no date type and stores the text as given.

`doc/use.rst` is updated so it no longer tells people the ODBC literal form is required, since after this it is not.

## Testing

All five suites pass. `test_bind_iso8601_timestamp_as_string` covers MySQL, PostgreSQL and SQL Server — not SQLite, which stores the text verbatim and so has nothing to prove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)