### PR TITLE
Leave the date and time optionals out of the Oracle suite

### DIFF
--- a/test/oracle_test.cpp
+++ b/test/oracle_test.cpp
@@ -16,6 +16,8 @@ struct oracle_fixture : public test_case_fixture
 
 // Oracle has no TIME type, only DATE and TIMESTAMP, so test_time has nothing to create a
 // column with here and is left out rather than made to pass against a different type.
+// Oracle's DATE carries a time of day, which the driver reports as SQL_TYPE_TIMESTAMP, so
+// test_date is left out on the same grounds.
 
 TEST_CASE_METHOD(oracle_fixture, "test_batch_binary", "[oracle][binary]")
 {

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -5130,8 +5130,14 @@ PRIMARY KEY(t2_fid)
 #ifdef NANODBC_HAS_STD_OPTIONAL
         test_batch_insert_integral_optional();
         test_string_optional();
-        test_time_optional();
-        test_date_optional();
+        // Oracle has no TIME type, and its DATE carries a time of day, which the driver
+        // describes as a timestamp rather than a date. test_time and test_date are left
+        // unregistered there on those grounds, and these assert the same column types.
+        if (vendor_ != database_vendor::oracle)
+        {
+            test_time_optional();
+            test_date_optional();
+        }
 #endif
     }
 };


### PR DESCRIPTION
`test_std_optional` runs four sub-tests, two of which do not apply to Oracle:

- `test_time_optional` creates a `t time` column. Oracle has no TIME type, only DATE and TIMESTAMP.
- `test_date_optional` expects a date column to describe itself as `SQL_TYPE_DATE`. Oracle's DATE carries a time of day, so the driver reports `SQL_TYPE_TIMESTAMP`.

Built at C++17 and run against Oracle Database Free 23, the first throws and the second reads the wrong type:

```
test_std_optional
  HY003: [Oracle][ODBC][Ora]ORA-00902: invalid datatype
```

```
test_std_optional
  REQUIRE( result.column_datatype(0) == 91 )
with expansion:
  93 == 91
```

`test_time` and `test_date` are already left unregistered for Oracle on exactly those grounds, so the optional forms follow them. The comment in `oracle_test.cpp` explained only the TIME exclusion and said nothing about DATE; both are now written down.

`test_batch_insert_integral_optional` and `test_string_optional` still run, so the C++17 optional path keeps its coverage on Oracle.

## Why CI did not catch this

Every `test-*` job builds at the CMake default of C++14, where `NANODBC_HAS_STD_OPTIONAL` is undefined and the entire test compiles to nothing. The job reported green against a suite it was not running. That gap is #514 and is not addressed here.

## Testing

The full Oracle suite at C++17, against a real Oracle Database Free 23 through Instant Client 23:

```
before: test cases: 64 | 63 passed | 1 failed
after:  All tests passed (1073 assertions in 64 test cases)
```

The two failures came out one at a time — fixing the TIME case exposed the DATE case underneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)