### PR TITLE
Start the Oracle tests against a faststart image

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -359,19 +359,19 @@ jobs:
     timeout-minutes: 45
     services:
       oracle:
-        image: container-registry.oracle.com/database/free:latest
+        image: gvenzl/oracle-free:23-slim-faststart
         ports:
           - 1521:1521
         env:
-          ORACLE_PWD: nanodbc
-        # The image carries its own health check, which runs the database's own status
-        # script. Only the timing is set here: opening takes several minutes on a runner,
-        # and a check of its own would have to guess at what ready looks like.
+          ORACLE_PASSWORD: nanodbc
+        # The image ships /opt/oracle/healthcheck.sh but declares no health check of its
+        # own, so the script is named here. A faststart image opens in well under a minute.
         options: >-
-          --health-interval 30s
-          --health-timeout 30s
-          --health-retries 40
-          --health-start-period 600s
+          --health-cmd /opt/oracle/healthcheck.sh
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 30
+          --health-start-period 30s
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       start_period: 60s
 
   oracle:
-    image: container-registry.oracle.com/database/free:${ORACLE_VERSION:-latest}
+    image: gvenzl/oracle-free:${ORACLE_VERSION:-23-slim-faststart}
     container_name: nanooracle
     restart: unless-stopped
     # Instant Client is published for x86_64 only.
@@ -107,14 +107,15 @@ services:
     ports:
       - "1521:1521"
     environment:
-      ORACLE_PWD: *default_credential
-    # The image carries its own health check, which runs the database's own status
-    # script, so only the timing is set here.
+      ORACLE_PASSWORD: *default_credential
+    # The image ships a health check script but declares no health check of its own,
+    # so the script is named here. A faststart image opens in well under a minute.
     healthcheck:
-      interval: 30s
-      timeout: 30s
-      retries: 40
-      start_period: 600s
+      test: ["CMD", "/opt/oracle/healthcheck.sh"]
+      interval: 10s
+      timeout: 10s
+      retries: 30
+      start_period: 30s
 
   nanodbc:
     build:


### PR DESCRIPTION
Container start dominated the Oracle job. Step timings from the run on #511:

```
 174s  Initialize containers
  22s  Build
  17s  Install
   5s  Test
```

231 seconds total, three quarters of it spent opening the database. Service containers are initialized before any step runs, so none of that overlaps with checkout or build.

`gvenzl/oracle-free` carries a prepared database rather than creating one on first boot. Measured locally against `container-registry.oracle.com/database/free:latest`:

| | official | faststart |
|---|---|---|
| ready | ~9 min | 22s |
| on disk | 26.9 GB | 6.03 GB |

Two differences the image needs accounting for, both handled here:

- the password comes from `ORACLE_PASSWORD` rather than `ORACLE_PWD`
- it ships `/opt/oracle/healthcheck.sh` but declares no `HEALTHCHECK`, so the script is named explicitly in the workflow options and the compose `healthcheck` block

## Testing

The suite passes against the new image unchanged — all 64 tests, matching the image it replaces. Verified by running the workflow's own steps (same package list, the Instant Client commands verbatim, the same cmake and ctest invocations) against both images in turn:

```
official:  1/1 Test #4: oracle_tests ... Passed  38.09 sec
faststart: 1/1 Test #4: oracle_tests ... Passed  38.11 sec
```

`docker compose config` resolves, and the health check script exits 0 against a running container.

Measured on this PR's own run, against the timings above:

```
 174s -> 66s   Initialize containers
 231s -> 122s  job total
```

Container start still dominates, since the runner pulls the image each time; 6 GB simply pulls faster than 27 GB. The 22 seconds an already-pulled faststart image takes to open is the floor, not what CI sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
