### PR TITLE
Cover setting connection attributes before connecting

### DIFF
--- a/doc/use.rst
+++ b/doc/use.rst
@@ -266,6 +266,36 @@ The rowset size is what to vary if the read is slow. Its effect is the same as t
 ``batch_ops`` sets the rowset size where a statement also carries parameters, so that the two are chosen separately.
 
 ******************************************************************************
+Setting connection attributes
+******************************************************************************
+
+Some ODBC connection attributes govern how the connection is made, so they have to reach the driver before it connects rather than after. The constructors and ``connect()`` overloads taking a list of attributes set them on the handle between allocating it and connecting with it:
+
+.. code-block:: cpp
+
+    #include <nanodbc/nanodbc.h>
+    #include <cstdint>
+    #include <list>
+    #include <sql.h>
+    #include <sqlext.h>
+
+    int main()
+    {
+        std::list<nanodbc::connection::attribute> attributes;
+        attributes.push_back({SQL_ATTR_LOGIN_TIMEOUT, SQL_IS_UINTEGER, (std::uintptr_t)30});
+
+        nanodbc::connection conn(NANODBC_TEXT("dsn"), attributes);
+
+        // or, on a connection that has not connected yet
+        nanodbc::connection other;
+        other.connect(NANODBC_TEXT("dsn"), attributes);
+    }
+
+Allocating a connection and setting attributes on it by hand before calling ``connect()`` does not work, and is not meant to: ``connect()`` frees the handle it is given and allocates another, so anything set on the old one goes with it. The overloads above are how the ordering is expressed.
+
+Where the library is built as C++17 or later, an attribute's value may also be a string or a binary buffer, which it holds for as long as the attribute lives. Below that the value is a ``std::uintptr_t``, which covers the integer attributes.
+
+******************************************************************************
 Examples
 ******************************************************************************
 

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -941,6 +941,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_connection_environment", "[mssql][connecti
     test_connection_environment();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_connection_attributes", "[mssql][connection][attributes]")
+{
+    test_connection_attributes();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_dbms_info", "[mssql][dmbs][metadata][info]")
 {
     test_dbms_info();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -231,6 +231,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_connection_environment", "[mysql][connecti
     test_connection_environment();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_connection_attributes", "[mysql][connection][attributes]")
+{
+    test_connection_attributes();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_dbms_info", "[mysql][dmbs][metadata][info]")
 {
     test_dbms_info();

--- a/test/oracle_test.cpp
+++ b/test/oracle_test.cpp
@@ -117,6 +117,11 @@ TEST_CASE_METHOD(oracle_fixture, "test_connection_environment", "[oracle][connec
     test_connection_environment();
 }
 
+TEST_CASE_METHOD(oracle_fixture, "test_connection_attributes", "[oracle][connection][attributes]")
+{
+    test_connection_attributes();
+}
+
 TEST_CASE_METHOD(oracle_fixture, "test_datasources", "[oracle][datasources]")
 {
     test_datasources();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -166,6 +166,14 @@ TEST_CASE_METHOD(postgresql_fixture, "test_connection_environment", "[postgresql
     test_connection_environment();
 }
 
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_connection_attributes",
+    "[postgresql][connection][attributes]")
+{
+    test_connection_attributes();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_dbms_info", "[postgresql][dmbs][metadata][info]")
 {
     test_dbms_info();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -240,6 +240,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_connection_environment", "[sqlite][connec
     test_connection_environment();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_connection_attributes", "[sqlite][connection][attributes]")
+{
+    test_connection_attributes();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_date", "[sqlite][date]")
 {
     test_date();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -5333,6 +5333,37 @@ PRIMARY KEY(t2_fid)
         }
     }
 
+    // Connection attributes have to reach the driver before it connects, since that is
+    // what several of them govern. The overloads taking a list set them on the handle
+    // between allocating it and connecting with it.
+    void test_connection_attributes()
+    {
+        std::list<nanodbc::connection::attribute> attributes;
+        attributes.push_back({SQL_ATTR_LOGIN_TIMEOUT, SQL_IS_UINTEGER, (std::uintptr_t)30});
+
+        // Constructed with the attributes, which connects.
+        {
+            nanodbc::connection connection(connection_string_, attributes);
+            REQUIRE(connection.connected());
+
+            auto results = execute(connection, NANODBC_TEXT("select 1;"));
+            REQUIRE(results.next());
+            REQUIRE(results.get<int>(0) == 1);
+        }
+
+        // And the same by way of connect(), on a connection that has none yet.
+        {
+            nanodbc::connection connection;
+            REQUIRE(!connection.connected());
+            connection.connect(connection_string_, attributes);
+            REQUIRE(connection.connected());
+
+            auto results = execute(connection, NANODBC_TEXT("select 1;"));
+            REQUIRE(results.next());
+            REQUIRE(results.get<int>(0) == 1);
+        }
+    }
+
     void test_std_optional()
     {
 #ifdef NANODBC_HAS_STD_OPTIONAL


### PR DESCRIPTION
Closes #215.

The issue reports that `SQLSetConnectAttr` cannot be called on a connection's handle before `connect()`, having noticed that `connect()` reallocates the handle unconditionally. That reading of the code is right:

```cpp
allocate_env_handle(env_);
disconnect();

deallocate_handle(dbc_, SQL_HANDLE_DBC);   // the handle you configured, freed
allocate_dbc_handle(dbc_, env_);
```

So the sequence suggested in the thread —

```cpp
nanodbc::connection c;
c.allocate();
c.set_attribute(...);
c.connect(...);
```

— cannot work, and could not be written anyway: `connection::set_attribute` is not public.

**What the issue asks for is nevertheless supported**, through the overloads taking a list of attributes. They set each one on the handle after allocating it and before connecting with it:

```cpp
std::list<nanodbc::connection::attribute> attributes;
attributes.push_back({SQL_ATTR_LOGIN_TIMEOUT, SQL_IS_UINTEGER, (std::uintptr_t)30});

nanodbc::connection conn(NANODBC_TEXT("dsn"), attributes);

nanodbc::connection other;
other.connect(NANODBC_TEXT("dsn"), attributes);
```

Confirmed in `connection_impl::connect`, where the loop calling `set_attribute` runs ahead of the `SQLConnect` call.

Two things kept this from being the obvious answer. Until #515 these overloads did not exist below C++17, which is the default the project builds at. And the only test covering them, `test_conn_attributes`, is guarded to C++17 because it passes a `nanodbc::string` as an attribute's value, which only the `std::variant` form accepts.

## Testing

`test_connection_attributes` uses an integer attribute, so it compiles in both arms and covers the constructor and `connect()` alike:

```
sqlite       All tests passed (7 assertions in 1 test case)
postgresql   All tests passed (7 assertions in 1 test case)
mysql        All tests passed (7 assertions in 1 test case)
mssql        All tests passed (7 assertions in 1 test case)
```

Built at C++14, which is where none of this was reachable before. Oracle is registered and left to its CI job, Instant Client being x86_64 only.

`doc/use.rst` gains a section covering the ordering, why setting attributes by hand beforehand does not survive, and what an attribute's value may be in each arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)