### PR TITLE
Show how to read many rows into containers

### DIFF
--- a/doc/use.rst
+++ b/doc/use.rst
@@ -227,6 +227,45 @@ The cursor type is a statement attribute, set before the statement runs:
 SQL Server, PostgreSQL, MySQL, SQLite and Oracle all honour ``SQL_CURSOR_STATIC`` through their ODBC drivers. A driver that cannot give the cursor asked for is free to substitute another and say so through ``SQLGetDiagRec`` rather than to fail, so a result that still will not scroll is worth checking the diagnostics for.
 
 ******************************************************************************
+Reading many rows into containers
+******************************************************************************
+
+Results are read a row at a time, and there is no binding of output buffers to read a column straight into a container. What makes a read bulk is the rowset: ``execute`` takes the number of rows to fetch per round trip, and the driver fills that many at once while ``next()`` walks what it fetched.
+
+``get_ref`` reads a column into a variable already to hand rather than returning a new one, which keeps a string's buffer in play across the loop instead of allocating one per row:
+
+.. code-block:: cpp
+
+    #include <nanodbc/nanodbc.h>
+    #include <string>
+    #include <vector>
+
+    int main()
+    {
+        nanodbc::connection conn(NANODBC_TEXT("dsn"));
+
+        // A thousand rows per round trip rather than one.
+        auto results = execute(conn, NANODBC_TEXT("select a, b from t"), 1000);
+
+        std::vector<nanodbc::string> a, b;
+        nanodbc::string value;
+        while (results.next())
+        {
+            results.get_ref(0, value);
+            a.push_back(value);
+
+            results.get_ref(1, value);
+            b.push_back(value);
+        }
+    }
+
+Reserving on the vectors is worth it where the row count is known or can be estimated, since the loop otherwise grows them as it goes.
+
+The rowset size is what to vary if the read is slow. Its effect is the same as the one batch parameters have, described above: the round trip is what costs, and fetching a thousand rows in one is far cheaper than a thousand round trips. Sizes beyond a few thousand rarely pay for the memory they take, since the rowset is held in full.
+
+``batch_ops`` sets the rowset size where a statement also carries parameters, so that the two are chosen separately.
+
+******************************************************************************
 Examples
 ******************************************************************************
 


### PR DESCRIPTION
Closes #163.

The issue asks for an example of a bulk select with STL containers holding the results, and the guide answered it nowhere.

What makes a read bulk is the rowset. `execute` takes the number of rows to fetch per round trip, and the driver fills that many at once while `next()` walks what was fetched. `get_ref` reads a column into a variable already to hand, so a string's buffer stays in play across the loop rather than being allocated once per row:

```cpp
auto results = execute(conn, NANODBC_TEXT("select a, b from t"), 1000);

std::vector<nanodbc::string> a, b;
nanodbc::string value;
while (results.next())
{
    results.get_ref(0, value);
    a.push_back(value);

    results.get_ref(1, value);
    b.push_back(value);
}
```

The last answer on the issue noted that there was no `result::get_ref`. There is now, which is part of why this was worth writing down rather than closing as already covered.

The section also says what to vary when a read is slow — the rowset size, for the same round trip reason batch parameters have, which the guide already covers just above — and points at `batch_ops` for statements carrying parameters too, where the rowset size and the parameter array length are chosen separately.

What this does not add is binding output buffers, so that a column fills a container directly. nanodbc has no such thing, and the example is the way to do it with what exists.

## Testing

rstcheck compiles the C++ blocks in the guide, so the example is known to compile. Compiling is not running, so it was also turned into a real program against SQLite — seeding a table, executing it, and checking what landed in the vectors:

```
example works: 3 rows, a[0]=a1 b[2]=b3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)