### PR TITLE
Build the API reference with Doxygen and doxygen-awesome-css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ __pycache__/
 coverage.lcov
 coverage.profdata
 *.profraw
+
+# Compilation database, written by CMAKE_EXPORT_COMPILE_COMMANDS.
+compile_commands.json
+.compile_commands.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- The API reference is a Doxygen site themed with doxygen-awesome-css, with search and a navigation tree. [`#373`](https://github.com/nanodbc/nanodbc/issues/373)
+- Five functions returning nothing documented a return value, which Doxygen reported and Breathe did not.
 - A floating point column read as text carries every digit needed to read back as the same value, where six decimals were rendered whatever the magnitude. [`#196`](https://github.com/nanodbc/nanodbc/issues/196)
 - A test covers binding a timestamp's fractional second, which counts nanoseconds and has to suit what the column resolves. [`#4`](https://github.com/nanodbc/nanodbc/issues/4)
 - A date or time parameter bound as text is declared as text, so the server reads it rather than the driver, which reads fewer spellings. [`#248`](https://github.com/nanodbc/nanodbc/issues/248)

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -34,4 +34,5 @@ DISABLE_INDEX          = NO
 FULL_SIDEBAR           = NO
 HTML_COLORSTYLE        = LIGHT
 HTML_EXTRA_STYLESHEET  = doxygen-awesome-css/doxygen-awesome.css \
-                         doxygen-awesome-css/doxygen-awesome-sidebar-only.css
+                         doxygen-awesome-css/doxygen-awesome-sidebar-only.css \
+                         doxygen-extra.css

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1,0 +1,37 @@
+# Doxygen configuration for the nanodbc API reference.
+#
+# The reference is a Doxygen site of its own, themed with doxygen-awesome-css, and is
+# written into the Sphinx output under api/ so that both are published together. See
+# the doxygen target in the Makefile, which fetches the theme this expects.
+
+PROJECT_NAME           = nanodbc
+PROJECT_BRIEF          = "A small C++ wrapper for the native C ODBC API"
+
+INPUT                  = ../nanodbc/nanodbc.h
+OUTPUT_DIRECTORY       = build/html/api
+HTML_OUTPUT            = .
+GENERATE_LATEX         = NO
+
+# The library is documented in the header; the implementation is not part of the API.
+EXTRACT_ALL            = NO
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = NO
+HIDE_UNDOC_MEMBERS     = NO
+
+# Friend declarations name implementation classes and are not part of the API.
+HIDE_FRIEND_COMPOUNDS  = YES
+PREDEFINED             = DOXYGEN=1
+
+JAVADOC_AUTOBRIEF      = YES
+SORT_MEMBER_DOCS       = NO
+WARN_IF_UNDOCUMENTED   = NO
+QUIET                  = YES
+
+# doxygen-awesome-css. HTML_COLORSTYLE must be LIGHT for the theme to control the
+# palette itself; it carries its own dark mode.
+GENERATE_TREEVIEW      = YES
+DISABLE_INDEX          = NO
+FULL_SIDEBAR           = NO
+HTML_COLORSTYLE        = LIGHT
+HTML_EXTRA_STYLESHEET  = doxygen-awesome-css/doxygen-awesome.css \
+                         doxygen-awesome-css/doxygen-awesome-sidebar-only.css

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,7 +17,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 .PHONY: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  doxygen    to generate Doxygen XML files."
+	@echo "  doxygen    to generate the API reference into $(BUILDDIR)/html/api"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
@@ -48,18 +48,30 @@ help:
 .PHONY: clean
 clean:
 	rm -rf $(BUILDDIR)/*
-	rm -rf doxygen/xml*;
-	rm -rf doxygen/html*;
+	rm -rf doxygen-awesome-css
+
+# doxygen-awesome-css is fetched rather than vendored, at the tag the Doxyfile was
+# written against. Doxygen 1.9.1 or later is needed for the theme to render.
+AWESOME_VERSION = v2.4.2
+AWESOME_DIR     = doxygen-awesome-css
+
+$(AWESOME_DIR):
+	git clone --quiet --depth 1 --branch $(AWESOME_VERSION) \
+		https://github.com/jothepro/doxygen-awesome-css.git $(AWESOME_DIR)
 
 .PHONY: doxygen
-doxygen:
-	cd ../ ; doxygen docs/doxygen/doxygen.conf; cd docs
+doxygen: $(AWESOME_DIR)
+	mkdir -p $(BUILDDIR)/html/api
+	doxygen Doxyfile
 	@echo
-	@echo "Build finished. The Doxygen pages are in docs/doxygen/xml and docs/doxygen/html."
+	@echo "Build finished. The API reference is in $(BUILDDIR)/html/api."
 
+# The reference is built after Sphinx, which would otherwise empty the output it
+# lives in.
 .PHONY: html
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(MAKE) doxygen
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -8,6 +8,8 @@ nanodbc is a library offering the primary API in C++ language.
 
 All functions and classes provided by the nanodbc library reside in namespace ``nanodbc``, all macros have prefix ``NANODBC_``.
 
+The reference is generated from ``nanodbc.h`` by Doxygen and lives beside these pages.
 
-.. autodoxygenfile:: nanodbc.h
-   :project: nanodbc
+.. raw:: html
+
+   <p><a class="reference external" href="api/index.html">Browse the API reference</a></p>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ import subprocess
 
 # If your documentation needs a minimal Sphinx version, state it here.
 # requirements.txt pins nothing, so this is the floor the extensions themselves set:
-# Breathe requires 7.2 or later, sphinx_rtd_theme 6 or later.
+# sphinx_rtd_theme requires Sphinx 6 or later.
 needs_sphinx = "7.2"
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -35,23 +35,9 @@ needs_sphinx = "7.2"
 # ones.
 extensions = [
     "sphinx.ext.githubpages",
-    "breathe",
 ]
 
-# Breathe
-breathe_default_project = "nanodbc"
-breathe_domain_by_extension = {"h": "cpp"}
-
 doc_dir = os.path.dirname(os.path.realpath(__file__))
-src_dir = os.path.join(os.path.dirname(doc_dir), "nanodbc")
-breathe_projects_source = {"nanodbc": (src_dir, ["nanodbc.h"])}
-breathe_implementation_filename_extensions = [".cpp"]
-breathe_doxygen_config_options = {
-    "PREDEFINED": "DOXYGEN=1",
-    # Friend declarations name implementation classes and are not part of the API.
-    # Sphinx's C++ domain cannot parse them either, so leave them out of the XML.
-    "HIDE_FRIEND_COMPOUNDS": "YES",
-}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/doxygen-extra.css
+++ b/doc/doxygen-extra.css
@@ -1,0 +1,28 @@
+/* Styling for the nanodbc API reference, loaded after doxygen-awesome-css.
+   Colours come from the theme's custom properties so that light and dark both work. */
+
+/* The license and credits blocks in nanodbc.h name one copyright holder, host or licence
+   per line, and are hard wrapped to suit. Doxygen passes raw HTML through untouched, and
+   HTML collapses whitespace, so the block is a pre element to keep those line endings.
+   pre-wrap rather than pre so that a long line still wraps rather than scrolling. */
+pre.license {
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: inherit;
+    font-size: 0.9em;
+    line-height: 1.5;
+    color: var(--page-secondary-foreground-color, #4b5157);
+    background: none;
+    border: none;
+    border-left: 3px solid var(--separator-color, #dedede);
+    border-radius: 0;
+    padding: 0.4em 0 0.4em 1em;
+    margin: 0.75em 0;
+    overflow-x: auto;
+}
+
+/* Links in those blocks are hosts and addresses rather than prose, so they read better
+   without the weight the theme gives links in body text. */
+pre.license a {
+    font-weight: normal;
+}

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,2 @@
-breathe
 sphinx
 sphinx_rtd_theme

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1136,7 +1136,6 @@ public:
     /// \param batch_operations Rows to fetch per rowset, or number of batch parameters to process.
     /// \param timeout Seconds before query timeout. Default is 0 indicating no timeout.
     /// \throws database_error
-    /// \return A result set object.
     /// \attention You will want to use transactions if you are doing batch operations because it
     ///            will prevent auto commits after each individual operation is executed.
     /// \see open(), prepare(), execute(), execute_direct(), result, transaction
@@ -1160,7 +1159,6 @@ public:
     /// \param batch_operations Rows to fetch per rowset, or number of batch parameters to process.
     /// \param timeout The number in seconds before query timeout. Default 0 meaning no timeout.
     /// \throws database_error
-    /// \return A result set object.
     /// \attention You will want to use transactions if you are doing batch operations because it
     ///            will prevent auto commits after each individual operation is executed.
     /// \see open(), prepare(), execute(), result, transaction
@@ -2809,7 +2807,6 @@ result execute(connection& conn, string const& query, long batch_operations = 1,
 /// \param query The SQL query that will be executed.
 /// \param batch_operations Rows to fetch per rowset, or number of batch parameters to process.
 /// \param timeout The number in seconds before query timeout. Default is 0 indicating no timeout.
-/// \return A result set object.
 /// \attention You will want to use transactions if you are doing batch operations because it will
 ///            prevent auto commits from occurring after each individual operation is executed.
 /// \see open(), prepare(), execute(), result, transaction
@@ -2833,7 +2830,6 @@ result execute(statement& stmt, long batch_operations = 1);
 /// \param stmt The prepared statement that will be executed.
 /// \param batch_operations Rows to fetch per rowset, or the number of batch parameters to process.
 /// \throws database_error
-/// \return A result set object.
 /// \attention You will want to use transactions if you are doing batch operations because it will
 ///            prevent auto commits from occurring after each individual operation is executed.
 /// \see open(), prepare(), execute(), result
@@ -2855,7 +2851,6 @@ result transact(statement& stmt, long batch_operations);
 /// \param stmt The prepared statement that will be executed in batch.
 /// \param batch_operations Rows to fetch per rowset, or the number of batch parameters to process.
 /// \throws database_error
-/// \return A result set object.
 /// \see open(), prepare(), execute(), result, transaction
 void just_transact(statement& stmt, long batch_operations);
 

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -23,7 +23,7 @@
 ///     - \ref bind_strings
 ///
 /// \section license License
-/// <div class="license">
+/// <pre class="license">
 /// Copyright (C) lexicalunit <lexicalunit@lexicalunit.com>
 /// Copyright (C) Mateusz Loskot <mateusz@loskot.net>
 ///
@@ -46,10 +46,10 @@
 /// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 /// THE SOFTWARE.
-/// </div>
+/// </pre>
 ///
 /// \section credits Credits
-/// <div class="license">
+/// <pre class="license">
 /// Much of the code in this file was originally derived from TinyODBC.
 /// TinyODBC is hosted at http://code.google.com/p/tiodbc/
 /// Copyright (C) SqUe squarious@gmail.com
@@ -72,7 +72,7 @@
 /// Copyright (C) Nick E. Geht
 /// License: Perpetual license to reproduce, distribute, adapt, perform, display, and sublicense.
 /// See http://www.codeguru.com/submission-guidelines.php for details.
-/// </div>
+/// </pre>
 
 #ifndef NANODBC_NANODBC_H
 #define NANODBC_NANODBC_H


### PR DESCRIPTION
Closes #373.

#373 asked whether [hdoc.io](https://hdoc.io) could generate the API reference. **It cannot**, and neither can the other clang-based candidate. What the issue wanted underneath — a better looking reference — turns out not to need a new generator at all.

## Why not hdoc

- Last commit **2024-08-07**; last release **1.4.1, February 2023**.
- **No release assets** on GitHub. The README points at hdoc.io for binaries.
- The prebuilt binary needs **an account and an API key** (`HDOC_PROJECT_API_KEY`), which means a secret in CI for an open-source project.
- The README states the repository is "a subset of a private repository where hdoc's development takes place".
- Building 1.4.1 from source **fails against LLVM 18** — `ninja: build stopped: subcommand failed`, no binary produced. My build log was truncated by my own `tail`, so I have the failure but not the specific error, and I am not going to claim a cause I did not capture.

## Why not clang-doc

LLVM's own `clang-doc` is the closest thing to hdoc's premise and ships in Ubuntu's `clang-tools`. It runs, but:

```
markdown backend:  **brief** Represents a statement on the database.
html backend:      (nothing)
```

It parses nanodbc's comments correctly — the markdown output proves it — and **its HTML backend emits none of them**. Tried with `--doxygen`, `--public` and `--extra-arg=-fparse-all-comments`. So it produces a symbol index with signatures and line numbers, not documentation. It also documents `result_impl`, `connection_impl` and `transaction_impl`, having no notion of a public header.

## What this does instead

`doc/Doxyfile` builds `nanodbc.h` into `build/html/api`, themed with [doxygen-awesome-css](https://github.com/jothepro/doxygen-awesome-css) at **v2.4.2** — MIT, last released March 2026 — with search and a navigation tree. Doxygen itself had a commit yesterday.

The `Makefile` fetches the theme at that tag and runs Doxygen **after** Sphinx, which would otherwise empty the directory the reference lives in. `make html` still builds everything.

**Breathe is gone.** It existed to render Doxygen XML inside Sphinx, which is what the separate reference now does directly, and the narrative pages never needed it. `doc/api.rst` links to the reference rather than inlining it.

## Two things that fell out of it

**Five real documentation bugs.** Doxygen reported functions that document a return value and return nothing — `just_execute` twice, `just_execute_direct`, `just_transact`, and `statement::just_execute`. Breathe never surfaced these. The reference now builds with **zero warnings**.

**A `.gitignore` entry**, which is strictly unrelated and I am flagging rather than burying: `CMAKE_EXPORT_COMPILE_COMMANDS` writes a compilation database into the working tree containing absolute paths. I generated one while testing clang-doc and nearly left it behind. Say the word and I will split it out.

## Testing

`make html` built end to end in a clean Ubuntu 24.04 container the way the Documentation workflow does: 527 files, Sphinx pages plus the themed reference, the link from `api.html` resolving, and the theme stylesheets in place. Doxygen 1.9.8 there, within doxygen-awesome's supported 1.9.1–1.16.1 range. `rstcheck` run locally as the lint job does.

The workflow needs no change — it already installs Doxygen and runs `make html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)