### PR TITLE
Bind a batch held as rows

### DIFF
--- a/doc/use.rst
+++ b/doc/use.rst
@@ -148,6 +148,42 @@ Where a driver walks them, a single statement carrying many rows is faster than 
 None of this applies to a database in the same process. SQLite has no round trip to save and shows no difference between the two.
 
 ******************************************************************************
+Binding a batch held as rows
+******************************************************************************
+
+Parameters are bound a column at a time, an array to each marker, which is the shape the drivers take. Data usually arrives as rows instead, a struct to each, and turning one into the other means a vector per column and a loop to fill them.
+
+``bind_rows`` does that. Each accessor names one parameter, in the order the markers appear, either as a pointer to a member or as anything callable with a row:
+
+.. code-block:: cpp
+
+    #include <nanodbc/nanodbc.h>
+    #include <vector>
+
+    struct person
+    {
+        long id;
+        nanodbc::string name;
+    };
+
+    int main()
+    {
+        nanodbc::connection conn(NANODBC_TEXT("dsn"));
+        std::vector<person> people{{1, NANODBC_TEXT("Ada")}, {2, NANODBC_TEXT("Grace")}};
+
+        nanodbc::statement stmt(conn);
+        prepare(stmt, NANODBC_TEXT("insert into people (id, name) values (?, ?)"));
+        bind_rows(stmt, people, &person::id, &person::name);
+        execute(stmt, people.size());
+    }
+
+The values are copied into the statement, so the rows are free to go out of scope before it runs. The overloads of ``bind`` taking a pointer bind the caller's buffer instead, which has to stay alive and unchanged until execution.
+
+Built as C++17 or later, an accessor yielding ``std::optional`` binds an absent value as null, which is how a nullable column is filled from a row that has no value for it.
+
+What reaches the driver is a parameter array either way, so this is the same batch described above, and the same limits apply to how far it carries.
+
+******************************************************************************
 Examples
 ******************************************************************************
 

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2652,6 +2652,14 @@ public:
         bool const* nulls = nullptr,
         T const* null_sentry = nullptr);
 
+    // takes a copy of the values, so that the caller's vector need not outlive the bind
+    template <class T>
+    void bind_vector(
+        param_direction direction,
+        short param_index,
+        std::vector<T> const& values,
+        bool const* nulls = nullptr);
+
     // handles multiple binary values
     void bind(
         param_direction direction,
@@ -2817,6 +2825,10 @@ private:
     std::map<short, std::vector<wide_string::value_type>> wide_string_data_;
     std::map<short, std::vector<std::string::value_type>> string_data_;
     std::map<short, std::vector<uint8_t>> binary_data_;
+    // Values the statement holds on behalf of a caller who bound a vector, kept as bytes
+    // because one statement's parameters are of no single type. ODBC reads a bound buffer
+    // when the statement executes, so these have to outlive the bind.
+    std::map<short, std::vector<uint8_t>> value_data_;
     std::map<short, bound_parameter> param_descr_data_;
 
 #if defined(NANODBC_DO_ASYNC_IMPL)
@@ -2869,6 +2881,24 @@ void statement::statement_impl::bind(
 
     bound_buffer<T> buffer(values, batch_size);
     bind_parameter(param, buffer);
+}
+
+template <class T>
+void statement::statement_impl::bind_vector(
+    param_direction direction,
+    short param_index,
+    std::vector<T> const& values,
+    bool const* nulls)
+{
+    // The values move to where the statement can keep them, the caller's vector being
+    // under no obligation to outlive the bind. Binding a parameter again replaces
+    // whatever was held for it.
+    auto& owned = value_data_[param_index];
+    owned.resize(values.size() * sizeof(T));
+    if (!values.empty())
+        std::memcpy(owned.data(), values.data(), owned.size());
+
+    bind(direction, param_index, reinterpret_cast<T const*>(owned.data()), values.size(), nulls);
 }
 
 template <class T, typename>
@@ -6347,7 +6377,11 @@ short statement::parameter_type(short param_index) const
     template void statement::bind(                                                                 \
         short, const type*, std::size_t, const type*, param_direction); /* n-ary, sentry */        \
     template void statement::bind(                                                                 \
-        short, const type*, std::size_t, const bool*, param_direction) /* n-ary, flags */
+        short, const type*, std::size_t, const bool*, param_direction); /* n-ary, flags */         \
+    template void statement::bind(                                                                 \
+        short, std::vector<type> const&, param_direction); /* vector, copied */                    \
+    template void statement::bind(                                                                 \
+        short, std::vector<type> const&, const bool*, param_direction) /* vector, flags */
 
 #define NANODBC_INSTANTIATE_BIND_VECTOR_STRINGS(type)                                              \
     template void statement::bind_strings(short, std::vector<type> const&, param_direction);       \
