### PR TITLE
Revert the date and time text binding, and run the suite against Oracle

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -354,6 +354,59 @@ jobs:
           export NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL ANSI};Server=localhost;Port=5432;Database=nanodbc;UID=postgres;PWD=postgres"
           ctest --test-dir ${GITHUB_WORKSPACE}/build --output-on-failure --no-tests=error -R postgresql_tests
 
+  test-oracle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    services:
+      oracle:
+        image: container-registry.oracle.com/database/free:latest
+        ports:
+          - 1521:1521
+        env:
+          ORACLE_PWD: nanodbc
+        options: >-
+          --health-cmd "grep -q 'DATABASE IS READY TO USE' /opt/oracle/diag/rdbms/*/*/trace/alert*.log"
+          --health-interval 15s
+          --health-timeout 10s
+          --health-retries 60
+          --health-start-period 300s
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install
+        run: |
+          apt-get -o DPkg::Lock::Timeout=120 update
+          apt-get -o DPkg::Lock::Timeout=120 install -y ccache unixodbc-dev unzip libaio1t64
+        shell: sudo bash {0}
+      - name: Install Oracle Instant Client
+        # Instant Client is published for x86_64 only, which the runners are. The driver
+        # asks for libaio.so.1, which Ubuntu ships as libaio.so.1t64.
+        run: |
+          curl -fsSL -o /tmp/ic-basic.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+          curl -fsSL -o /tmp/ic-odbc.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-odbc-linuxx64.zip
+          sudo unzip -oq /tmp/ic-basic.zip -d /opt/oracle
+          sudo unzip -oq /tmp/ic-odbc.zip -d /opt/oracle
+          ic=$(ls -d /opt/oracle/instantclient_*)
+          sudo ln -sf /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
+          echo "${ic}" | sudo tee /etc/ld.so.conf.d/oracle-instantclient.conf
+          sudo ldconfig
+          printf '[Oracle]\nDescription=Oracle Instant Client ODBC\nDriver=%s/libsqora.so.23.1\n' "${ic}" | sudo odbcinst -i -d -r
+      - name: Restore compiled objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.ccache
+          key: ccache-oracle-${{ github.sha }}
+          restore-keys: ccache-oracle-
+      - name: Configure
+        run: |
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+      - name: Build
+        run: |
+          cmake --build ${GITHUB_WORKSPACE}/build --parallel --target oracle_tests
+      - name: Test
+        run: |
+          export NANODBC_TEST_CONNSTR_ORACLE="Driver={Oracle};DBQ=localhost:1521/FREEPDB1;UID=system;PWD=nanodbc;"
+          ctest --test-dir ${GITHUB_WORKSPACE}/build --output-on-failure --no-tests=error -R oracle_tests
+
   test-mssql:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -377,7 +377,7 @@ jobs:
       - name: Install
         run: |
           apt-get -o DPkg::Lock::Timeout=120 update
-          apt-get -o DPkg::Lock::Timeout=120 install -y ccache unixodbc-dev unzip libaio1t64
+          apt-get -o DPkg::Lock::Timeout=120 install -y ccache unixodbc unixodbc-dev odbcinst unzip libaio1t64
         shell: sudo bash {0}
       - name: Install Oracle Instant Client
         # Instant Client is published for x86_64 only, which the runners are. The driver

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -364,12 +364,14 @@ jobs:
           - 1521:1521
         env:
           ORACLE_PWD: nanodbc
+        # The image carries its own health check, which runs the database's own status
+        # script. Only the timing is set here: opening takes several minutes on a runner,
+        # and a check of its own would have to guess at what ready looks like.
         options: >-
-          --health-cmd "grep -q 'DATABASE IS READY TO USE' /opt/oracle/diag/rdbms/*/*/trace/alert*.log"
-          --health-interval 15s
-          --health-timeout 10s
-          --health-retries 60
-          --health-start-period 300s
+          --health-interval 30s
+          --health-timeout 30s
+          --health-retries 40
+          --health-start-period 600s
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- A date or time parameter bound as text is declared as the driver describes it, Oracle refusing the ODBC literal form when it is declared as text. [`#248`](https://github.com/nanodbc/nanodbc/issues/248)
 - `statement::execute` takes a `batch_ops`, so the rowset size and the parameter array length can differ. [`#162`](https://github.com/nanodbc/nanodbc/issues/162)
 - Documented that how far a batch of parameters carries is the driver's to decide, with measurements. [`#241`](https://github.com/nanodbc/nanodbc/issues/241)
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -54,6 +54,27 @@ RUN curl -sSL -o /tmp/packages-microsoft-prod.deb "https://packages.microsoft.co
     && odbcinst -i -d -f /usr/share/sqliteodbc/unixodbc.ini \
     && printf '[nanodbc_dsn]\nDriver=SQLite3\nDatabase=/tmp/nanodbc_dsn.db\n' > /etc/odbc.ini
 
+# Oracle Instant Client, published for x86_64 only, so the driver is registered only
+# where it can load. The driver asks for libaio.so.1, which Ubuntu 24.04 ships as
+# libaio.so.1t64.
+RUN arch="$(uname -m)" \
+    && if [ "${arch}" = "x86_64" ]; then \
+    apt-get -qy update \
+    && apt-get -qy install --no-upgrade --no-install-recommends libaio1t64 unzip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL -o /tmp/ic-basic.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip \
+    && curl -fsSL -o /tmp/ic-odbc.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-odbc-linuxx64.zip \
+    && unzip -oq /tmp/ic-basic.zip -d /opt/oracle \
+    && unzip -oq /tmp/ic-odbc.zip -d /opt/oracle \
+    && rm /tmp/ic-basic.zip /tmp/ic-odbc.zip \
+    && ic="$(ls -d /opt/oracle/instantclient_*)" \
+    && ln -sf /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1 \
+    && echo "${ic}" > /etc/ld.so.conf.d/oracle-instantclient.conf \
+    && ldconfig \
+    && printf '[Oracle]\nDescription=Oracle Instant Client ODBC\nDriver=%s/libsqora.so.23.1\n' "${ic}" \
+    | odbcinst -i -d -r \
+    ; else echo "Instant Client is x86_64 only; skipping on ${arch}"; fi
+
 # MySQL names the x86_64 build x86-64bit and the arm64 one aarch64.
 RUN arch="$(uname -m)" \
     && if [ "${arch}" = "x86_64" ]; then arch="x86-64bit"; fi \

--- a/doc/use.rst
+++ b/doc/use.rst
@@ -117,9 +117,9 @@ On SQL Server, ``SET NOCOUNT ON`` withholds the counts instead, leaving the rows
 Dates and times as strings
 ******************************************************************************
 
-A string bound to a date, time or timestamp parameter is declared to the driver as text, so the server reads it rather than the driver does. Drivers accept little beyond the literals ODBC spells out — ``yyyy-mm-dd``, ``hh:mm:ss`` and ``yyyy-mm-dd hh:mm:ss[.f...]``, a space between date and time and no time zone offset — while servers read a good deal more, ISO 8601 among it. Both ``2020-09-03 15:27:38`` and ``2020-09-03T15:27:38`` therefore store the time, and a time zone offset is applied or ignored according to the type of the column it lands in.
+A string bound to a date, time or timestamp parameter is read by the driver, which accepts the literals ODBC spells out and little else: ``yyyy-mm-dd``, ``hh:mm:ss`` and ``yyyy-mm-dd hh:mm:ss[.f...]``, a space between date and time and no time zone offset. That form is the portable one and every driver here stores it correctly.
 
-What a server accepts remains the server's business. SQL Server rejects an offset on a ``datetime`` column, and says so.
+ISO 8601 looks close enough to pass and is not. Given ``2020-09-03T15:27:38-02:00``, the PostgreSQL driver stores ``2020-09-03 00:00:00`` and reports success, the ``T`` having stopped it reading the time, with nothing in the return code or the diagnostics to say so. SQL Server refuses the same value outright. Writing it as ``2020-09-03 15:27:38`` stores the time on both.
 
 Binding a ``nanodbc::timestamp`` avoids the question, since it carries its fields rather than a spelling of them.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,23 @@ services:
       retries: 30
       start_period: 60s
 
+  oracle:
+    image: container-registry.oracle.com/database/free:${ORACLE_VERSION:-latest}
+    container_name: nanooracle
+    restart: unless-stopped
+    # Instant Client is published for x86_64 only.
+    platform: linux/amd64
+    ports:
+      - "1521:1521"
+    environment:
+      ORACLE_PWD: *default_credential
+    healthcheck:
+      test: ["CMD-SHELL", "grep -q 'DATABASE IS READY TO USE' /opt/oracle/diag/rdbms/*/*/trace/alert*.log 2>/dev/null || healthcheck.sh"]
+      interval: 15s
+      timeout: 10s
+      retries: 40
+      start_period: 300s
+
   nanodbc:
     build:
       context: .
@@ -114,6 +131,10 @@ services:
         condition: service_healthy
       mssql:
         condition: service_healthy
+    # Oracle is deliberately not depended on: it takes minutes to open and its driver is
+    # published for x86_64 only, so waiting for it would cost every run on every host to
+    # serve the one suite that cannot run on some of them. Start it when it is wanted,
+    # with docker compose up -d oracle.
 
     volumes:
       - .:/opt/nanodbc
@@ -134,3 +155,4 @@ services:
       NANODBC_TEST_CONNSTR_MYSQL: "Driver={MySQL ODBC 8.4 ANSI Driver};Server=mysql;Database=nanodbc;User=root;Password=nanodbc;big_packets=1;"
       NANODBC_TEST_CONNSTR_MARIADB: "Driver={MariaDB Unicode};Server=mariadb;Port=3306;Database=nanodbc;User=root;Password=nanodbc;"
       NANODBC_TEST_CONNSTR_MSSQL: "Driver={ODBC Driver 18 for SQL Server};Server=mssql;Database=master;UID=sa;PWD=Password12!;TrustServerCertificate=yes;"
+      NANODBC_TEST_CONNSTR_ORACLE: "Driver={Oracle};DBQ=oracle:1521/FREEPDB1;UID=system;PWD=nanodbc;"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,12 +108,13 @@ services:
       - "1521:1521"
     environment:
       ORACLE_PWD: *default_credential
+    # The image carries its own health check, which runs the database's own status
+    # script, so only the timing is set here.
     healthcheck:
-      test: ["CMD-SHELL", "grep -q 'DATABASE IS READY TO USE' /opt/oracle/diag/rdbms/*/*/trace/alert*.log 2>/dev/null || healthcheck.sh"]
-      interval: 15s
-      timeout: 10s
+      interval: 30s
+      timeout: 30s
       retries: 40
-      start_period: 300s
+      start_period: 600s
 
   nanodbc:
     build:

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -5473,7 +5473,7 @@ auto from_string(std::string const& s, unsigned long long)
 // answer should not turn on which of the two a driver chose.
 inline auto from_string(std::string const& s, bool)
 {
-    return from_string(s, (long long){}) != 0;
+    return from_string(s, static_cast<long long>(0)) != 0;
 }
 
 template <typename R, typename std::enable_if<std::is_integral<R>::value, int>::type = 0>

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -942,6 +942,7 @@ public:
         , cbdata_(nullptr)
         , pdata_(nullptr)
         , bound_(false)
+        , cached_(false)
     {
     }
 
@@ -952,6 +953,8 @@ public:
     {
         for (std::size_t i = 0; i < count; ++i)
             cbdata_[i] = 0;
+        cache_.clear();
+        cached_ = false;
     }
 
 public:
@@ -966,6 +969,10 @@ public:
     std::unique_ptr<nanodbc::null_type[]> cbdata_;
     std::unique_ptr<char[]> pdata_;
     bool bound_;
+    // An unbound column read ahead of time, because asking whether it is null costs the
+    // only reading of it there is. Emptied when the row moves.
+    std::vector<std::uint8_t> cache_;
+    bool cached_;
 };
 
 // Renders value as decimal digits, zero padded to at least width, keeping a minus sign in
@@ -3950,31 +3957,65 @@ public:
         if (rowset_position_ >= rows())
             throw index_range_error();
 
-        // An unbound column carries no indicator from the fetch, so ask the driver. Only
-        // binary can be asked: a zero buffer length reports the length and moves no data.
-        // The others cannot, and report what the fetch knew.
-        if (!col.bound_ && col.ctype_ == SQL_C_BINARY)
+        // An unbound column carries no indicator from the fetch, so the driver has to be
+        // asked. Asking costs the only reading of the column there is: a driver hands
+        // over a character or binary value once, and a zero length SQLGetData counts as
+        // part of that handing over on some of them, Oracle's among them, which then
+        // returns the rest of the value to whoever reads next. So the value is read here
+        // in full and kept for that reader.
+        if (!col.bound_ && col.ctype_ == SQL_C_BINARY && !col.cached_)
+            read_binary_into_cache(column);
+
+        return col.cbdata_[static_cast<size_t>(rowset_position_)] == SQL_NULL_DATA;
+    }
+
+    // Reads an unbound binary column in full, recording its length as the indicator the
+    // fetch did not leave. A driver that declines leaves the question to what the fetch
+    // knew, and nothing is cached.
+    void read_binary_into_cache(short column) const
+    {
+        bound_column& col = bound_columns_[column];
+        std::vector<std::uint8_t> out;
+        std::uint8_t buffer[1024];
+        SQLLEN indicator = 0;
+        RETCODE rc = SQL_SUCCESS;
+        bool answered = false;
+
+        do
         {
-            SQLCHAR unused = 0;
-            constexpr SQLLEN buffer_length = 0;
-            SQLLEN indicator = 0;
-            RETCODE rc = SQL_SUCCESS;
             NANODBC_CALL_RC(
                 SQLGetData,
                 rc,
                 stmt_.native_statement_handle(),       // StatementHandle
                 static_cast<SQLUSMALLINT>(column + 1), // Col_or_Param_Num
-                col.ctype_,                            // TargetType
-                &unused,                               // TargetValuePtr
-                buffer_length,                         // BufferLength
+                SQL_C_BINARY,                          // TargetType
+                buffer,                                // TargetValuePtr
+                sizeof(buffer),                        // BufferLength
                 &indicator);                           // StrLen_or_IndPtr
-            // A driver that declines leaves the question to what the fetch knew.
-            if (rc == SQL_SUCCESS || rc == SQL_SUCCESS_WITH_INFO)
-                col.cbdata_[static_cast<size_t>(rowset_position_)] =
-                    static_cast<null_type>(indicator);
-        }
+            if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO)
+                break;
+            answered = true;
+            if (indicator == SQL_NULL_DATA)
+            {
+                col.cbdata_[static_cast<std::size_t>(rowset_position_)] =
+                    static_cast<null_type>(SQL_NULL_DATA);
+                col.cached_ = true;
+                return;
+            }
+            auto const filled =
+                indicator == SQL_NO_TOTAL
+                    ? sizeof(buffer)
+                    : std::min<std::size_t>(static_cast<std::size_t>(indicator), sizeof(buffer));
+            out.insert(out.end(), buffer, buffer + filled);
+        } while (rc == SQL_SUCCESS_WITH_INFO);
 
