### PR TITLE
Test that the transaction isolation level holds for the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- A test covers the transaction isolation level set by a statement holding for the session, as it is the session's to hold. [`#10`](https://github.com/nanodbc/nanodbc/issues/10)
 - A floating point column read as text carries every digit needed to read back as the same value, where six decimals were rendered whatever the magnitude. [`#196`](https://github.com/nanodbc/nanodbc/issues/196)
 - A test covers binding a timestamp's fractional second, which counts nanoseconds and has to suit what the column resolves. [`#4`](https://github.com/nanodbc/nanodbc/issues/4)
 - A date or time parameter bound as text is declared as text, so the server reads it rather than the driver, which reads fewer spellings. [`#248`](https://github.com/nanodbc/nanodbc/issues/248)

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1685,6 +1685,42 @@ TEST_CASE_METHOD(mssql_fixture, "test_timestamp", "[mssql][rowversion][timestamp
     }
 }
 
+// The isolation level belongs to the session, so setting it with a statement holds for
+// the statements after it, and for a transaction opened later.
+TEST_CASE_METHOD(mssql_fixture, "test_transaction_isolation_level_persists", "[mssql][transaction]")
+{
+    auto connection = connect();
+
+    auto const level = [&]()
+    {
+        auto results = execute(
+            connection,
+            NANODBC_TEXT(
+                "select transaction_isolation_level from sys.dm_exec_sessions "
+                "where session_id = @@SPID;"));
+        REQUIRE(results.next());
+        return results.get<int>(0);
+    };
+
+    int const read_uncommitted = 1;
+    int const serializable = 4;
+
+    execute(connection, NANODBC_TEXT("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;"));
+    REQUIRE(level() == read_uncommitted);
+    // Each call above runs its own statement, so the level outlasts the one that set it.
+    REQUIRE(level() == read_uncommitted);
+
+    execute(connection, NANODBC_TEXT("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;"));
+    REQUIRE(level() == serializable);
+
+    {
+        nanodbc::transaction transaction(connection);
+        REQUIRE(level() == serializable);
+        transaction.commit();
+    }
+    REQUIRE(level() == serializable);
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_transaction", "[mssql][transaction]")
 {
     test_transaction();


### PR DESCRIPTION
Closes #10.

#10, from 2017, reported that `SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED` did not stick — the level read back as read committed. @mloskot reopened it saying it was worth investigating and covering with tests, and it stayed open since.

**It sticks.** Against SQL Server 2025:

```
before                     2   read committed
after the SET              1   read uncommitted
three statements later     1
after SET SERIALIZABLE     4
inside a transaction       4
after the transaction      4
```

The level belongs to the session, so it outlasts the statement that set it, the statements after it, and a transaction opened later. Each line above is a separate `execute` on the same connection, so nothing about nanodbc issuing a fresh statement loses it.

`test_transaction_isolation_level_persists` reads the level back through `sys.dm_exec_sessions` for the current `@@SPID`, which is the check the reporter described making, and asserts it after a plain statement, after a second statement, and either side of a transaction.

SQL Server only — `sys.dm_exec_sessions` and the numeric levels are its own.

I have not tried to establish what the reporter hit in 2017. It could have been driver-side connection pooling handing them a different physical session, which was @mloskot's guess at the time and would produce exactly this symptom, but that is speculation and the report has no reproducer attached to test it against.

## Testing

All five suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)