@@ -6468,6 +6502,22 @@ void statement::bind(
     param_direction direction)
 {
     impl_->bind(direction, param_index, values, nullptr, null_sentry);
+}
+
+template <class T>
+void statement::bind(short param_index, std::vector<T> const& values, param_direction direction)
+{
+    impl_->bind_vector(direction, param_index, values);
+}
+
+template <class T>
+void statement::bind(
+    short param_index,
+    std::vector<T> const& values,
+    bool const* nulls,
+    param_direction direction)
+{
+    impl_->bind_vector(direction, param_index, values, nulls);
 }
 
 template <class T, typename>

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1326,6 +1326,25 @@ public:
         uint8_t const* null_sentry,
         param_direction direction = PARAM_IN);
 
+    /// \brief Binds multiple values, holding a copy of them.
+    ///
+    /// The overloads taking a pointer bind the caller's buffer, which has to stay alive
+    /// and unchanged until the statement has been executed. These take a copy instead, so
+    /// the vector is free to go out of scope.
+    /// \see bind_multi
+    template <class T>
+    void
+    bind(short param_index, std::vector<T> const& values, param_direction direction = PARAM_IN);
+
+    /// \brief Binds multiple values, holding a copy of them.
+    /// \see bind_multi
+    template <class T>
+    void bind(
+        short param_index,
+        std::vector<T> const& values,
+        bool const* nulls,
+        param_direction direction = PARAM_IN);
+
     /// @}
 
     /// \addtogroup bind_strings Binding multiple string values
@@ -2831,6 +2850,221 @@ void just_execute(
     string const& query,
     long batch_operations = 1,
     long timeout = 0);
