### PR TITLE
Let a statement size its rowset apart from its parameter array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## Unreleased
+
+- `statement::execute` takes a `batch_ops`, so the rowset size and the parameter array length can differ. [`#162`](https://github.com/nanodbc/nanodbc/issues/162)
+
 ## v2.18.0
 
 - The API reference is a Doxygen site themed with doxygen-awesome-css, with search and a navigation tree. [`#373`](https://github.com/nanodbc/nanodbc/issues/373)

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2295,6 +2295,22 @@ public:
         return rc;
     }
 
+    result execute(batch_ops const& array_sizes, long timeout, statement& statement)
+    {
+        // A length that was never chosen is 1: one set of parameters, one row at a time.
+        long const parameter_sets =
+            array_sizes.parameter_array_length > 0 ? array_sizes.parameter_array_length : 1;
+        long const rows_per_fetch = array_sizes.rowset_size > 0 ? array_sizes.rowset_size : 1;
+#ifdef NANODBC_ENABLE_WORKAROUND_NODATA
+        const RETCODE rc = just_execute(parameter_sets, timeout, statement);
+        if (rc == SQL_NO_DATA)
+            return result();
+#else
+        just_execute(parameter_sets, timeout, statement);
+#endif
+        return {statement, rows_per_fetch};
+    }
+
     result execute(long batch_operations, long timeout, statement& statement)
     {
 #ifdef NANODBC_ENABLE_WORKAROUND_NODATA
@@ -6167,6 +6183,11 @@ result statement::execute_direct(
     long timeout)
 {
     return impl_->execute_direct(conn, query, array_sizes, timeout, *this);
+}
+
+result statement::execute(batch_ops const& array_sizes, long timeout)
+{
+    return impl_->execute(array_sizes, timeout, *this);
 }
 
 #if defined(NANODBC_DO_ASYNC_IMPL)

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1155,6 +1155,22 @@ public:
     /// \see open(), prepare(), result, transaction
     class result execute(long batch_operations = 1, long timeout = 0);
 
+    /// \brief Execute the previously prepared query now, sizing the parameter array and
+    ///        the rowset separately.
+    ///
+    /// The number of parameter sets to execute and the number of rows to fetch at a time
+    /// are unrelated: a query taking one set of parameters may still want its rows in
+    /// large blocks. The single argument overload sets both alike, which asks the driver
+    /// to read as many parameter sets as it was told to fetch rows.
+    ///
+    /// \param array_sizes Parameter array length and rowset size. A length of zero or less
+    ///                    leaves that one at 1.
+    /// \param timeout The number in seconds before query timeout. Default 0 meaning no timeout.
+    /// \throws database_error
+    /// \return A result set object.
+    /// \see open(), prepare(), result, transaction, batch_ops
+    class result execute(batch_ops const& array_sizes, long timeout = 0);
+
     /// \brief Execute the previously prepared query now without constructing result object.
     /// \param batch_operations Rows to fetch per rowset, or number of batch parameters to process.
     /// \param timeout The number in seconds before query timeout. Default 0 meaning no timeout.

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -221,6 +221,14 @@ TEST_CASE_METHOD(mssql_fixture, "test_batch_insert_integral", "[mssql][batch][in
     test_batch_insert_integral();
 }
 
+TEST_CASE_METHOD(
+    mssql_fixture,
+    "test_rowset_size_apart_from_parameter_sets",
+    "[mssql][result][rowset]")
+{
+    test_rowset_size_apart_from_parameter_sets();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_batch_delete", "[mssql][batch][delete]")
 {
     test_batch_delete();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -128,6 +128,14 @@ TEST_CASE_METHOD(mysql_fixture, "test_batch_insert_integer", "[mysql][batch][int
     test_batch_insert_integral();
 }
 
+TEST_CASE_METHOD(
+    mysql_fixture,
+    "test_rowset_size_apart_from_parameter_sets",
+    "[mysql][result][rowset]")
+{
+    test_rowset_size_apart_from_parameter_sets();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_batch_delete", "[mysql][batch][delete]")
 {
     test_batch_delete();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -74,6 +74,14 @@ TEST_CASE_METHOD(postgresql_fixture, "test_batch_insert_integer", "[postgresql][
     test_batch_insert_integral();
 }
 
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_rowset_size_apart_from_parameter_sets",
+    "[postgresql][result][rowset]")
+{
+    test_rowset_size_apart_from_parameter_sets();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_batch_delete", "[postgresql][batch][delete]")
 {
     test_batch_delete();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -114,6 +114,14 @@ TEST_CASE_METHOD(sqlite_fixture, "test_batch_insert_integral", "[sqlite][batch][
     test_batch_insert_integral();
 }
 
+TEST_CASE_METHOD(
+    sqlite_fixture,
+    "test_rowset_size_apart_from_parameter_sets",
+    "[sqlite][result][rowset]")
+{
+    test_rowset_size_apart_from_parameter_sets();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_batch_delete", "[sqlite][batch][delete]")
 {
     test_batch_delete();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -151,6 +151,48 @@ struct test_case_fixture : public base_test_fixture
         }
     }
 #endif
+    // How many parameter sets a statement executes and how many rows it fetches at a time
+    // are unrelated. A query taking one set of parameters may still want its rows in large
+    // blocks, which asking for both with one number cannot express.
+    void test_rowset_size_apart_from_parameter_sets()
+    {
+        auto connection = connect();
+        create_table(
+            connection,
+            NANODBC_TEXT("test_rowset_size_apart_from_parameter_sets"),
+            NANODBC_TEXT("(i int)"));
+        for (int i = 0; i < 20; ++i)
+        {
+            execute(
+                connection,
+                NANODBC_TEXT(
+                    "insert into test_rowset_size_apart_from_parameter_sets (i) "
+                    "values (") +
+                    nanodbc::string(1, static_cast<nanodbc::string::value_type>('0' + i / 10)) +
+                    nanodbc::string(1, static_cast<nanodbc::string::value_type>('0' + i % 10)) +
+                    NANODBC_TEXT(");"));
+        }
+
+        int const threshold = 5;
+        nanodbc::statement statement(connection);
+        statement.prepare(NANODBC_TEXT(
+            "select i from test_rowset_size_apart_from_parameter_sets "
+            "where i >= ? order by i;"));
+        statement.bind(0, &threshold);
+
+        nanodbc::batch_ops array_sizes;
+        array_sizes.parameter_array_length = 1;
+        array_sizes.rowset_size = 10;
+
+        auto results = statement.execute(array_sizes);
+        REQUIRE(results.rowset_size() == 10);
+
+        int rows = 0;
+        while (results.next())
+            ++rows;
+        REQUIRE(rows == 15);
+    }
+
     // A batch runs the statement once per parameter set, so the sets that match nothing
     // are not errors and the ones that match are still carried out.
     void test_batch_delete()


### PR DESCRIPTION
Closes #162. **This adds public API**, so it wants a considered look.

#162 asked whether it is right that `batch_operations` sets both `SQL_ATTR_PARAMSET_SIZE` and `SQL_ATTR_ROW_ARRAY_SIZE`. It is not — the two are unrelated in ODBC, and a query taking one set of parameters may still want its rows in large blocks. Three people have run into it, the last calling it "a fundamental blocker when moving large quantities of data", and one describing "undefined behavior akin to reading from uninitialized memory".

That description is accurate. Asking for a rowset of 100 tells the driver there are 100 parameter sets; where the caller bound one, the driver reads the other 99 from past the end of the buffer.

## Reproduced

```
prepare + bind + execute(100)                 -> threw
execute_direct with batch_ops{1, 100}         -> 500 rows, rowset_size=100
prepare + bind + execute(batch_ops{1, 100})   -> 400 rows, rowset_size=100   (this PR)
```

The middle line is why this is a small change: **`batch_ops` already carries the two lengths separately, and `execute_direct` already takes one.** What was missing is that `execute` did not, so a prepared statement with bound parameters — the case the issue is about — could not reach it.

## The change

`statement::execute(batch_ops const&, long timeout = 0)`, mirroring the `execute_direct` overload beside it. It passes `parameter_array_length` to `just_execute` and hands `rowset_size` to the result. A length of zero or less leaves that one at 1, so a default-constructed `batch_ops` behaves as a plain execute rather than setting an array size of -1.

Nothing existing changes: the `long` overload still sets both alike, which is right for the batch-insert case it was written for.

`test_rowset_size_apart_from_parameter_sets` binds one parameter, asks for a rowset of 10, and reads 15 rows, on SQLite, MySQL, PostgreSQL and SQL Server.

## Testing

All five suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)