### PR TITLE
Test binding a timestamp's fractional second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - A floating point column read as text carries every digit needed to read back as the same value, where six decimals were rendered whatever the magnitude. [`#196`](https://github.com/nanodbc/nanodbc/issues/196)
+- A test covers binding a timestamp's fractional second, which counts nanoseconds and has to suit what the column resolves. [`#4`](https://github.com/nanodbc/nanodbc/issues/4)
 - A date or time parameter bound as text is declared as text, so the server reads it rather than the driver, which reads fewer spellings. [`#248`](https://github.com/nanodbc/nanodbc/issues/248)
 - A test covers reading a generated identity back from an INSERT through the OUTPUT clause. [`#193`](https://github.com/nanodbc/nanodbc/issues/193)
 - Documented that a batch returns a result set per statement, counts included, and how to reach the rows. [`#247`](https://github.com/nanodbc/nanodbc/issues/247)

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1792,6 +1792,56 @@ TEST_CASE_METHOD(mssql_fixture, "test_async", "[mssql][async]")
 }
 #endif
 
+// A timestamp's fraction counts nanoseconds, while datetime2(7) resolves a hundred of
+// them, so the fraction bound has to be a multiple of 100. Asking for finer than the
+// column carries is refused rather than rounded.
+TEST_CASE_METHOD(mssql_fixture, "test_bind_timestamp_fraction", "[mssql][bind][timestamp]")
+{
+    auto connection = connect();
+    create_table(
+        connection,
+        NANODBC_TEXT("test_bind_timestamp_fraction"),
+        NANODBC_TEXT("(id int, t datetime2(7))"));
+
+    auto const bind_fraction = [&](std::int32_t fraction)
+    {
+        execute(connection, NANODBC_TEXT("delete from test_bind_timestamp_fraction;"));
+
+        nanodbc::timestamp stamp{};
+        stamp.year = 2020;
+        stamp.month = 9;
+        stamp.day = 3;
+        stamp.hour = 15;
+        stamp.min = 27;
+        stamp.sec = 38;
+        stamp.fract = fraction;
+
+        nanodbc::statement statement(connection);
+        statement.prepare(
+            NANODBC_TEXT("insert into test_bind_timestamp_fraction (id, t) values (1, ?);"));
+        statement.bind(0, &stamp);
+        statement.just_execute();
+    };
+
+    auto const stored_fraction = [&]()
+    {
+        auto results =
+            execute(connection, NANODBC_TEXT("select t from test_bind_timestamp_fraction;"));
+        REQUIRE(results.next());
+        return results.get<nanodbc::timestamp>(0).fract;
+    };
+
+    for (std::int32_t const fraction : {0, 100, 1000000, 123456700, 999999900})
+    {
+        bind_fraction(fraction);
+        REQUIRE(stored_fraction() == fraction);
+    }
+
+    // Finer than a hundred nanoseconds is more than the column holds.
+    REQUIRE_THROWS_AS(bind_fraction(1), nanodbc::database_error);
+    REQUIRE_THROWS_AS(bind_fraction(9999999), nanodbc::database_error);
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_bind_float", "[mssql][number][float]")
 {
     auto conn = connect();


### PR DESCRIPTION
Closes #4.

#4, from 2017, reported that binding a `nanodbc::timestamp` with a fractional second failed with `22008 Datetime field overflow. Fractional second precision exceeds the scale specified in the parameter binding`.

**Fractions bind correctly**, at the full precision the column carries. Against SQL Server 2025 with a `datetime2(7)`:

```
fract=0          ->  15:27:38.0000000
fract=100        ->  15:27:38.0000001
fract=1000000    ->  15:27:38.0010000
fract=123456700  ->  15:27:38.1234567
fract=999999900  ->  15:27:38.9999999
```

**The reporter's own value still throws, and should.** `nanodbc::timestamp::fract` counts **nanoseconds**, mirroring the ODBC `SQL_TIMESTAMP_STRUCT`, while `datetime2(7)` resolves to **100 nanoseconds**. So a fraction that is not a multiple of 100 asks for precision the column cannot hold:

```
fract=9999999  ->  22008   (the value from the issue)
fract=1        ->  22008
fract=99       ->  22008
```

That is the driver refusing to invent precision, not nanodbc truncating. It also explains the "if I bind tm.fract = 9999999 the library inserts 0090000" the reporter saw on an older driver — same mismatch, quietly mangled then rather than refused.

`test_bind_timestamp_fraction` pins both halves: the multiples of 100 that store exactly, and the finer ones that raise `database_error`. Having the refusal in the test matters as much as the successes, since that is the part which looks like a bug and is not.

## Testing

All five suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)