+
+/// \brief Implementation details, not part of the interface.
+namespace detail
+{
+
+/// \brief Reads a member through a pointer to it.
+template <class Row, class Member, class Class>
+Member const& read_field(Row const& row, Member Class::* field)
+{
+    return row.*field;
+}
+
+/// \brief Reads a value by calling something with the row.
+template <class Row, class Accessor>
+auto read_field(Row const& row, Accessor const& accessor) -> decltype(accessor(row))
+{
+    return accessor(row);
+}
+
+/// \brief The type an accessor yields for a row, stripped of reference and const.
+template <class Row, class Accessor>
+struct field_type
+{
+    using type = typename std::decay<
+        decltype(read_field(std::declval<Row const&>(), std::declval<Accessor const&>()))>::type;
+};
+
+template <class T>
+struct is_optional : std::false_type
+{
+};
+
+#ifdef NANODBC_HAS_STD_OPTIONAL
+template <class T>
+struct is_optional<std::optional<T>> : std::true_type
+{
+};
+#endif
+
+template <class T>
+struct is_bindable_string : std::false_type
+{
+};
+
+template <>
+struct is_bindable_string<std::string> : std::true_type
+{
+};
+
+template <>
+struct is_bindable_string<wide_string> : std::true_type
+{
+};
+
+// Four ways to bind a column, told apart by what the accessor yields.
+struct bind_as_value
+{
+};
+struct bind_as_string
+{
+};
+struct bind_as_optional_value
+{
+};
+struct bind_as_optional_string
+{
+};
+
+template <class T, bool IsOptional = is_optional<T>::value>
+struct bind_kind
+{
+    using type = typename std::
+        conditional<is_bindable_string<T>::value, bind_as_string, bind_as_value>::type;
+};
+
+#ifdef NANODBC_HAS_STD_OPTIONAL
+template <class T>
+struct bind_kind<T, true>
+{
+    using type = typename std::conditional<
+        is_bindable_string<typename T::value_type>::value,
+        bind_as_optional_string,
+        bind_as_optional_value>::type;
+};
+#endif
+
+template <class Rows, class Accessor>
+void bind_column(
+    statement& stmt,
+    short param_index,
+    Rows const& rows,
+    Accessor const& accessor,
+    bind_as_value)
+{
+    using value_type = typename field_type<typename Rows::value_type, Accessor>::type;
+    std::vector<value_type> column;
+    column.reserve(rows.size());
+    for (auto const& row : rows)
+        column.push_back(read_field(row, accessor));
+    stmt.bind(param_index, column);
+}
+
+template <class Rows, class Accessor>
+void bind_column(
+    statement& stmt,
+    short param_index,
+    Rows const& rows,
+    Accessor const& accessor,
+    bind_as_string)
+{
+    using value_type = typename field_type<typename Rows::value_type, Accessor>::type;
+    std::vector<value_type> column;
+    column.reserve(rows.size());
+    for (auto const& row : rows)
+        column.push_back(read_field(row, accessor));
+    stmt.bind_strings(param_index, column);
+}
+
+#ifdef NANODBC_HAS_STD_OPTIONAL
+// An absent value still occupies its place in the column, so that the values line up with
+// the flags marking which of them are null.
+template <class Rows, class Accessor, class Column>
+std::unique_ptr<bool[]> gather_optional(Rows const& rows, Accessor const& accessor, Column& column)
+{
+    std::unique_ptr<bool[]> nulls(new bool[rows.size()]);
+    std::size_t i = 0;
+    for (auto const& row : rows)
+    {
+        auto const& value = read_field(row, accessor);
+        nulls[i++] = !value.has_value();
+        column.push_back(value ? *value : typename Column::value_type());
+    }
+    return nulls;
+}
+
+template <class Rows, class Accessor>
+void bind_column(
+    statement& stmt,
+    short param_index,
+    Rows const& rows,
+    Accessor const& accessor,
+    bind_as_optional_value)
+{
+    using optional_type = typename field_type<typename Rows::value_type, Accessor>::type;
+    std::vector<typename optional_type::value_type> column;
+    column.reserve(rows.size());
+    auto const nulls = gather_optional(rows, accessor, column);
+    stmt.bind(param_index, column, nulls.get());
+}
+
+template <class Rows, class Accessor>
+void bind_column(
+    statement& stmt,
+    short param_index,
+    Rows const& rows,
+    Accessor const& accessor,
+    bind_as_optional_string)
+{
+    using optional_type = typename field_type<typename Rows::value_type, Accessor>::type;
+    std::vector<typename optional_type::value_type> column;
+    column.reserve(rows.size());
+    auto const nulls = gather_optional(rows, accessor, column);
+    stmt.bind_strings(param_index, column, nulls.get());
+}
+#endif
+
+template <class Rows, class Accessor>
+void bind_one(statement& stmt, short param_index, Rows const& rows, Accessor const& accessor)
+{
+    using value_type = typename field_type<typename Rows::value_type, Accessor>::type;
+    bind_column(stmt, param_index, rows, accessor, typename bind_kind<value_type>::type());
+}
+
+} // namespace detail
+
+/// \brief Binds a range of rows, a parameter at a time.
+///
+/// Parameters are bound column-wise, which is what the ODBC drivers expect, from rows held
+/// however the caller finds convenient. Each accessor names one parameter, in the order the
+/// placeholders appear: either a pointer to a member, or anything callable with a row.
+///
+/// \code
+/// struct person
+/// {
+///     long id;
+///     nanodbc::string name;
+/// };
+///
+/// std::vector<person> people = load();
+/// nanodbc::statement stmt(conn);
+/// prepare(stmt, NANODBC_TEXT("insert into people (id, name) values (?, ?)"));
+/// bind_rows(stmt, people, &person::id, &person::name);
+/// execute(stmt, people.size());
+/// \endcode
+///
+/// Where the library is built as C++17 or later, an accessor yielding std::optional binds
+/// an absent value as null.
+///
+/// The values are copied into the statement, so the rows are free to go out of scope
+/// before it is executed.
+///
+/// \param stmt The prepared statement to bind to.
+/// \param rows The rows to bind, a container with size() whose values the accessors read.
+/// \param accessors One per parameter marker, left to right.
+/// \throws database_error
+/// \see statement::bind(), statement::bind_strings(), execute()
+template <class Rows, class... Accessors>
+void bind_rows(statement& stmt, Rows const& rows, Accessors const&... accessors)
+{
+    short param_index = 0;
+    // Expanded through a braced list, which C++14 orders left to right where a fold
+    // expression is not yet available.
+    int const sequence[] = {0, (detail::bind_one(stmt, param_index++, rows, accessors), 0)...};
+    (void)sequence;
+}
 
 /// \brief Execute the previously prepared query now.
 /// \param stmt The prepared statement that will be executed.

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -249,6 +249,16 @@ TEST_CASE_METHOD(mssql_fixture, "test_batch_insert_mixed", "[mssql][batch]")
     test_batch_insert_mixed();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_bind_rows", "[mssql][batch][bind_rows]")
