### PR TITLE
Reach the attribute constructors at C++14

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1286,7 +1286,6 @@ public:
         }
     }
 
-#ifdef NANODBC_HAS_STD_VARIANT
     connection_impl(
         string const& dsn,
         string const& user,
@@ -1329,7 +1328,6 @@ public:
             throw;
         }
     }
-#endif
 
     ~connection_impl() noexcept
     {
@@ -5863,7 +5861,6 @@ connection::connection(string const& connection_string, long timeout)
 {
 }
 
-#ifdef NANODBC_HAS_STD_VARIANT
 connection::connection(
     string const& dsn,
     string const& user,
@@ -5877,7 +5874,6 @@ connection::connection(string const& connection_string, std::list<attribute> con
     : impl_(std::make_shared<connection_impl>(connection_string, attributes))
 {
 }
-#endif
 
 connection::~connection() noexcept {}
 
@@ -5901,7 +5897,6 @@ void connection::connect(string const& connection_string, long timeout)
     impl_->connect(connection_string, timeout);
 }
 
-#ifdef NANODBC_HAS_STD_VARIANT
 void connection::connect(
     string const& dsn,
     string const& user,
@@ -5915,7 +5910,6 @@ void connection::connect(string const& connection_string, std::list<attribute> c
 {
     impl_->connect(connection_string, attributes);
 }
-#endif
 
 #if !defined(NANODBC_DISABLE_ASYNC) && defined(SQL_ATTR_ASYNC_DBC_EVENT)
 bool connection::async_connect(

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -884,7 +884,7 @@ public:
         friend class nanodbc::statement::statement_impl;
     };
 #else
-private:
+public:
     class attribute : public nanodbc::attribute
     {
     public:
@@ -1549,7 +1549,7 @@ public:
         friend class nanodbc::connection::connection_impl;
     };
 #else
-private:
+public:
     class attribute : public nanodbc::attribute
     {
     public:
@@ -1602,7 +1602,6 @@ public:
     /// \see connected(), connect()
     explicit connection(string const& connection_string, long timeout = 0);
 
-#ifdef NANODBC_HAS_STD_VARIANT
     /// \brief Create new connection object, set the connection attributes passed as
     /// arguments and connect to the given data source.
     ///
@@ -1632,7 +1631,6 @@ public:
     /// \throws database_error
     /// \see connected(), connect(), attribute
     connection(string const& connection_string, std::list<attribute> const& attributes);
-#endif
     /// \brief Automatically disconnects from the database and frees all associated resources.
     ///
     /// Will not throw even if disconnecting causes some kind of error and raises an exception.
@@ -1669,7 +1667,6 @@ public:
     /// \see connected()
     void connect(string const& connection_string, long timeout = 0);
 
-#ifdef NANODBC_HAS_STD_VARIANT
     /// \brief Set the connection attributes passed by the user, and connect to the given
     /// data source.
     /// \param dsn The name of the data source.
@@ -1691,7 +1688,6 @@ public:
     /// \throws database_error
     /// \see connected(), attribute
     void connect(string const& connection_string, std::list<attribute> const& attributes);
-#endif
 #if !defined(NANODBC_DISABLE_ASYNC)
     /// \brief Initiate an asynchronous connection operation to the given data source.
     ///

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -580,13 +580,11 @@ TEST_CASE_METHOD(
             "in the table in bound col', 'this is the longest text of the three texts in "
             "the table in unbound col');"));
 
-#ifdef NANODBC_HAS_STD_VARIANT
+    // A scrollable cursor, asked for by statement attribute. The value is an integer, so
+    // this reads the same whether or not std::variant is available.
     std::list<nanodbc::statement::attribute> attributes;
     attributes.push_back({SQL_ATTR_CURSOR_TYPE, 0, (std::uintptr_t)SQL_CURSOR_STATIC});
     nanodbc::statement stmt(conn, attributes);
-#else
-    nanodbc::statement stmt(conn);
-#endif
     nanodbc::batch_ops array_sizes;
     array_sizes.rowset_size = rowset_size;
     nanodbc::result results = stmt.execute_direct(


### PR DESCRIPTION
Closes #494.

The constructors taking ODBC attributes could not be called unless the library was built at C++17 or later, which is more than the issue describes — there were two separate causes.

`statement::attribute` and `connection::attribute` are declared in two arms. The `std::variant` arm is `public`, the other was `private`, so at C++14 a caller got:

```
error: class nanodbc::statement::attribute is private within this context
```

Beyond that, the `connection` constructors and `connect()` overloads taking `std::list<attribute>` were inside `#ifdef NANODBC_HAS_STD_VARIANT` altogether. At C++14 they did not exist at all:

```
error: no matching constructor for initialization of 'nanodbc::connection'
note: candidate constructor not viable: no known conversion from
      'std::list<nanodbc::connection::attribute>' to 'long' for 2nd argument
```

## Why the guard was not load-bearing

Attributes are applied by reading `attribute_`, `string_length_` and `value_ptr_`, and both arms of the base class carry all three. The variant-free `attribute` takes a `std::uintptr_t` and is otherwise identical, and `connection_impl`'s `connect()` overloads that do the work were never guarded — only the constructors that call them were. The guarded constructors just `allocate()` and delegate.

Five guards are removed. The one around the variant `attribute`'s own constructor stays, since that walks the alternatives to decide what `value_ptr_` points at and genuinely needs `std::variant`.

## Testing

`test_block_cursor_with_nvarchar` asked for a scrollable cursor by statement attribute at C++17 and fell back to a plain statement below it — the attribute path was never exercised at C++14. That fallback is gone, so the test now covers both, which is what guards this against coming back:

```
C++14: All tests passed (12 assertions in 1 test case)
```

`test_conn_attributes` stays guarded deliberately. It passes a `nanodbc::string` and a `std::string` as the attribute's resource, and only the variant form accepts those; the variant-free `attribute` takes a `std::uintptr_t`.

Library and callers compile and link at C++14, 17 and 20. Formatted with clang-format 20, the version CI pins.

This also unblocks #368, whose fix is to ask for `SQL_CURSOR_STATIC` through exactly this constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)