### PR TITLE
Render a floating point column with the digits it needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- A floating point column read as text carries every digit needed to read back as the same value, where six decimals were rendered whatever the magnitude. [`#196`](https://github.com/nanodbc/nanodbc/issues/196)
 - A date or time parameter bound as text is declared as text, so the server reads it rather than the driver, which reads fewer spellings. [`#248`](https://github.com/nanodbc/nanodbc/issues/248)
 - A test covers reading a generated identity back from an INSERT through the OUTPUT clause. [`#193`](https://github.com/nanodbc/nanodbc/issues/193)
 - Documented that a batch returns a result set per statement, counts included, and how to reach the rows. [`#247`](https://github.com/nanodbc/nanodbc/issues/247)

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -23,7 +23,9 @@
 #include <ctime>
 #include <iomanip>
 #include <limits>
+#include <locale>
 #include <map>
+#include <sstream>
 #include <type_traits>
 
 #ifndef __clang__
@@ -1126,6 +1128,31 @@ inline void allocate_dbc_handle(SQLHDBC& conn, SQLHENV env)
         deallocate_handle(conn, SQL_HANDLE_DBC);
         throw;
     }
+}
+
+// The fewest digits that read back as the same value. std::to_string renders a floating
+// point value as %f, six digits after the point whatever the magnitude, which drops
+// precision from a large value and all of a small one: 1.23e-07 comes out "0.000000".
+template <class T>
+inline std::string render_floating_point(T value)
+{
+    std::ostringstream out;
+    out.imbue(std::locale::classic());
+    for (auto precision = std::numeric_limits<T>::digits10;
+         precision <= std::numeric_limits<T>::max_digits10;
+         ++precision)
+    {
+        out.str(std::string());
+        out << std::setprecision(precision) << value;
+
+        std::istringstream in(out.str());
+        in.imbue(std::locale::classic());
+        T parsed = 0;
+        in >> parsed;
+        if (parsed == value)
+            break;
+    }
+    return out.str();
 }
 
 } // namespace
@@ -5010,11 +5037,11 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         return;
 
     case SQL_C_FLOAT:
-        convert(std::to_string(*ensure_pdata<float>(column)), result);
+        convert(render_floating_point(*ensure_pdata<float>(column)), result);
         return;
 
     case SQL_C_DOUBLE:
-        convert(std::to_string(*ensure_pdata<double>(column)), result);
+        convert(render_floating_point(*ensure_pdata<double>(column)), result);
         return;
 
     case SQL_C_DATE:

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1817,19 +1817,24 @@ TEST_CASE_METHOD(mssql_fixture, "test_bind_float", "[mssql][number][float]")
         auto result =
             nanodbc::execute(conn, NANODBC_TEXT("select r,f,f24,f53,d from test_bind_float"));
         result.next();
-        // Read as text, each column reads back as the value it holds. The digits are
-        // the column's to decide rather than the literal's: a C float widened into a
-        // float(53) holds 3.1229999065399170, and saying so is the point.
+        // Read as text and read back as a number, each column names the value it holds.
+        // Comparing numbers rather than characters leaves how many digits were written
+        // out of it. Slicing the text instead truncates rather than rounds, which is how
+        // 3.1229999065399170 reads as 3.122 while being 3.123 to every digit a float
+        // carries.
+        auto const names_the_same_value = [](std::string const& text, double value)
+        { return Catch::Matchers::WithinRel(value, 1e-6).match(std::stod(text)); };
+
         REQUIRE(result.get<float>(0) == static_cast<float>(r));
-        REQUIRE(std::stod(result.get<std::string>(0)) == result.get<double>(0));
+        REQUIRE(names_the_same_value(result.get<std::string>(0), result.get<double>(0)));
         REQUIRE(result.get<float>(1) == static_cast<float>(f));
-        REQUIRE(std::stod(result.get<std::string>(1)) == result.get<double>(1));
+        REQUIRE(names_the_same_value(result.get<std::string>(1), result.get<double>(1)));
         REQUIRE(result.get<float>(2) == static_cast<float>(f));
-        REQUIRE(std::stod(result.get<std::string>(2)) == result.get<double>(2));
+        REQUIRE(names_the_same_value(result.get<std::string>(2), result.get<double>(2)));
         REQUIRE(result.get<float>(3) == static_cast<float>(f));
-        REQUIRE(std::stod(result.get<std::string>(3)) == result.get<double>(3));
+        REQUIRE(names_the_same_value(result.get<std::string>(3), result.get<double>(3)));
         REQUIRE(result.get<double>(4) == static_cast<double>(d));
-        REQUIRE(std::stod(result.get<std::string>(4)) == result.get<double>(4));
+        REQUIRE(names_the_same_value(result.get<std::string>(4), result.get<double>(4)));
     }
 }
 

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1817,16 +1817,19 @@ TEST_CASE_METHOD(mssql_fixture, "test_bind_float", "[mssql][number][float]")
         auto result =
             nanodbc::execute(conn, NANODBC_TEXT("select r,f,f24,f53,d from test_bind_float"));
         result.next();