+{
+    test_bind_rows();
+}
+
+TEST_CASE_METHOD(mssql_fixture, "test_bind_rows_null", "[mssql][batch][bind_rows]")
+{
+    test_bind_rows_null();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_std_optional", "[mssql][optional]")
 {
     test_std_optional();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -156,6 +156,16 @@ TEST_CASE_METHOD(mysql_fixture, "test_batch_insert_mixed", "[mysql][batch]")
     test_batch_insert_mixed();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_bind_rows", "[mysql][batch][bind_rows]")
+{
+    test_bind_rows();
+}
+
+TEST_CASE_METHOD(mysql_fixture, "test_bind_rows_null", "[mysql][batch][bind_rows]")
+{
+    test_bind_rows_null();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_std_optional", "[mysql][optional]")
 {
     test_std_optional();

--- a/test/oracle_test.cpp
+++ b/test/oracle_test.cpp
@@ -32,6 +32,16 @@ TEST_CASE_METHOD(oracle_fixture, "test_batch_insert_mixed", "[oracle][batch]")
     test_batch_insert_mixed();
 }
 
+TEST_CASE_METHOD(oracle_fixture, "test_bind_rows", "[oracle][batch][bind_rows]")
+{
+    test_bind_rows();
+}
+
+TEST_CASE_METHOD(oracle_fixture, "test_bind_rows_null", "[oracle][batch][bind_rows]")
+{
+    test_bind_rows_null();
+}
+
 TEST_CASE_METHOD(oracle_fixture, "test_batch_insert_null", "[oracle][batch][null]")
 {
     test_batch_insert_null();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -94,6 +94,16 @@ TEST_CASE_METHOD(postgresql_fixture, "test_batch_insert_mixed", "[postgresql][ba
     test_batch_insert_mixed();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "test_bind_rows", "[postgresql][batch][bind_rows]")
+{
+    test_bind_rows();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "test_bind_rows_null", "[postgresql][batch][bind_rows]")
+{
+    test_bind_rows_null();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_std_optional", "[postgresql][optional]")
 {
     test_std_optional();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -137,6 +137,16 @@ TEST_CASE_METHOD(sqlite_fixture, "test_batch_insert_mixed", "[sqlite][batch]")
     test_batch_insert_mixed();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_bind_rows", "[sqlite][batch][bind_rows]")
+{
+    test_bind_rows();
+}
+
+TEST_CASE_METHOD(sqlite_fixture, "test_bind_rows_null", "[sqlite][batch][bind_rows]")
+{
+    test_bind_rows_null();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_batch_insert_string", "[sqlite][batch][string]")
 {
     test_batch_insert_string();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -304,6 +304,113 @@ struct test_case_fixture : public base_test_fixture
         }
     }
 
+    void test_bind_rows()
+    {
+        struct row
+        {
+            int i;
+            nanodbc::string s;
+            float f;
+        };
+
+        auto conn = connect();
+        create_table(
+            conn, NANODBC_TEXT("test_bind_rows"), NANODBC_TEXT("(i int, s varchar(60), f float)"));
+
+        nanodbc::statement stmt(conn);
+        prepare(stmt, NANODBC_TEXT("insert into test_bind_rows (i, s, f) values (?, ?, ?)"));
+        REQUIRE(stmt.parameters() == 3);
+
+        std::size_t const batch_size = 3;
+        {
+            std::vector<row> rows{
+                {1, NANODBC_TEXT("first"), 1.5f},
+                {2, NANODBC_TEXT("second"), 2.5f},
+                {3, NANODBC_TEXT("third"), 3.5f}};
+
+            // The last parameter is read by a call rather than named as a member, since
+            // both are allowed.
+            nanodbc::bind_rows(stmt, rows, &row::i, &row::s, [](row const& r) { return r.f; });
+        }
+
+        // The rows are out of scope by here. What the statement executes is its own copy.
+        nanodbc::execute(stmt, batch_size);
+
+        auto result = nanodbc::execute(
+            conn, NANODBC_TEXT("select i, s, f from test_bind_rows order by i asc"));
+
+        REQUIRE(result.next());
+        REQUIRE(result.get<int>(0) == 1);
+        REQUIRE(result.get<nanodbc::string>(1) == NANODBC_TEXT("first"));
+        REQUIRE(result.get<float>(2) == Catch::Approx(1.5f));
+
+        REQUIRE(result.next());
+        REQUIRE(result.get<int>(0) == 2);
+        REQUIRE(result.get<nanodbc::string>(1) == NANODBC_TEXT("second"));
+        REQUIRE(result.get<float>(2) == Catch::Approx(2.5f));
+
+        REQUIRE(result.next());
+        REQUIRE(result.get<int>(0) == 3);
+        REQUIRE(result.get<nanodbc::string>(1) == NANODBC_TEXT("third"));
+        REQUIRE(result.get<float>(2) == Catch::Approx(3.5f));
+
+        REQUIRE(!result.next());
+    }
+
+    void test_bind_rows_null()
+    {
+#ifdef NANODBC_HAS_STD_OPTIONAL
+        struct row
+        {
+            int i;
+            std::optional<nanodbc::string> s;
+            std::optional<float> f;
+        };
+
+        auto conn = connect();
+        create_table(
+            conn,
+            NANODBC_TEXT("test_bind_rows_null"),
+            NANODBC_TEXT("(i int, s varchar(60), f float)"));
+
+        nanodbc::statement stmt(conn);
+        prepare(stmt, NANODBC_TEXT("insert into test_bind_rows_null (i, s, f) values (?, ?, ?)"));
+
+        std::vector<row> rows{
+            {1, nanodbc::string(NANODBC_TEXT("present")), 1.5f},
+            {2, std::nullopt, std::nullopt},
+            {3, nanodbc::string(NANODBC_TEXT("also present")), 3.5f}};
+
+        nanodbc::bind_rows(stmt, rows, &row::i, &row::s, &row::f);
+        nanodbc::execute(stmt, rows.size());
+
+        auto result = nanodbc::execute(
+            conn, NANODBC_TEXT("select i, s, f from test_bind_rows_null order by i asc"));
+
+        REQUIRE(result.next());
+        REQUIRE(result.get<int>(0) == 1);
+        REQUIRE(!result.is_null(1));
+        REQUIRE(result.get<nanodbc::string>(1) == NANODBC_TEXT("present"));
+        REQUIRE(!result.is_null(2));
+        REQUIRE(result.get<float>(2) == Catch::Approx(1.5f));
+
+        REQUIRE(result.next());
+        REQUIRE(result.get<int>(0) == 2);
+        REQUIRE(result.is_null(1));
+        REQUIRE(result.is_null(2));
+
+        REQUIRE(result.next());
+        REQUIRE(result.get<int>(0) == 3);
+        REQUIRE(!result.is_null(1));
+        REQUIRE(result.get<nanodbc::string>(1) == NANODBC_TEXT("also present"));
+        REQUIRE(!result.is_null(2));
+
+        REQUIRE(!result.next());
+#else
+        SUCCEED("binding an absent value as null asks for std::optional, so C++17 or later");
+#endif
+    }
+
     template <std::size_t BatchSize, std::size_t MaxValueSize>
     void test_batch_insert_string_template(
         nanodbc::connection& conn,


### PR DESCRIPTION
Closes #443.

Parameters bind a column at a time, an array to each marker, which is the shape the drivers take. Data usually arrives as rows instead, so a caller holding a struct per row has to build a vector per column and fill it — the ten vectors for a ten-member struct that #443 describes.

```cpp
struct person
{
    long id;
    nanodbc::string name;
    nanodbc::timestamp born;
};

std::vector<person> people = load();

nanodbc::statement stmt(conn);
prepare(stmt, NANODBC_TEXT("insert into people (id, name, born) values (?, ?, ?)"));
bind_rows(stmt, people, &person::id, &person::name, &person::born);
execute(stmt, people.size());
```

Each accessor names one parameter, in the order the markers appear, either as a pointer to a member or as anything callable with a row. Built as C++17 or later, an accessor yielding `std::optional` binds an absent value as null.

## What this is not

ODBC has a row-wise parameter binding of its own, setting `SQL_ATTR_PARAM_BIND_TYPE` to the size of the row. That is not what this is. The spec requires each parameter's length/indicator to be a member of the row structure, since `StrLen_or_IndPtr` points into the row and strides with it, and character data has to be a fixed-size array — which excludes any member that is a `std::string`. It would ask callers to lay their types out for ODBC.

Binding stays column-wise here, which is what the drivers are built around, and the transposition the caller was writing by hand moves into the library.

## Lifetime

The columns are copied into the statement. `statement_impl` already owns the buffers it binds for strings and binary values, keyed by parameter index, so this adds one more map of the same kind rather than a new lifetime rule. The rows are free to go out of scope before the statement runs — which the test relies on deliberately.

That rests on two new `bind` overloads taking `std::vector<T>`, which copy rather than binding the caller's buffer. They mirror the existing `bind_strings(short, std::vector<T> const&)` and the binary vector overloads, and are useful on their own, so they are public and documented as copying.

## Testing

`test_bind_rows` covers members and a callable accessor together, and lets the rows fall out of scope before executing so a dangling bind would fail. `test_bind_rows_null` covers `std::optional`, and says so via `SUCCEED` at C++14 rather than passing silently.

Registered for SQLite, PostgreSQL, MySQL, SQL Server and Oracle. Not for Vertica, which has no CI job and which I cannot run here.

Verified at C++17, where the optional path is live — 34 assertions per backend, against 17 at C++14:

```
sqlite      All tests passed (34 assertions in 2 test cases)
postgresql  All tests passed (34 assertions in 2 test cases)
mysql       All tests passed (34 assertions in 2 test cases)
mssql       All tests passed (34 assertions in 2 test cases)
```

Also compiled and linked at C++14, 17 and 20 — the C++14 build is the one that decides whether the `std::optional` machinery is properly guarded — and formatted with clang-format 20, the version CI pins.

The example in `doc/use.rst` is compiled as part of checking it, not only rstcheck'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)