### PR TITLE
Cover reading a result other than forwards

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,10 @@ jobs:
           DOCS_DIR: "doc/"
       - name: Install rstcheck
         run: python3 -m pip install --disable-pip-version-check "rstcheck[sphinx]==6.3.0"
+      # rstcheck compiles the C++ blocks, and the ones reaching for an ODBC constant need
+      # the ODBC headers to compile at all.
+      - name: Install ODBC headers
+        run: sudo apt-get -o DPkg::Lock::Timeout=120 install -y unixodbc-dev
       - name: Run rstcheck
         run: rstcheck doc/*.rst
 

--- a/doc/use.rst
+++ b/doc/use.rst
@@ -184,6 +184,49 @@ Built as C++17 or later, an accessor yielding ``std::optional`` binds an absent 
 What reaches the driver is a parameter array either way, so this is the same batch described above, and the same limits apply to how far it carries.
 
 ******************************************************************************
+Reading a result other than forwards
+******************************************************************************
+
+``next()`` works on any result. ``first()``, ``last()``, ``prior()``, ``move()`` and ``skip()`` ask the driver to fetch somewhere other than the next row, and a cursor has to be able to scroll for that. ODBC does not give one by default, so the calls fail:
+
+.. code-block:: text
+
+    HY106: [Microsoft][ODBC Driver 18 for SQL Server]Fetch type out of range
+
+``position()`` reporting zero comes from the same place.
+
+The cursor type is a statement attribute, set before the statement runs:
+
+.. code-block:: cpp
+
+    #include <nanodbc/nanodbc.h>
+    #include <cstdint>
+    #include <list>
+    #include <sql.h>
+    #include <sqlext.h>
+
+    int main()
+    {
+        nanodbc::connection conn(NANODBC_TEXT("dsn"));
+
+        std::list<nanodbc::statement::attribute> attributes;
+        attributes.push_back({SQL_ATTR_CURSOR_TYPE, 0, (std::uintptr_t)SQL_CURSOR_STATIC});
+
+        nanodbc::statement stmt(conn, attributes);
+        prepare(stmt, NANODBC_TEXT("select i from t order by i asc"));
+        auto results = execute(stmt);
+
+        results.last();
+        results.prior();
+        results.first();
+        results.move(2);  // absolute, counted from one
+    }
+
+``SQL_CURSOR_STATIC`` takes a snapshot of the rows and scrolls over it. ``SQL_CURSOR_DYNAMIC`` and ``SQL_CURSOR_KEYSET_DRIVEN`` scroll as well and see later changes to differing degrees, at a cost the driver decides. A scrolling cursor is dearer than the forward only one, which is why it is not what you get without asking.
+
+SQL Server, PostgreSQL, MySQL, SQLite and Oracle all honour ``SQL_CURSOR_STATIC`` through their ODBC drivers. A driver that cannot give the cursor asked for is free to substitute another and say so through ``SQLGetDiagRec`` rather than to fail, so a result that still will not scroll is worth checking the diagnostics for.
+
+******************************************************************************
 Examples
 ******************************************************************************
 

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1914,8 +1914,12 @@ public:
     bool prior();
 
     /// \brief Moves to and fetches the specified row in the current result set.
+    /// \param row The row to fetch, counted from one.
     /// \return true if there are results or false otherwise.
     /// \throws database_error
+    /// \attention Fetching anywhere other than forward asks the driver for a cursor that
+    ///            scrolls, which ODBC does not give by default. Without one the call fails
+    ///            with HY106. \see statement::attribute, SQL_ATTR_CURSOR_TYPE
     bool move(long row);
 
     /// \brief Skips a number of rows and then fetches the resulting row in the current result set.

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -1234,6 +1234,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_result_rowset_navigation", "[mssql][result
     test_result_rowset_navigation();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_scrollable_cursor", "[mssql][result][cursor][scroll]")
+{
+    test_scrollable_cursor();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_execute_direct_batch_ops", "[mssql][statement][batch]")
 {
     test_execute_direct_batch_ops();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -413,6 +413,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_result_rowset_navigation", "[mysql][result
     test_result_rowset_navigation();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_scrollable_cursor", "[mysql][result][cursor][scroll]")
+{
+    test_scrollable_cursor();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_execute_direct_batch_ops", "[mysql][statement][batch]")
 {
     test_execute_direct_batch_ops();

--- a/test/oracle_test.cpp
+++ b/test/oracle_test.cpp
@@ -284,6 +284,11 @@ TEST_CASE_METHOD(oracle_fixture, "test_result_rowset_navigation", "[oracle][resu
     test_result_rowset_navigation();
 }
 
+TEST_CASE_METHOD(oracle_fixture, "test_scrollable_cursor", "[oracle][result][cursor][scroll]")
+{
+    test_scrollable_cursor();
+}
+
 TEST_CASE_METHOD(oracle_fixture, "test_result_unbind", "[oracle][result][unbind]")
 {
     test_result_unbind();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -362,6 +362,14 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     postgresql_fixture,
+    "test_scrollable_cursor",
+    "[postgresql][result][cursor][scroll]")
+{
+    test_scrollable_cursor();
+}
+
+TEST_CASE_METHOD(
+    postgresql_fixture,
     "test_execute_direct_batch_ops",
     "[postgresql][statement][batch]")
 {

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -481,6 +481,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_result_rowset_navigation", "[sqlite][resu
     test_result_rowset_navigation();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_scrollable_cursor", "[sqlite][result][cursor][scroll]")
+{
+    test_scrollable_cursor();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_execute_direct_batch_ops", "[sqlite][statement][batch]")
 {
     test_execute_direct_batch_ops();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <list>
 #include <random>
 #include <set>
 #include <tuple>
@@ -1693,6 +1694,43 @@ struct test_case_fixture : public base_test_fixture
             {
             }
         }
+    }
+
+    // first(), last(), prior() and move() ask the driver to fetch somewhere other than
+    // forward, which a forward only cursor refuses with HY106. ODBC leaves the cursor
+    // forward only unless asked otherwise, so the statement asks.
+    void test_scrollable_cursor()
+    {
+        auto connection = connect();
+        create_table(connection, NANODBC_TEXT("test_scrollable_cursor"), NANODBC_TEXT("(i int)"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_scrollable_cursor (i) values (1), (2), (3);"));
+
+        std::list<nanodbc::statement::attribute> attributes;
+        attributes.push_back({SQL_ATTR_CURSOR_TYPE, 0, (std::uintptr_t)SQL_CURSOR_STATIC});
+        nanodbc::statement statement(connection, attributes);
+        prepare(statement, NANODBC_TEXT("select i from test_scrollable_cursor order by i asc;"));
+        auto results = execute(statement);
+
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == 1);
+
+        REQUIRE(results.last());
+        REQUIRE(results.get<int>(0) == 3);
+
+        REQUIRE(results.prior());
+        REQUIRE(results.get<int>(0) == 2);
+
+        REQUIRE(results.first());
+        REQUIRE(results.get<int>(0) == 1);
+
+        // An absolute row number, which ODBC counts from one.
+        REQUIRE(results.move(3));
+        REQUIRE(results.get<int>(0) == 3);
+
+        REQUIRE(results.move(1));
+        REQUIRE(results.get<int>(0) == 1);
     }
 
     // batch_ops chooses the parameter array length and the rowset size separately, where


### PR DESCRIPTION
Closes #368.

**Stacked on #515** — the recipe below cannot be written at C++14 until that lands, which is why the issue has sat with a known answer and no fix. GitHub will retarget this to `main` once #515 merges.

`first()`, `last()`, `prior()`, `move()` and `skip()` ask the driver to fetch somewhere other than the next row. ODBC gives a forward only cursor unless asked otherwise, which refuses them:

```
HY106: [Microsoft][ODBC Driver 18 for SQL Server]Fetch type out of range
```

The one test touching those calls wrapped them in `try { ... } catch (nanodbc::database_error const&) {}` and carried on, with a comment noting that a forward only cursor rejects the reposition. So nothing anywhere asserted that scrolling worked — failure was an accepted outcome.

`test_scrollable_cursor` asks for a scrollable cursor and checks the navigation lands on the rows it should, with nothing caught.

## Portability

Scrolling is the driver's to offer, so this was measured rather than assumed. All five honour `SQL_CURSOR_STATIC`, at C++14:

```
sqlite       All tests passed (14 assertions in 1 test case)
postgresql   All tests passed (14 assertions in 1 test case)
mysql        All tests passed (14 assertions in 1 test case)
mssql        All tests passed (14 assertions in 1 test case)
oracle       All tests passed (14 assertions in 1 test case)
```

Oracle was run through an amd64 container against Oracle Database Free 23, Instant Client being published for x86_64 only.

## move() counts from one

`move()` hands its argument to `SQLFetchScroll` as `SQL_FETCH_ABSOLUTE`, which ODBC counts from one. The documentation did not say so, and the first draft of this test asserted the other convention and failed. That is now on the declaration, together with a note that scrolling needs a cursor that can do it.

## Documentation

`doc/use.rst` gains a section covering the symptom, the recipe, and what the cursor types cost.

The lint job installs `unixodbc-dev`: rstcheck compiles the C++ blocks it finds, and this example reaches for `SQL_ATTR_CURSOR_TYPE`, so without the headers it cannot compile at all. Suppressing the error in `.rstcheck.cfg` would have left the example unchecked; this way it is genuinely compiled. Verified locally that `rstcheck doc/*.rst` passes once the headers are findable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)