-        return col.cbdata_[static_cast<size_t>(rowset_position_)] == SQL_NULL_DATA;
+        if (!answered)
+            return;
+
+        col.cbdata_[static_cast<std::size_t>(rowset_position_)] =
+            static_cast<null_type>(out.size());
+        col.cache_ = std::move(out);
+        col.cached_ = true;
     }
 
     bool is_null(string const& column_name) const
@@ -4854,6 +4895,18 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         if (!is_bound(column) ||
             (bound_column_was_truncated(column) && supports_get_data_on_bound_column()))
         {
+            // A binary column read to answer whether it was null was read in full, the
+            // driver handing such a value over once, so the answer is served from what
+            // that read kept rather than asked for again.
+            if (col.cached_)
+            {
+                convert(
+                    std::string(
+                        reinterpret_cast<char const*>(col.cache_.data()), col.cache_.size()),
+                    result);
+                return;
+            }
+
             // Input is always std::string, while output may be std::string or wide_string
             std::string out;
             // Data still available, which shrinks with each SQLGetData; not the amount
@@ -5123,6 +5176,14 @@ inline void result::result_impl::get_ref_impl<std::vector<std::uint8_t>>(
     {
         if (!is_bound(column))
         {
+            // Asking whether the column was null had to read it, the driver handing a
+            // binary value over once, so the answer is served from what that read kept.
+            if (col.cached_)
+            {
+                result = col.cache_;
+                return;
+            }
+
             // Input and output is always array of bytes.
             std::vector<std::uint8_t> out;
             std::uint8_t buffer[1024] = {0};

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -5515,6 +5515,12 @@ void result::result_impl::get_ref_from_string_column(short column, T& result) co
         throw type_incompatible_error();
     std::string str;
     get_ref_impl(col.column_, str);
+    // An unbound column reports null only once the read has happened, and a null leaves
+    // nothing to convert: from_string would raise out of the standard library rather than
+    // the fallback being handed back. The caller tests for the null again after this
+    // returns.
+    if (is_null(column))
+        return;
     result = from_string<T>(str);
 }
 

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -5030,9 +5030,14 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         return;
     }
 
+    // A bit is 0 or 1 by definition, whatever a driver puts in the byte. Oracle's writes
+    // the character rather than the value, and 49 is not what was stored.
+    case SQL_C_BIT:
+        convert(std::string(*ensure_pdata<int8_t>(column) != 0 ? "1" : "0"), result);
+        return;
+
     // std::to_string renders each as the SQL type demands: "%d" and "%lld" for integers,
     // "%f" for floating point, whose column scale is undefined.
-    case SQL_C_BIT:
     case SQL_C_TINYINT:
     case SQL_C_STINYINT:
         convert(std::to_string(*ensure_pdata<int8_t>(column)), result);
@@ -5463,6 +5468,14 @@ auto from_string(std::string const& s, unsigned long long)
     return std::stoull(s);
 }
 
+// A bool is tested rather than narrowed. Reading 42 as a bool is true, which is what it
+// is where the driver hands the value over as a number rather than as text, and the
+// answer should not turn on which of the two a driver chose.
+inline auto from_string(std::string const& s, bool)
+{
+    return from_string(s, (long long){}) != 0;
+}
+
 template <typename R, typename std::enable_if<std::is_integral<R>::value, int>::type = 0>
 auto from_string(std::string const& s, R)
 {
@@ -5569,7 +5582,9 @@ void result::result_impl::get_ref_impl(short column, T& result) const
     switch (col.ctype_)
     {
     case SQL_C_BIT:
-        result = (T) * (ensure_pdata<int8_t>(column));
+        // A bit is 0 or 1 by definition. A driver writing the character '1' into the byte,
+        // as Oracle's does, means what it stored rather than 49.
+        result = static_cast<T>(*ensure_pdata<int8_t>(column) != 0 ? 1 : 0);
         return;
     case SQL_C_CHAR:
     case SQL_C_WCHAR:

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2491,29 +2491,6 @@ public:
         return static_cast<short>(param_type);
     }
 
-    // Whether a parameter takes a date, a time, or both.
-    static bool is_datetime_param_type(SQLSMALLINT type) noexcept
-    {
-        switch (type)
-        {
-        case SQL_DATE:
-        case SQL_TYPE_DATE:
-        case SQL_TIME:
-        case SQL_TYPE_TIME:
-        case SQL_TIMESTAMP:
-        case SQL_TYPE_TIMESTAMP:
-#ifdef SQL_SS_TIME2
-        case SQL_SS_TIME2:
-#endif
-#ifdef SQL_SS_TIMESTAMPOFFSET
-        case SQL_SS_TIMESTAMPOFFSET:
-#endif
-            return true;
-        default:
-            return false;
-        }
-    }
-
     static SQLSMALLINT param_type_from_direction(param_direction direction)
     {
         switch (direction)
@@ -2640,20 +2617,6 @@ public:
         if (buffer_size == 0)
             buffer_size = (std::char_traits<T>::length(buffer.values_) + 1) * sizeof(T);
 
-        // A date or time parameter given text is declared as text, which leaves the
-        // server to read the value rather than the driver. Drivers read a narrower set of
-        // spellings than the servers they speak to, and report success whether or not
-        // they read all of what they were given.
-        auto parameter_type = param.type_;
-        auto parameter_size = param.size_;
-        auto parameter_scale = param.scale_;
-        if (is_datetime_param_type(parameter_type))
-        {
-            parameter_type = SQL_VARCHAR;
-            parameter_size = buffer_size / sizeof(T);
-            parameter_scale = 0;
-        }
-
         RETCODE rc = SQL_SUCCESS;
         NANODBC_CALL_RC(
             SQLBindParameter,
@@ -2662,9 +2625,9 @@ public:
             param.index_ + 1, // parameter number
             param.iotype_,    // input or output type
             buffer.ctype_,    // value type
-            parameter_type,   // parameter type
-            parameter_size,   // column size ignored for many types, but needed for strings
-            parameter_scale,  // decimal digits
+            param.type_,      // parameter type
+            param.size_,      // column size ignored for many types, but needed for strings
+            param.scale_,     // decimal digits
             (SQLPOINTER)buffer.values_, // parameter value
             buffer_size,                // buffer length
             bind_len_or_null_[param.index_].data());

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3976,7 +3976,7 @@ public:
     {
         bound_column& col = bound_columns_[column];
         std::vector<std::uint8_t> out;
-        std::uint8_t buffer[1024];
+        std::uint8_t buffer[1024] = {0};
         SQLLEN indicator = 0;
         RETCODE rc = SQL_SUCCESS;
         bool answered = false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@ target_compile_features(utility_tests PRIVATE cxx_std_14)
 add_test(NAME utility_tests COMMAND utility_tests)
 add_dependencies(tests utility_tests)
 
-set(test_list mssql mysql postgresql sqlite vertica)
+set(test_list mssql mysql oracle postgresql sqlite vertica)
 
 foreach(test_item IN LISTS test_list)
   if (DEFINED ENV{CI} AND DEFINED ENV{DB})

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -319,8 +319,12 @@ struct base_test_fixture
             return NANODBC_TEXT("blob") + s;
         case database_vendor::postgresql:
             return NANODBC_TEXT("bytea");
+        case database_vendor::oracle:
+            // Oracle spells a bounded binary raw, which holds 2000 bytes at most, and
+            // anything longer than that a blob.
+            return size > 0 && size <= 2000 ? NANODBC_TEXT("raw") + s : NANODBC_TEXT("blob");
         default:
-            return NANODBC_TEXT("varbinary") + s; // Oracle, MySQL, SQL Server,...standard type?
+            return NANODBC_TEXT("varbinary") + s;
         }
     }
 
@@ -332,6 +336,18 @@ struct base_test_fixture
             return NANODBC_TEXT("bit");
         default:
             return NANODBC_TEXT("boolean");
+        }
+    }
+
+    // Oracle has no bigint; its numbers carry a precision instead.
+    nanodbc::string get_bigint_type_name()
+    {
+        switch (vendor_)
+        {
+        case database_vendor::oracle:
+            return NANODBC_TEXT("number(19)");
+        default:
+            return NANODBC_TEXT("bigint");
         }
     }
 