+        // Read as text, each column reads back as the value it holds. The digits are
+        // the column's to decide rather than the literal's: a C float widened into a
+        // float(53) holds 3.1229999065399170, and saying so is the point.
         REQUIRE(result.get<float>(0) == static_cast<float>(r));
-        REQUIRE(result.get<std::string>(0).substr(0, 5) == "1.123");
+        REQUIRE(std::stod(result.get<std::string>(0)) == result.get<double>(0));
         REQUIRE(result.get<float>(1) == static_cast<float>(f));
-        REQUIRE(result.get<std::string>(1).substr(0, 5) == "3.123");
+        REQUIRE(std::stod(result.get<std::string>(1)) == result.get<double>(1));
         REQUIRE(result.get<float>(2) == static_cast<float>(f));
-        REQUIRE(result.get<std::string>(2).substr(0, 5) == "3.123");
+        REQUIRE(std::stod(result.get<std::string>(2)) == result.get<double>(2));
         REQUIRE(result.get<float>(3) == static_cast<float>(f));
-        REQUIRE(result.get<std::string>(3).substr(0, 5) == "3.123");
+        REQUIRE(std::stod(result.get<std::string>(3)) == result.get<double>(3));
         REQUIRE(result.get<double>(4) == static_cast<double>(d));
-        REQUIRE(result.get<std::string>(4).substr(0, 5) == "7.123");
+        REQUIRE(std::stod(result.get<std::string>(4)) == result.get<double>(4));
     }
 }
 


### PR DESCRIPTION
Found while looking at #196. **This changes rendered output**, so it wants a decision — though less of one than I first wrote, see the correction below.

## The bug

`std::to_string` writes a floating point value as `%f`: six digits after the point, whatever the magnitude. Reading a `double precision` column as a string:

```
1.23456789012345   ->  "1.234568"           precision lost
1.23e-07           ->  "0.000000"           value gone entirely
123456789.5        ->  "123456789.500000"   fine
```

The middle line is the serious one. A small value silently reads back as **zero** — not truncated, gone.

`std::to_string` is also locale-dependent, so under a locale with a comma decimal separator it writes a comma. That is a second fault in the same call.

## The fix

`render_floating_point` writes the fewest digits that read back as the same value, through the classic locale in both directions:

```
1.23456789012345   ->  "1.23456789012345"
1.23e-07           ->  "1.23e-07"
123456789.5        ->  "123456789.5"
```

## A correction to my first version of this PR

I originally claimed an irreconcilable conflict: that preserving `1.23e-07` needs fifteen significant digits while showing a widened float as `"3.123"` needs six. That overstated it.

`test_bind_float` had been asserting `result.get<std::string>(1).substr(0, 5) == "3.123"`, and began failing with `"3.122"`. **Slicing five characters truncates where rounding would carry.** `3.1229999065399170` sliced is `"3.122"`; rounded to the digits a float actually carries it is `3.123`. The two numbers were never meaningfully different — the comparison was.

The second commit replaces that with reading the text back as a number and comparing it to the value with a relative tolerance. It passes against **both** the old rendering and the new one, verified by building it each way. So the test pins the property worth having — the text names the value — and no longer decides how many digits get written.

That leaves the rendering choice standing on its own merits rather than on a test, which is where it belongs.

## Relation to #196

Adjacent but not the same. #196 reports that nanodbc leaned on `SQLDescribeCol`'s decimal digits, which a driver may return as 0. That reliance is **already gone** — `std::to_string` replaced it, and brought this instead. I have not closed #196, since its reporter never supplied the reproducer they were asked for and I cannot confirm their case is this one.

## The remaining choice

Fidelity, as here, never loses a value but prints `3.1229999065399170` where a `float` was widened into a `float(53)`.

General format at six significant digits would print `3.123` and still fix the `"0.000000"` catastrophe, at the cost of truncating genuine doubles past six significant digits.

I picked fidelity on the grounds that display noise can be reformatted by the caller and lost data cannot. The test is indifferent either way, so swapping is a one-line change if you prefer the friendlier output.

## Testing

All five suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)