### PR TITLE
Test a batch delete whose first parameter set matches nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- A test covers a batch delete whose first parameter set matches nothing, which the drivers count differently and carry out alike. [`#168`](https://github.com/nanodbc/nanodbc/issues/168)
 - A floating point column read as text carries every digit needed to read back as the same value, where six decimals were rendered whatever the magnitude. [`#196`](https://github.com/nanodbc/nanodbc/issues/196)
 - A test covers binding a timestamp's fractional second, which counts nanoseconds and has to suit what the column resolves. [`#4`](https://github.com/nanodbc/nanodbc/issues/4)
 - A date or time parameter bound as text is declared as text, so the server reads it rather than the driver, which reads fewer spellings. [`#248`](https://github.com/nanodbc/nanodbc/issues/248)

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -221,6 +221,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_batch_insert_integral", "[mssql][batch][in
     test_batch_insert_integral();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_batch_delete", "[mssql][batch][delete]")
+{
+    test_batch_delete();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_batch_insert_null", "[mssql][batch][null]")
 {
     test_batch_insert_null();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -128,6 +128,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_batch_insert_integer", "[mysql][batch][int
     test_batch_insert_integral();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_batch_delete", "[mysql][batch][delete]")
+{
+    test_batch_delete();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_batch_insert_null", "[mysql][batch][null]")
 {
     test_batch_insert_null();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -74,6 +74,11 @@ TEST_CASE_METHOD(postgresql_fixture, "test_batch_insert_integer", "[postgresql][
     test_batch_insert_integral();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "test_batch_delete", "[postgresql][batch][delete]")
+{
+    test_batch_delete();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_batch_insert_null", "[postgresql][batch][null]")
 {
     test_batch_insert_null();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -114,6 +114,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_batch_insert_integral", "[sqlite][batch][
     test_batch_insert_integral();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_batch_delete", "[sqlite][batch][delete]")
+{
+    test_batch_delete();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_batch_insert_null", "[sqlite][batch][null]")
 {
     test_batch_insert_null();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -151,6 +151,36 @@ struct test_case_fixture : public base_test_fixture
         }
     }
 #endif
+    // A batch runs the statement once per parameter set, so the sets that match nothing
+    // are not errors and the ones that match are still carried out.
+    void test_batch_delete()
+    {
+        auto connection = connect();
+        create_table(connection, NANODBC_TEXT("test_batch_delete"), NANODBC_TEXT("(i int)"));
+        execute(
+            connection, NANODBC_TEXT("insert into test_batch_delete (i) values (1), (2), (3);"));
+
+        // The first set matches nothing, so a driver reporting only the first set's count
+        // reports zero for a batch that went on to delete two rows. How many rows
+        // affected_rows() answers with for a batch is the driver's to decide, and the
+        // drivers here disagree; what the batch did to the table is not.
+        int const keys[] = {40, 1, 2};
+        std::size_t const batch = 3;
+
+        nanodbc::statement statement(connection);
+        statement.prepare(NANODBC_TEXT("delete from test_batch_delete where i = ?;"));
+        statement.bind(0, keys, batch);
+        execute(statement, static_cast<long>(batch));
+
+        auto results = execute(connection, NANODBC_TEXT("select count(*) from test_batch_delete;"));
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 1);
+
+        auto remaining = execute(connection, NANODBC_TEXT("select i from test_batch_delete;"));
+        REQUIRE(remaining.next());
+        REQUIRE(remaining.get<int>(0) == 3);
+    }
+
     void test_batch_insert_mixed()
     {
         std::size_t const batch_size = 9;


### PR DESCRIPTION
Addresses the tasklist on #168. **Leaving that issue open** — the test covers what the drivers agree on, and the disagreement it exposed is a design question rather than something to assert.

#168 asked whether nanodbc conforms to what ODBC says about `SQLRowCount` after a batch, quoting a pgsql-odbc thread: for a `SQL_PARC_BATCH` driver you must call `SQLRowCount`/`SQLMoreResults` in a loop to get each count.

The batch coverage in the suite was all inserts, so a batch that deletes had none at all.

## What every driver agrees on

`test_batch_delete` deletes three keys of which **the first matches nothing**, then checks the table. All four carry the batch out correctly — the two matching sets delete their rows, and the set matching nothing is not an error, exactly as the quoted thread says it should not be.

## What they do not agree on

Reading `affected_rows()` after that same batch:

| driver | `SQL_PARAM_ARRAY_ROW_COUNTS` | `affected_rows()` | rows actually deleted |
|---|---|---|---|
| SQLite | unreported | 2 | 2 |
| MySQL | `SQL_PARC_NO_BATCH` | 2 | 2 |
| SQL Server | `SQL_PARC_BATCH` | 2 | 2 |
| **PostgreSQL** | `SQL_PARC_BATCH` | **0** | 2 |

PostgreSQL hands back the first parameter set's count alone, so a batch that deleted two rows reports zero. Ordering matters to the answer: with the matching key first, every driver returns 1 and the discrepancy hides.

`statement::affected_rows` is a single `SQLRowCount` call, so nanodbc does not do the loop the thread describes — and cannot straightforwardly, since consuming result sets to sum them would take them away from `next_result`.

So the answer to the question in the title is **no**, not for a `SQL_PARC_BATCH` driver. Making it conform needs either a separate accessor that does the loop, or a change to how results are consumed. That is a maintainer's decision, which is why this PR adds the test and not a fix, and why the test says nothing about the count.

There is precedent for the ambiguity in the suite already: `test_affected_rows` accepts 4, 0 or -1 for the same statement.

## Testing

All five suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)