@@ -353,8 +369,11 @@ struct base_test_fixture
         {
         case database_vendor::vertica:
             return NANODBC_TEXT("long varchar");
+        case database_vendor::oracle:
+            // Oracle has no text; a character column with no bound is a clob.
+            return NANODBC_TEXT("clob");
         default:
-            return NANODBC_TEXT("text"); // Oracle, MySQL, SQL Server,...standard type?
+            return NANODBC_TEXT("text");
         }
     }
 
@@ -371,10 +390,35 @@ struct base_test_fixture
         case database_vendor::mysql:
             return NANODBC_TEXT("group_concat(") + column + NANODBC_TEXT(" separator '") +
                    separator + NANODBC_TEXT("')");
+        case database_vendor::oracle:
+            // Oracle spells it listagg, and wants the order stated.
+            return NANODBC_TEXT("listagg(") + column + NANODBC_TEXT(", '") + separator +
+                   NANODBC_TEXT("') within group (order by ") + column + NANODBC_TEXT(")");
         default:
             return NANODBC_TEXT("string_agg(") + column + NANODBC_TEXT(", '") + separator +
                    NANODBC_TEXT("')");
         }
+    }
+
+    // An unquoted identifier folds to upper case on Oracle, which is what the standard
+    // asks for, so a name written lower case in a query comes back upper case from the
+    // catalog and has to be looked up that way.
+    nanodbc::string as_identifier(nanodbc::string const& name) const
+    {
+        if (vendor_ != database_vendor::oracle)
+            return name;
+
+        nanodbc::string folded;
+        folded.reserve(name.size());
+        for (auto const c : name)
+        {
+            folded.push_back(
+                c >= static_cast<nanodbc::string::value_type>('a') &&
+                        c <= static_cast<nanodbc::string::value_type>('z')
+                    ? static_cast<nanodbc::string::value_type>(c - ('a' - 'A'))
+                    : c);
+        }
+        return folded;
     }
 
     nanodbc::string get_primary_key_name(nanodbc::string const& assumed)

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -331,14 +331,6 @@ TEST_CASE_METHOD(mssql_fixture, "test_insert_output_identity", "[mssql][result][
 
 TEST_CASE_METHOD(
     mssql_fixture,
-    "test_bind_iso8601_timestamp_as_string",
-    "[mssql][statement][bind][timestamp]")
-{
-    test_bind_iso8601_timestamp_as_string();
-}
-
-TEST_CASE_METHOD(
-    mssql_fixture,
     "test_bind_timestamp_as_string",
     "[mssql][statement][bind][timestamp]")
 {

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -163,14 +163,6 @@ TEST_CASE_METHOD(mysql_fixture, "test_std_optional", "[mysql][optional]")
 
 TEST_CASE_METHOD(
     mysql_fixture,
-    "test_bind_iso8601_timestamp_as_string",
-    "[mysql][statement][bind][timestamp]")
-{
-    test_bind_iso8601_timestamp_as_string();
-}
-
-TEST_CASE_METHOD(
-    mysql_fixture,
     "test_bind_timestamp_as_string",
     "[mysql][statement][bind][timestamp]")
 {

--- a/test/oracle_test.cpp
+++ b/test/oracle_test.cpp
@@ -1,0 +1,378 @@
+#include "test_case_fixture.h"
+
+namespace
+{
+struct oracle_fixture : public test_case_fixture
+{
+    oracle_fixture()
+        : test_case_fixture()
+    {
+        // connection string from command line or NANODBC_TEST_CONNSTR environment variable
+        if (connection_string_.empty())
+            connection_string_ = get_env("NANODBC_TEST_CONNSTR_ORACLE");
+    }
+};
+} // namespace
+
+// Oracle has no TIME type, only DATE and TIMESTAMP, so test_time has nothing to create a
+// column with here and is left out rather than made to pass against a different type.
+
+TEST_CASE_METHOD(oracle_fixture, "test_batch_binary", "[oracle][binary]")
+{
+    test_batch_binary();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_batch_delete", "[oracle][batch][delete]")
+{
+    test_batch_delete();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_batch_insert_mixed", "[oracle][batch]")
+{
+    test_batch_insert_mixed();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_batch_insert_null", "[oracle][batch][null]")
+{
+    test_batch_insert_null();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_batch_insert_string", "[oracle][batch][string]")
+{
+    test_batch_insert_string();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_binary_read_shapes", "[oracle][result][binary]")
+{
+    test_binary_read_shapes();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_bind_arithmetic_null_sentry", "[oracle][bind][null]")
+{
+    test_bind_arithmetic_null_sentry();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_bind_binary_null_sentry", "[oracle][binary][null]")
+{
+    test_bind_binary_null_sentry();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_bind_date_to_timestamp_parameter", "[oracle][bind][date]")
+{
+    test_bind_date_to_timestamp_parameter();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_bind_every_form", "[oracle][bind][batch]")
+{
+    test_bind_every_form();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_bind_null_array", "[oracle][null]")
+{
+    test_bind_null_array();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_bind_null_in_single_row_batch", "[oracle][bind][null]")
+{
+    test_bind_null_in_single_row_batch();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_bind_null_sentry", "[oracle][statement]")
+{
+    test_bind_null_sentry();
+}
+
+TEST_CASE_METHOD(
+    oracle_fixture,
+    "test_bind_timestamp_as_string",
+    "[oracle][statement][bind][timestamp]")
+{
+    test_bind_timestamp_as_string();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_column_descriptor", "[oracle][columns]")
+{
+    test_column_descriptor();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_connection_catalog_name", "[oracle][connection][metadata]")
+{
+    test_connection_catalog_name();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_connection_environment", "[oracle][connection]")
+{
+    test_connection_environment();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_datasources", "[oracle][datasources]")
+{
+    test_datasources();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_driver", "[oracle][driver]")
+{
+    test_driver();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_driver_info", "[oracle][driver][metadata][info]")
+{
+    test_driver_info();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_error", "[oracle][error]")
+{
+    test_error();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_exception", "[oracle][exception]")
+{
+    test_exception();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_execute_direct_batch_ops", "[oracle][statement][batch]")
+{
+    test_execute_direct_batch_ops();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_execute_multiple", "[oracle][execute]")
+{
+    test_execute_multiple();
+}
+
+TEST_CASE_METHOD(
+    oracle_fixture,
+    "test_execute_multiple_transaction",
+    "[oracle][execute][transaction]")
+{
+    test_execute_multiple_transaction();
+}
+
+TEST_CASE_METHOD(
+    oracle_fixture,
+    "test_execute_prepared_statement_repeatedly",
+    "[oracle][statement][prepare]")
+{
+    test_execute_prepared_statement_repeatedly();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_get_every_ctype", "[oracle][result][types]")
+{
+    test_get_every_ctype();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_get_info", "[oracle][dmbs][metadata][info]")
+{
+    test_get_info();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_get_info_widest", "[oracle][metadata][info]")
+{
+    test_get_info_widest();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_handle_copy_move_and_swap", "[oracle][handle]")
+{
+    test_handle_copy_move_and_swap();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_integral_small_types", "[oracle][integral]")
+{
+    test_integral_small_types();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_integral_small_types_batch", "[oracle][integral][batch]")
+{
+    test_integral_small_types_batch();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_integral_to_string_conversion", "[oracle][integral]")
+{
+    test_integral_to_string_conversion();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_is_null_binary", "[oracle][binary][null]")
+{
+    test_is_null_binary();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_just_execute_forms", "[oracle][execute]")
+{
+    test_just_execute_forms();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_long_text_chunk_boundaries", "[oracle][result][string]")
+{
+    test_long_text_chunk_boundaries();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_move", "[oracle][move]")
+{
+    test_move();
+}
+
+TEST_CASE_METHOD(
+    oracle_fixture,
+    "test_nested_transaction_rollback",
+    "[oracle][transaction][rollback]")
+{
+    test_nested_transaction_rollback();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_null", "[oracle][null]")
+{
+    test_null();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_null_long_text_fallback", "[oracle][result][null]")
+{
+    test_null_long_text_fallback();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_null_with_bound_columns_unbound", "[oracle][null][unbound]")
+{
+    test_null_with_bound_columns_unbound();
+}
+
+TEST_CASE_METHOD(
+    oracle_fixture,
+    "test_parameter_metadata_before_description",
+    "[oracle][statement]")
+{
+    test_parameter_metadata_before_description();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_result_accessors", "[oracle][result][accessors]")
+{
+    test_result_accessors();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_result_at_end", "[oracle][result]")
+{
+    test_result_at_end();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_result_column_metadata", "[oracle][result][metadata]")
+{
+    test_result_column_metadata();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_result_iterator", "[oracle][result][iterator]")
+{
+    test_result_iterator();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_result_iterator_post_increment", "[oracle][looping]")
+{
+    test_result_iterator_post_increment();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_result_rowset_navigation", "[oracle][result][rowset]")
+{
+    test_result_rowset_navigation();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_result_unbind", "[oracle][result][unbind]")
+{
+    test_result_unbind();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_simple", "[oracle]")
+{
+    test_simple();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_statement_cancel", "[oracle][statement]")
+{
+    test_statement_cancel();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_statement_open_close", "[oracle][statement]")
+{
+    test_statement_open_close();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_statement_parameter_description", "[oracle][statement]")
+{
+    test_statement_parameter_description();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_statement_timeout", "[oracle][statement]")
+{
+    test_statement_timeout();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_statement_usable_when_result_gone", "[oracle][statement]")
+{
+    test_statement_usable_when_result_gone();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_std_optional", "[oracle][optional]")
+{
+    test_std_optional();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_string", "[oracle][string]")
+{
+    test_string();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_string_aggregate", "[oracle][result][string]")
+{
+    test_string_aggregate();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_string_vector", "[oracle][string]")
+{
+    test_string_vector();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_string_view_vector", "[oracle][string]")
+{
+    test_string_view_vector();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_timeouts", "[oracle][statement]")
+{
+    test_timeouts();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_transaction", "[oracle][transaction]")
+{
+    test_transaction();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_while_next_iteration", "[oracle][looping]")
+{
+    test_while_next_iteration();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_while_not_end_iteration", "[oracle][looping]")
+{
+    test_while_not_end_iteration();
+}
+
+#if defined(_MSC_VER)
+
+TEST_CASE_METHOD(oracle_fixture, "test_win32_variant", "[oracle][variant][windows]")
+{
+    test_win32_variant();
+}
+
+TEST_CASE_METHOD(
+    oracle_fixture,
+    "test_win32_variant_null_literal",
+    "[oracle][variant][windows][null]")
+{
+    test_win32_variant_null_literal();
+}
+
+TEST_CASE_METHOD(
+    oracle_fixture,
+    "test_win32_variant_row_cached_result",
+    "[oracle][variant][windows]")
+{
+    test_win32_variant_row_cached_result();
+}
+
+#endif // _MSC_VER

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -55,14 +55,6 @@ TEST_CASE_METHOD(postgresql_fixture, "test_datasources", "[postgresql][datasourc
 
 TEST_CASE_METHOD(
     postgresql_fixture,
-    "test_bind_iso8601_timestamp_as_string",
-    "[postgresql][statement][bind][timestamp]")
-{
-    test_bind_iso8601_timestamp_as_string();
-}
-
-TEST_CASE_METHOD(
-    postgresql_fixture,
     "test_bind_timestamp_as_string",
     "[postgresql][statement][bind][timestamp]")
 {

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -519,7 +519,8 @@ struct test_case_fixture : public base_test_fixture
         create_table(
             connection,
             NANODBC_TEXT("test_result_accessors"),
-            NANODBC_TEXT("(i int, s varchar(10), f float, bg bigint)"));
+            NANODBC_TEXT("(i int, s varchar(10), f float, bg ") + get_bigint_type_name() +
+                NANODBC_TEXT(")"));
         execute(
             connection,
             NANODBC_TEXT(
@@ -1013,7 +1014,8 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(
             results.get<nanodbc::string>(1, NANODBC_TEXT("fallback")) == NANODBC_TEXT("fallback"));
         REQUIRE(
-            results.get<nanodbc::string>(NANODBC_TEXT("t"), NANODBC_TEXT("fallback")) ==
+            results.get<nanodbc::string>(
+                as_identifier(NANODBC_TEXT("t")), NANODBC_TEXT("fallback")) ==
             NANODBC_TEXT("fallback"));
     }
 
@@ -1217,10 +1219,9 @@ struct test_case_fixture : public base_test_fixture
         create_table(
             connection,
             NANODBC_TEXT("test_get_every_ctype"),
-            NANODBC_TEXT(
-                "(ti smallint, si smallint, i int, bi bigint, f float, d float, "
-                "s varchar(10), b ") +
-                get_bool_type_name() + NANODBC_TEXT(")"));
+            NANODBC_TEXT("(ti smallint, si smallint, i int, bi ") + get_bigint_type_name() +
+                NANODBC_TEXT(", f float, d float, s varchar(10), b ") + get_bool_type_name() +
+                NANODBC_TEXT(")"));
         // PostgreSQL will not take an integer for a boolean column.
         nanodbc::string const yes =
             vendor_ == database_vendor::postgresql ? NANODBC_TEXT("true") : NANODBC_TEXT("1");
@@ -1486,10 +1487,10 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(results.columns() == 2);
 
         // Position and name name the same two columns, in the same order.
-        REQUIRE(results.column_name(0) == NANODBC_TEXT("i"));
-        REQUIRE(results.column_name(1) == NANODBC_TEXT("s"));
-        REQUIRE(results.column(NANODBC_TEXT("i")) == 0);
-        REQUIRE(results.column(NANODBC_TEXT("s")) == 1);
+        REQUIRE(results.column_name(0) == as_identifier(NANODBC_TEXT("i")));
+        REQUIRE(results.column_name(1) == as_identifier(NANODBC_TEXT("s")));
+        REQUIRE(results.column(as_identifier(NANODBC_TEXT("i"))) == 0);
+        REQUIRE(results.column(as_identifier(NANODBC_TEXT("s"))) == 1);
 
         for (short i = 0; i < results.columns(); ++i)
         {
@@ -1507,11 +1508,12 @@ struct test_case_fixture : public base_test_fixture
         }
 
         // The width the driver reports is the one the table asked for.
-        REQUIRE(results.column_size(NANODBC_TEXT("s")) == 60);
+        REQUIRE(results.column_size(as_identifier(NANODBC_TEXT("s"))) == 60);
 
         // A name no column carries is an error rather than a position.
         REQUIRE_THROWS_AS(
-            results.column(NANODBC_TEXT("no_such_column")), nanodbc::index_range_error);
+            results.column(as_identifier(NANODBC_TEXT("no_such_column"))),
+            nanodbc::index_range_error);
     }
 
     void test_result_rowset_navigation()
@@ -1646,7 +1648,7 @@ struct test_case_fixture : public base_test_fixture
                 execute(connection, NANODBC_TEXT("select i, j from test_result_unbind;"));
             REQUIRE(results.next());
             REQUIRE(results.is_bound(0));
-            REQUIRE(results.is_bound(NANODBC_TEXT("j")));
+            REQUIRE(results.is_bound(as_identifier(NANODBC_TEXT("j"))));
 
             results.unbind(short(0));
             REQUIRE(!results.is_bound(0));
@@ -1657,8 +1659,8 @@ struct test_case_fixture : public base_test_fixture
             auto results =
                 execute(connection, NANODBC_TEXT("select i, j from test_result_unbind;"));
             REQUIRE(results.next());
-            results.unbind(NANODBC_TEXT("j"));
-            REQUIRE(!results.is_bound(NANODBC_TEXT("j")));
+            results.unbind(as_identifier(NANODBC_TEXT("j")));
+            REQUIRE(!results.is_bound(as_identifier(NANODBC_TEXT("j"))));
         }
 
         {
@@ -1712,7 +1714,8 @@ struct test_case_fixture : public base_test_fixture
                 get_string_agg_expression(NANODBC_TEXT("v"), NANODBC_TEXT(",")) +
                 NANODBC_TEXT(" as joined from test_string_aggregate;"));
         REQUIRE(by_name.next());
-        REQUIRE(by_name.get<nanodbc::string>(NANODBC_TEXT("joined")).size() == expected);
+        REQUIRE(
+            by_name.get<nanodbc::string>(as_identifier(NANODBC_TEXT("joined"))).size() == expected);
     }
 
     // Preparing once and executing many times is the point of preparing at all. The
@@ -1908,7 +1911,7 @@ struct test_case_fixture : public base_test_fixture
             REQUIRE(results.next());
             // Asked before anything has read the column.
             REQUIRE(results.is_null(1));
-            REQUIRE(results.is_null(NANODBC_TEXT("b")));
+            REQUIRE(results.is_null(as_identifier(NANODBC_TEXT("b"))));
             // And a read of it says so rather than handing back an empty value.
             REQUIRE_THROWS_AS(
                 results.get<std::vector<std::uint8_t>>(1), nanodbc::null_access_error);
@@ -2039,7 +2042,7 @@ struct test_case_fixture : public base_test_fixture
             nanodbc::catalog::columns columns = catalog.find_columns(NANODBC_TEXT("%"), table_name);
 
             REQUIRE(columns.next());
-            REQUIRE(columns.column_name() == NANODBC_TEXT("c0"));
+            REQUIRE(columns.column_name() == as_identifier(NANODBC_TEXT("c0")));
             REQUIRE(!columns.table_name().empty());
             REQUIRE(columns.data_type() != 0);
             REQUIRE(columns.ordinal_position() > 0);
@@ -2081,7 +2084,7 @@ struct test_case_fixture : public base_test_fixture
             REQUIRE(!columns.type_name().empty()); // data source dependant name, check once
 
             REQUIRE(columns.next());
-            REQUIRE(columns.column_name() == NANODBC_TEXT("c1"));
+            REQUIRE(columns.column_name() == as_identifier(NANODBC_TEXT("c1")));
             if (vendor_ == database_vendor::vertica)
             {
                 REQUIRE(columns.sql_data_type() == SQL_BIGINT);
@@ -2101,7 +2104,7 @@ struct test_case_fixture : public base_test_fixture
                 REQUIRE(columns.is_nullable() == NANODBC_TEXT("NO"));
 
             REQUIRE(columns.next());
-            REQUIRE(columns.column_name() == NANODBC_TEXT("c2"));
+            REQUIRE(columns.column_name() == as_identifier(NANODBC_TEXT("c2")));
             REQUIRE(
                 (columns.sql_data_type() == SQL_FLOAT || columns.sql_data_type() == SQL_REAL ||
                  columns.sql_data_type() == SQL_DOUBLE));
@@ -2112,7 +2115,7 @@ struct test_case_fixture : public base_test_fixture
                 REQUIRE(columns.is_nullable() == NANODBC_TEXT("YES"));
 
             REQUIRE(columns.next());
-            REQUIRE(columns.column_name() == NANODBC_TEXT("c3"));
+            REQUIRE(columns.column_name() == as_identifier(NANODBC_TEXT("c3")));
             // SQLite has no decimal type, so its driver types c3 as text and reports the
             // scale of decimal(9, 3) as the column size.
             if (vendor_ == database_vendor::sqlite)
@@ -2141,7 +2144,7 @@ struct test_case_fixture : public base_test_fixture
                 REQUIRE(columns.is_nullable() == NANODBC_TEXT("YES"));
 
             REQUIRE(columns.next());
-            REQUIRE(columns.column_name() == NANODBC_TEXT("c4"));
+            REQUIRE(columns.column_name() == as_identifier(NANODBC_TEXT("c4")));
             if (contains_string(dbms, NANODBC_TEXT("SQLite")))
             {
                 REQUIRE(columns.sql_data_type() == SQL_TYPE_DATE);
@@ -2165,7 +2168,7 @@ struct test_case_fixture : public base_test_fixture
             }
 
             REQUIRE(columns.next());
-            REQUIRE(columns.column_name() == NANODBC_TEXT("c5"));
+            REQUIRE(columns.column_name() == as_identifier(NANODBC_TEXT("c5")));
             REQUIRE((
                 columns.sql_data_type() == SQL_VARCHAR || columns.sql_data_type() == SQL_WVARCHAR));
             REQUIRE(columns.column_size() == 60);
@@ -2188,13 +2191,13 @@ struct test_case_fixture : public base_test_fixture
                 REQUIRE(columns.column_default() == NANODBC_TEXT("\'sample value\'"));
 
             REQUIRE(columns.next());
-            REQUIRE(columns.column_name() == NANODBC_TEXT("c6"));
+            REQUIRE(columns.column_name() == as_identifier(NANODBC_TEXT("c6")));
             REQUIRE((
                 columns.sql_data_type() == SQL_VARCHAR || columns.sql_data_type() == SQL_WVARCHAR));
             REQUIRE(columns.column_size() == 120);
 
             REQUIRE(columns.next());
-            REQUIRE(columns.column_name() == NANODBC_TEXT("c7"));
+            REQUIRE(columns.column_name() == as_identifier(NANODBC_TEXT("c7")));
             REQUIRE(
                 (columns.sql_data_type() == SQL_LONGVARCHAR ||
                  columns.sql_data_type() == SQL_WLONGVARCHAR));
@@ -2211,7 +2214,7 @@ struct test_case_fixture : public base_test_fixture
             check_data_type_size(text_type_name, columns.column_size());
 
             REQUIRE(columns.next());
-            REQUIRE(columns.column_name() == NANODBC_TEXT("c8"));
+            REQUIRE(columns.column_name() == as_identifier(NANODBC_TEXT("c8")));
             REQUIRE(
                 (columns.sql_data_type() == SQL_VARBINARY ||
                  columns.sql_data_type() == SQL_LONGVARBINARY || // MySQL reports SQL_LONGVARBINARY
@@ -2308,7 +2311,7 @@ struct test_case_fixture : public base_test_fixture
             nanodbc::catalog::primary_keys keys = catalog.find_primary_keys(table_name);
             REQUIRE(keys.next());
             REQUIRE(keys.table_name() == table_name);
-            REQUIRE(keys.column_name() == NANODBC_TEXT("i"));
+            REQUIRE(keys.column_name() == as_identifier(NANODBC_TEXT("i")));
             REQUIRE(keys.column_number() == 1);
             keys.table_catalog();
             keys.table_schema();
@@ -2332,7 +2335,7 @@ struct test_case_fixture : public base_test_fixture
             nanodbc::catalog::primary_keys keys = catalog.find_primary_keys(table_name);
             REQUIRE(keys.next());
             REQUIRE(keys.table_name() == table_name);
-            REQUIRE(keys.column_name() == NANODBC_TEXT("a"));
+            REQUIRE(keys.column_name() == as_identifier(NANODBC_TEXT("a")));
             REQUIRE(keys.column_number() == 1);
             auto const pk_composite1 = get_primary_key_name(NANODBC_TEXT("test_pk_composite"));
             if (!pk_composite1.empty()) // constraint relevant
@@ -2340,7 +2343,7 @@ struct test_case_fixture : public base_test_fixture
 
             REQUIRE(keys.next());
             REQUIRE(keys.table_name() == table_name);
-            REQUIRE(keys.column_name() == NANODBC_TEXT("b"));
+            REQUIRE(keys.column_name() == as_identifier(NANODBC_TEXT("b")));
             REQUIRE(keys.column_number() == 2);
             auto const pk_composite2 = get_primary_key_name(NANODBC_TEXT("test_pk_composite"));
             if (!pk_composite2.empty()) // constraint relevant
@@ -2705,7 +2708,7 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(result.columns() == 7);
 
         // i int
-        REQUIRE(result.column_name(0) == NANODBC_TEXT("i"));
+        REQUIRE(result.column_name(0) == as_identifier(NANODBC_TEXT("i")));
         REQUIRE(result.column_datatype(0) == SQL_INTEGER);
         if (vendor_ == database_vendor::sqlserver)
         {
@@ -2722,7 +2725,7 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(result.column_decimal_digits(0) == 0);
         REQUIRE(!result.column_unsigned(0));
         // d decimal(7,3)
-        REQUIRE(result.column_name(1) == NANODBC_TEXT("d"));
+        REQUIRE(result.column_name(1) == as_identifier(NANODBC_TEXT("d")));
         if (vendor_ == database_vendor::sqlite)
         {
 #ifdef _WIN32
@@ -2749,7 +2752,7 @@ struct test_case_fixture : public base_test_fixture
         }
         REQUIRE(result.column_size(1) == 7);
         // n numeric(7,3)
-        REQUIRE(result.column_name(2) == NANODBC_TEXT("n"));
+        REQUIRE(result.column_name(2) == as_identifier(NANODBC_TEXT("n")));
         REQUIRE(result.column_size(2) == 7);
         if (vendor_ == database_vendor::sqlite)
         {
@@ -2819,7 +2822,7 @@ struct test_case_fixture : public base_test_fixture
         {
             auto result = execute(connection, NANODBC_TEXT("select d from test_date;"));
 
-            REQUIRE(result.column_name(0) == NANODBC_TEXT("d"));
+            REQUIRE(result.column_name(0) == as_identifier(NANODBC_TEXT("d")));
 #if (ODBCVER > SQL_OV_ODBC2)
             REQUIRE(result.column_datatype(0) == SQL_TYPE_DATE);
 #else
@@ -2856,7 +2859,7 @@ struct test_case_fixture : public base_test_fixture
         {
             auto result = execute(connection, NANODBC_TEXT("select d from test_date_optional;"));
 
-            REQUIRE(result.column_name(0) == NANODBC_TEXT("d"));
+            REQUIRE(result.column_name(0) == as_identifier(NANODBC_TEXT("d")));
 #if (ODBCVER > SQL_OV_ODBC2)
             REQUIRE(result.column_datatype(0) == SQL_TYPE_DATE);
 #else
@@ -3328,9 +3331,9 @@ PRIMARY KEY(t2_fid)
             // t1_fid1
             REQUIRE(!ird.auto_unique_value(0));
             if (vendor_ == database_vendor::sqlite)
-                REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("fid1"));
+                REQUIRE(ird.base_column_name(0) == as_identifier(NANODBC_TEXT("fid1")));
             else
-                REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("t1_fid1"));
+                REQUIRE(ird.base_column_name(0) == as_identifier(NANODBC_TEXT("t1_fid1")));
             if (mariadb_)
                 REQUIRE(ird.name(0) == NANODBC_TEXT("t1_fid1"));
             else
@@ -3342,7 +3345,7 @@ PRIMARY KEY(t2_fid)
                 REQUIRE(ird.table_name(0) == NANODBC_TEXT("t1"));
             // t1_fid2
             REQUIRE(!ird.auto_unique_value(1));
-            REQUIRE(ird.base_column_name(1) == NANODBC_TEXT("t1_fid2"));
+            REQUIRE(ird.base_column_name(1) == as_identifier(NANODBC_TEXT("t1_fid2")));
             REQUIRE(ird.name(1) == NANODBC_TEXT("t1_fid2"));
             REQUIRE(ird.base_table_name(1) == NANODBC_TEXT("t1"));
             if (vendor_ == database_vendor::mysql)
@@ -3350,7 +3353,7 @@ PRIMARY KEY(t2_fid)
             else
                 REQUIRE(ird.table_name(1) == NANODBC_TEXT("t1"));
             // name
-            REQUIRE(ird.base_column_name(2) == NANODBC_TEXT("name"));
+            REQUIRE(ird.base_column_name(2) == as_identifier(NANODBC_TEXT("name")));
             REQUIRE(ird.name(2) == NANODBC_TEXT("name"));
             REQUIRE(ird.base_table_name(2) == NANODBC_TEXT("t1"));
             if (vendor_ == database_vendor::mysql)
@@ -3380,9 +3383,9 @@ PRIMARY KEY(t2_fid)
             REQUIRE(ird.count() == 5);
             // fid1
             if (vendor_ == database_vendor::sqlite)
-                REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("fid1"));
+                REQUIRE(ird.base_column_name(0) == as_identifier(NANODBC_TEXT("fid1")));
             else
-                REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("t1_fid1"));
+                REQUIRE(ird.base_column_name(0) == as_identifier(NANODBC_TEXT("t1_fid1")));
             if (mariadb_)
                 REQUIRE(ird.name(0) == NANODBC_TEXT("t1_fid1"));
             else
@@ -3445,7 +3448,7 @@ PRIMARY KEY(t2_fid)
         // name
         REQUIRE(!ird.auto_unique_value(0));
         if (vendor_ == database_vendor::sqlite || vendor_ == database_vendor::postgresql)
-            REQUIRE(ird.base_column_name(0) == NANODBC_TEXT("name"));
+            REQUIRE(ird.base_column_name(0) == as_identifier(NANODBC_TEXT("name")));
         else
             REQUIRE(ird.base_column_name(0) == NANODBC_TEXT(""));
         // For a column of an expression MariaDB's driver reports no name at all.
@@ -3458,7 +3461,7 @@ PRIMARY KEY(t2_fid)
         // age
         REQUIRE(!ird.auto_unique_value(1));
         if (vendor_ == database_vendor::sqlite || vendor_ == database_vendor::postgresql)
-            REQUIRE(ird.base_column_name(1) == NANODBC_TEXT("age"));
+            REQUIRE(ird.base_column_name(1) == as_identifier(NANODBC_TEXT("age")));
         else
             REQUIRE(ird.base_column_name(1) == NANODBC_TEXT(""));
         if (mariadb_)
@@ -3673,9 +3676,9 @@ PRIMARY KEY(t2_fid)
         REQUIRE(results.get<bool>(2) == b);
 
         // by column name
-        REQUIRE(results.get<signed char>(NANODBC_TEXT("sc")) == sc);
-        REQUIRE(results.get<unsigned char>(NANODBC_TEXT("uc")) == uc);
-        REQUIRE(results.get<bool>(NANODBC_TEXT("b")) == b);
+        REQUIRE(results.get<signed char>(as_identifier(NANODBC_TEXT("sc"))) == sc);
+        REQUIRE(results.get<unsigned char>(as_identifier(NANODBC_TEXT("uc"))) == uc);
+        REQUIRE(results.get<bool>(as_identifier(NANODBC_TEXT("b"))) == b);
 
         // with fallback, which is not used because none of the values are null
         REQUIRE(results.get<signed char>(0, 0) == sc);
@@ -3696,9 +3699,9 @@ PRIMARY KEY(t2_fid)
         sc_ref = 0;
         uc_ref = 0;
         b_ref = false;
-        results.get_ref(NANODBC_TEXT("sc"), sc_ref);
-        results.get_ref(NANODBC_TEXT("uc"), uc_ref);
-        results.get_ref(NANODBC_TEXT("b"), b_ref);
+        results.get_ref(as_identifier(NANODBC_TEXT("sc")), sc_ref);
+        results.get_ref(as_identifier(NANODBC_TEXT("uc")), uc_ref);
+        results.get_ref(as_identifier(NANODBC_TEXT("b")), b_ref);
         REQUIRE(sc_ref == sc);
         REQUIRE(uc_ref == uc);
         REQUIRE(b_ref == b);
@@ -4127,8 +4130,8 @@ PRIMARY KEY(t2_fid)
             }
 
             REQUIRE(results.rowset_size() == 1);
-            REQUIRE(results.column_name(0) == NANODBC_TEXT("a"));
-            REQUIRE(results.column_name(1) == NANODBC_TEXT("b"));
+            REQUIRE(results.column_name(0) == as_identifier(NANODBC_TEXT("a")));
+            REQUIRE(results.column_name(1) == as_identifier(NANODBC_TEXT("b")));
 
             // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
             REQUIRE(results.next());
@@ -4136,26 +4139,30 @@ PRIMARY KEY(t2_fid)
             // .....................................................................................
             REQUIRE(results.rows() == 1);
             REQUIRE(results.is_null(0));
-            REQUIRE(results.is_null(NANODBC_TEXT("a")));
+            REQUIRE(results.is_null(as_identifier(NANODBC_TEXT("a"))));
             REQUIRE(results.get<int>(0, -1) == -1);
-            REQUIRE(results.get<int>(NANODBC_TEXT("a"), -1) == -1);
+            REQUIRE(results.get<int>(as_identifier(NANODBC_TEXT("a")), -1) == -1);
             REQUIRE(results.get<nanodbc::string>(0, NANODBC_TEXT("null")) == NANODBC_TEXT("null"));
             REQUIRE(
-                results.get<nanodbc::string>(NANODBC_TEXT("a"), NANODBC_TEXT("null")) ==
+                results.get<nanodbc::string>(
+                    as_identifier(NANODBC_TEXT("a")), NANODBC_TEXT("null")) ==
                 NANODBC_TEXT("null"));
             REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("z"));
-            REQUIRE(results.get<nanodbc::string>(NANODBC_TEXT("b")) == NANODBC_TEXT("z"));
+            REQUIRE(
+                results.get<nanodbc::string>(as_identifier(NANODBC_TEXT("b"))) ==
+                NANODBC_TEXT("z"));
 
             int ref_int;
             results.get_ref(0, -1, ref_int);
             REQUIRE(ref_int == -1);
-            results.get_ref(NANODBC_TEXT("a"), -2, ref_int);
+            results.get_ref(as_identifier(NANODBC_TEXT("a")), -2, ref_int);
             REQUIRE(ref_int == -2);
 
             nanodbc::string ref_str;
             results.get_ref<nanodbc::string>(0, NANODBC_TEXT("null"), ref_str);
             REQUIRE(ref_str == NANODBC_TEXT("null"));
-            results.get_ref<nanodbc::string>(NANODBC_TEXT("a"), NANODBC_TEXT("null2"), ref_str);
+            results.get_ref<nanodbc::string>(
+                as_identifier(NANODBC_TEXT("a")), NANODBC_TEXT("null2"), ref_str);
             REQUIRE(ref_str == NANODBC_TEXT("null2"));
 
             // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -4163,9 +4170,11 @@ PRIMARY KEY(t2_fid)
             // row = 1|one
             // .....................................................................................
             REQUIRE(results.get<int>(0) == 1);
-            REQUIRE(results.get<int>(NANODBC_TEXT("a")) == 1);
+            REQUIRE(results.get<int>(as_identifier(NANODBC_TEXT("a"))) == 1);
             REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("one"));
-            REQUIRE(results.get<nanodbc::string>(NANODBC_TEXT("b")) == NANODBC_TEXT("one"));
+            REQUIRE(
+                results.get<nanodbc::string>(as_identifier(NANODBC_TEXT("b"))) ==
+                NANODBC_TEXT("one"));
 
             nanodbc::result results_copy = results;
 
@@ -4174,9 +4183,11 @@ PRIMARY KEY(t2_fid)
             // row = 2|two
             // .....................................................................................
             REQUIRE(results_copy.get<int>(0, -1) == 2);
-            REQUIRE(results_copy.get<int>(NANODBC_TEXT("a"), -1) == 2);
+            REQUIRE(results_copy.get<int>(as_identifier(NANODBC_TEXT("a")), -1) == 2);
             REQUIRE(results_copy.get<nanodbc::string>(1) == NANODBC_TEXT("two"));
-            REQUIRE(results_copy.get<nanodbc::string>(NANODBC_TEXT("b")) == NANODBC_TEXT("two"));
+            REQUIRE(
+                results_copy.get<nanodbc::string>(as_identifier(NANODBC_TEXT("b"))) ==
+                NANODBC_TEXT("two"));
 
             // result::position() needs SQL_ATTR_CURSOR_TYPE at SQL_CURSOR_STATIC or better,
             // which the default SQL_CURSOR_FORWARD_ONLY does not offer.
@@ -4187,9 +4198,13 @@ PRIMARY KEY(t2_fid)
             // row = 3|tri
             // .....................................................................................
             REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("3"));
-            REQUIRE(results.get<nanodbc::string>(NANODBC_TEXT("a")) == NANODBC_TEXT("3"));
+            REQUIRE(
+                results.get<nanodbc::string>(as_identifier(NANODBC_TEXT("a"))) ==
+                NANODBC_TEXT("3"));
             REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("tri"));
-            REQUIRE(results.get<nanodbc::string>(NANODBC_TEXT("b")) == NANODBC_TEXT("tri"));
+            REQUIRE(
+                results.get<nanodbc::string>(as_identifier(NANODBC_TEXT("b"))) ==
+                NANODBC_TEXT("tri"));
 
             REQUIRE(!results.next());
             REQUIRE(results.at_end());

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1139,10 +1139,10 @@ struct test_case_fixture : public base_test_fixture
 
         // By name as well as by position: the fallback for an unbound column is decided
         // after the read rather than before it, on a path of its own.
-        REQUIRE(
-            results
-                .get<std::vector<std::uint8_t>>(NANODBC_TEXT("long_b"), std::vector<std::uint8_t>{})
-                .empty());
+        REQUIRE(results
+                    .get<std::vector<std::uint8_t>>(
+                        as_identifier(NANODBC_TEXT("long_b")), std::vector<std::uint8_t>{})
+                    .empty());
         REQUIRE(results
                     .get<std::vector<std::uint8_t>>(
                         NANODBC_TEXT("small_b"), std::vector<std::uint8_t>{})
@@ -4462,19 +4462,16 @@ PRIMARY KEY(t2_fid)
             {0x00, 0x01, 0x02, 0x03}, {0x03, 0x02, 0x01, 0x00}};
 
         drop_table(connection, NANODBC_TEXT("test_batch_binary"));
-        nanodbc::string const binary_type_name = get_binary_type_name();
-
         // PostgreSQL does not allow limits on bytea fields, MS-SQL requires
-        // them on varbinary fields
-        nanodbc::string create_table_sql = NANODBC_TEXT("create table test_batch_binary (s ");
-        if (vendor_ == database_vendor::postgresql)
-        {
-            create_table_sql = create_table_sql + binary_type_name + NANODBC_TEXT(")");
-        }
-        else
-        {
-            create_table_sql = create_table_sql + binary_type_name + NANODBC_TEXT("(10))");
-        }
+        // them on varbinary fields. The size belongs to the type name rather than being
+        // appended to it, a bounded binary being spelled differently from an unbounded
+        // one on some databases.
+        nanodbc::string const binary_type_name = vendor_ == database_vendor::postgresql
+                                                     ? get_binary_type_name()
+                                                     : get_binary_type_name(10);
+        nanodbc::string const create_table_sql =
+            NANODBC_TEXT("create table test_batch_binary (s ") + binary_type_name +
+            NANODBC_TEXT(")");
 
         execute(connection, create_table_sql);
         nanodbc::statement query(connection);

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1145,7 +1145,7 @@ struct test_case_fixture : public base_test_fixture
                     .empty());
         REQUIRE(results
                     .get<std::vector<std::uint8_t>>(
-                        NANODBC_TEXT("small_b"), std::vector<std::uint8_t>{})
+                        as_identifier(NANODBC_TEXT("small_b")), std::vector<std::uint8_t>{})
                     .empty());
 
         REQUIRE(!results.next());
@@ -1287,7 +1287,9 @@ struct test_case_fixture : public base_test_fixture
             connection, NANODBC_TEXT("test_get_every_ctype_date"), NANODBC_TEXT("(d date)"));
         execute(
             connection,
-            NANODBC_TEXT("insert into test_get_every_ctype_date (d) values ('2006-12-30');"));
+            // The ODBC date escape rather than a bare literal: a bare one is read in whatever
+            // format the database is set to, and Oracle's is DD-MON-RR.
+            NANODBC_TEXT("insert into test_get_every_ctype_date (d) values ({d '2006-12-30'});"));
         auto dates = execute(connection, NANODBC_TEXT("select d from test_get_every_ctype_date;"));
         REQUIRE(dates.next());
         REQUIRE_THROWS_AS(dates.get<int>(0), nanodbc::type_incompatible_error);
@@ -1315,7 +1317,7 @@ struct test_case_fixture : public base_test_fixture
         check_bind_forms<short>(narrow_column, 10, 20, 30);
         check_bind_forms<unsigned short>(narrow_column, 10, 20, 30);
 
-        auto const wide_column = NANODBC_TEXT("bigint");
+        auto const wide_column = get_bigint_type_name();
         check_bind_forms<int>(wide_column, 100, 200, 300);
         check_bind_forms<unsigned int>(wide_column, 100, 200, 300);
         check_bind_forms<long>(wide_column, 1000, 2000, 3000);

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -290,7 +290,13 @@ struct test_case_fixture : public base_test_fixture
                     REQUIRE(
                         result.get<float>(1) ==
                         floats[i]); // exact test might fail, switch to Approx
-                    REQUIRE(result.get<nanodbc::string>(2) == strings[i]);
+                    // Oracle keeps an empty string as null, having no way to tell the two
+                    // apart, so the one empty value in the batch comes back null rather
+                    // than as the empty string that went in.
+                    if (vendor_ == database_vendor::oracle && strings[i][0] == 0)
+                        REQUIRE(result.is_null(2));
+                    else
+                        REQUIRE(result.get<nanodbc::string>(2) == strings[i]);
                     ++i;
                 }
                 REQUIRE(i == batch_size);
@@ -531,7 +537,7 @@ struct test_case_fixture : public base_test_fixture
             execute(connection, NANODBC_TEXT("select i, s, f, bg from test_result_accessors;"));
         REQUIRE(results.next());
 
-        nanodbc::string const i_name = NANODBC_TEXT("i");
+        nanodbc::string const i_name = as_identifier(NANODBC_TEXT("i"));
         check_every_accessor<bool>(results, 0, i_name, true);
         check_every_accessor<signed char>(results, 0, i_name, 42);
         check_every_accessor<unsigned char>(results, 0, i_name, 42);
@@ -547,7 +553,7 @@ struct test_case_fixture : public base_test_fixture
         check_every_accessor<double>(results, 0, i_name, 42.0);
         check_every_accessor<nanodbc::string>(results, 0, i_name, NANODBC_TEXT("42"));
 
-        nanodbc::string const s_name = NANODBC_TEXT("s");
+        nanodbc::string const s_name = as_identifier(NANODBC_TEXT("s"));
         check_every_accessor<nanodbc::string>(results, 1, s_name, NANODBC_TEXT("forty two"));
 
         // A text column can also be read one character at a time, which is a conversion of
@@ -557,13 +563,13 @@ struct test_case_fixture : public base_test_fixture
 
         // Each column type binds to a C type of its own, and every target type reaches it
         // by a branch of its own, so the wider columns are read across types as well.
-        nanodbc::string const f_name = NANODBC_TEXT("f");
+        nanodbc::string const f_name = as_identifier(NANODBC_TEXT("f"));
         check_every_accessor<double>(results, 2, f_name, 42.0);
         check_every_accessor<int>(results, 2, f_name, 42);
         check_every_accessor<long long>(results, 2, f_name, 42LL);
         check_every_accessor<short>(results, 2, f_name, 42);
 
-        nanodbc::string const bg_name = NANODBC_TEXT("bg");
+        nanodbc::string const bg_name = as_identifier(NANODBC_TEXT("bg"));
         check_every_accessor<long long>(results, 3, bg_name, 42LL);
         check_every_accessor<int>(results, 3, bg_name, 42);
         check_every_accessor<double>(results, 3, bg_name, 42.0);
@@ -1320,10 +1326,18 @@ struct test_case_fixture : public base_test_fixture
         auto const wide_column = get_bigint_type_name();
         check_bind_forms<int>(wide_column, 100, 200, 300);
         check_bind_forms<unsigned int>(wide_column, 100, 200, 300);
-        check_bind_forms<long>(wide_column, 1000, 2000, 3000);
-        check_bind_forms<unsigned long>(wide_column, 1000, 2000, 3000);
-        check_bind_forms<long long>(wide_column, 10000, 20000, 30000);
-        check_bind_forms<unsigned long long>(wide_column, 10000, 20000, 30000);
+
+        // Oracle's driver takes a SQL_C_SBIGINT binding and then fails the execution,
+        // leaving no diagnostic record to say why, whatever type the parameter is
+        // declared as. The same value bound as SQL_C_SLONG goes in, so it is the sixty
+        // four bit C type it will not carry rather than the size of the number.
+        if (vendor_ != database_vendor::oracle)
+        {
+            check_bind_forms<long>(wide_column, 1000, 2000, 3000);
+            check_bind_forms<unsigned long>(wide_column, 1000, 2000, 3000);
+            check_bind_forms<long long>(wide_column, 10000, 20000, 30000);
+            check_bind_forms<unsigned long long>(wide_column, 10000, 20000, 30000);
+        }
 
         // Values a float holds exactly, so that the sentry compares equal.
         auto const real_column = NANODBC_TEXT("float");
@@ -2711,7 +2725,18 @@ struct test_case_fixture : public base_test_fixture
 
         // i int
         REQUIRE(result.column_name(0) == as_identifier(NANODBC_TEXT("i")));
-        REQUIRE(result.column_datatype(0) == SQL_INTEGER);
+        // Oracle has one numeric type and describes an int as that: SQL_DECIMAL with the
+        // 38 digits a NUMBER carries, rather than SQL_INTEGER with ten.
+        if (vendor_ == database_vendor::oracle)
+        {
+            REQUIRE(result.column_datatype(0) == SQL_DECIMAL);
+            REQUIRE(result.column_size(0) == 38);
+        }
+        else
+        {
+            REQUIRE(result.column_datatype(0) == SQL_INTEGER);
+            REQUIRE(result.column_size(0) == 10);
+        }
         if (vendor_ == database_vendor::sqlserver)
         {
             REQUIRE(result.column_c_datatype(0) == SQL_C_SLONG);
@@ -2723,7 +2748,6 @@ struct test_case_fixture : public base_test_fixture
                 type_name, Catch::Matchers::ContainsSubstring("int", Catch::CaseSensitive::No));
             REQUIRE(result.column_c_datatype(0) == SQL_C_SLONG);
         }
-        REQUIRE(result.column_size(0) == 10);
         REQUIRE(result.column_decimal_digits(0) == 0);
         REQUIRE(!result.column_unsigned(0));
         // d decimal(7,3)

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -1601,38 +1601,6 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(rows == 4);
     }
 
-    // The same moment written the ISO 8601 way, which reaches the server whole because a
-    // date or time parameter given text is declared as text. A driver asked to read this
-    // one as a timestamp takes the date and stops at the "T", and says nothing of it.
-    void test_bind_iso8601_timestamp_as_string()
-    {
-        auto connection = connect();
-        create_table(
-            connection,
-            NANODBC_TEXT("test_bind_iso8601_timestamp_as_string"),
-            NANODBC_TEXT("(id int, ts ") + get_timestamp_type_name() + NANODBC_TEXT(")"));
-
-        auto const value = NANODBC_TEXT("2020-09-03T15:27:38");
-
-        nanodbc::statement statement(connection);
-        statement.prepare(NANODBC_TEXT(
-            "insert into test_bind_iso8601_timestamp_as_string (id, ts) values (1, ?);"));
-        statement.bind(0, value);
-        statement.just_execute();
-
-        auto results = execute(
-            connection, NANODBC_TEXT("select ts from test_bind_iso8601_timestamp_as_string;"));
-        REQUIRE(results.next());
-
-        auto const stamp = results.template get<nanodbc::timestamp>(0);
-        REQUIRE(stamp.year == 2020);
-        REQUIRE(stamp.month == 9);
-        REQUIRE(stamp.day == 3);
-        REQUIRE(stamp.hour == 15);
-        REQUIRE(stamp.min == 27);
-        REQUIRE(stamp.sec == 38);
-    }
-
     // A timestamp in the form ODBC spells its literals, "yyyy-mm-dd hh:mm:ss", bound as
     // a string and read back field by field.
     void test_bind_timestamp_as_string()


### PR DESCRIPTION
**Reverts the bind change from #502, which shipped in v2.18.0 and breaks Oracle**, and brings Oracle into CI so the revert is guarded by a test rather than by argument. Five further bugs surfaced along the way, all fixed here.

## The regression

#502 declared a character value bound to a date or time parameter as `SQL_VARCHAR`, so the server parsed it rather than the driver. Oracle converts text to a timestamp with `NLS_DATE_FORMAT`, `DD-MON-RR` by default, and so refuses the literal form ODBC itself specifies. Raw ODBC, no nanodbc linked in:

```
binding "2020-09-03 15:27:38" to a timestamp column
  as the described type (before #502)   rc=0   OK
  as SQL_VARCHAR (after #502)           rc=-1  ORA-01843: An invalid month was specified
```

That is the **conforming** case failing, to make a non-conforming one work elsewhere. #502 claimed "never worse on any driver here", which was true; **here** was every driver the suite could reach, and that PR named Oracle as the likeliest to disagree. It was not tested because it was not in CI. It is now.

`test_bind_timestamp_as_string` passes on Oracle with this revert and fails without it, so the regression is guarded from here on.

## Oracle in CI

The Free container pulls anonymously and the Instant Client ODBC driver downloads without a login, both verified. `docker-compose.yml` gains a service, `Dockerfile.dev` the driver, `ci-linux.yml` a job.

`oracle_test.cpp` runs the **64 tests** the PostgreSQL, MySQL and SQLite suites share — the portable set, taken from their intersection rather than hand-picked. **All 64 pass**, 1033 assertions. The only omission is `test_time`: Oracle has no TIME type, so there is no column to create.

Oracle is deliberately **not** in the `nanodbc` service's `depends_on`. It takes minutes to open and its driver is x86_64 only, so waiting on it would cost every local run on every host to serve a suite some of them cannot run at all. `docker compose up -d oracle` when it is wanted.

## Five bugs, all in shared code

| | found because |
|---|---|
| **Binary corruption.** `is_null` probed an unbound binary column with a zero-length `SQLGetData`, commented as moving no data. ODBC promises no such thing — a driver hands a value over once, and the probe consumed the first byte. `01020304` read back as `020304`. | Oracle counts the probe as a read; three other drivers tolerate it |
| **`std::` exceptions escaping `get<T>(col, fallback)`.** A null unbound numeric reached `from_string` as an empty string and left as `std::invalid_argument`, before the caller's null check could hand back the fallback. | others bind these columns, so nullness is known before the read |
| **`SQL_C_BIT` passed through unnormalised.** A bit is 0 or 1 by definition; Oracle's driver writes the character, so a boolean read as 49. | only Oracle writes the character |
| **`get<bool>` throwing on 42.** Read as an integer it casts to true; read as text it was range-checked against `numeric_limits<bool>::max()` and threw. Same value, different answer by how the driver described the column. | only Oracle describes `int` as `SQL_DECIMAL` |
| **A bare date literal in a test**, read in whatever format the database is set to. Now the ODBC escape, which every driver translates. | Oracle's format is `DD-MON-RR` |

Three of these are one mistake in different clothes: assuming nullness can be learned before, and without cost, then using a value that is not there. #423 was the same shape.

## Three differences described, not worked around

Each verified at the driver level with raw ODBC before being written down:

- Oracle's driver takes a `SQL_C_SBIGINT` binding and then **fails the execution leaving no diagnostic record**, whatever the parameter is declared as. `SQL_C_SLONG` with the same value goes in. That is why the failure showed only as a bare `00000:`.
- Oracle has one numeric type, so an `int` is described as `SQL_DECIMAL` with 38 digits.
- An empty string is stored as null, Oracle having no way to tell them apart.

## Testing

Oracle 64/64. All five other suites pass after every change in this branch, checked each time — the binary fix broke three of them on its first attempt, which is how the second half of it was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)