### PR TITLE
Report every diagnostic a failure carries

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -580,6 +580,10 @@ recent_error(SQLHANDLE handle, SQLSMALLINT handle_type, long& native, std::strin
     SQLINTEGER native_error = 0;
     SQLSMALLINT total_bytes = 0;
     NANODBC_SQLCHAR sql_state[6] = {0};
+    // ODBC orders the records with the most relevant first, so the state and the native
+    // code are taken from that one however many follow it.
+    NANODBC_SQLCHAR first_sql_state[6] = {0};
+    SQLINTEGER first_native_error = 0;
     RETCODE rc = SQL_SUCCESS;
 
     do
@@ -620,32 +624,31 @@ recent_error(SQLHANDLE handle, SQLSMALLINT handle_type, long& native, std::strin
             return rvalue;
         }
 
+        if (i == 1)
+        {
+            std::copy(std::begin(sql_state), std::end(sql_state), std::begin(first_sql_state));
+            first_native_error = native_error;
+        }
+
         if (!result.empty())
             result += ' ';
 
         result += nanodbc::string(sql_message.begin(), sql_message.end());
         i++;
-
-// NOTE: unixODBC using PostgreSQL and SQLite drivers crash if you call SQLGetDiagRec()
-// more than once. So as a (terrible but the best possible) workaround just exit
-// this loop early on non-Windows systems.
-#ifndef _MSC_VER
-        break;
-#endif
     } while (rc != SQL_NO_DATA);
 
     convert(std::move(result), rvalue);
-    if (size(sql_state) > 0)
+    if (size(first_sql_state) > 0)
     {
         state.clear();
-        state.reserve(size(sql_state));
-        for (std::size_t idx = 0; idx != size(sql_state); ++idx)
+        state.reserve(size(first_sql_state));
+        for (std::size_t idx = 0; idx != size(first_sql_state); ++idx)
         {
-            state.push_back(static_cast<char>(sql_state[idx]));
+            state.push_back(static_cast<char>(first_sql_state[idx]));
         }
     }
 
-    native = native_error;
+    native = first_native_error;
     std::string status = state;
     status += ": ";
     status += rvalue;


### PR DESCRIPTION
Closes #315.

The issue says `recent_error` "captures the last one only". That is not quite it — the loop already joins the records it reads:

```cpp
if (!result.empty())
    result += ' ';
result += nanodbc::string(sql_message.begin(), sql_message.end());
```

What limited it was this, immediately after:

```cpp
// NOTE: unixODBC using PostgreSQL and SQLite drivers crash if you call SQLGetDiagRec()
// more than once. So as a (terrible but the best possible) workaround just exit
// this loop early on non-Windows systems.
#ifndef _MSC_VER
        break;
#endif
```

So everywhere but Windows exactly one record was ever read, and any further diagnostics were dropped.

## The crash it guarded against

Removing the break is only defensible if that crash is gone, so I measured rather than assumed. Instrumenting the loop to count how often a second record is actually read, across the full suites:

```
sqlite       multi-record diagnostics: 0
postgresql   multi-record diagnostics: 7
mysql        multi-record diagnostics: 0
mssql        multi-record diagnostics: 1
```

PostgreSQL — one of the two drivers named in the note — returns several records seven times over its suite and does not crash. SQLite returns one, which still means `SQLGetDiagRec` is called a second time and answers `SQL_NO_DATA`; calling it more than once is precisely what the note warns about, and it is fine.

That mattered to check. Had no driver ever produced more than one record, the suites passing would have said nothing at all about the crash, because the loop would never have run twice.

## State and native code

They were taken from whichever record the loop read last. With the break in place that was the first record on Linux and the last on Windows — the two platforms disagreed.

They now come from the first record explicitly, which is the one ODBC orders as most relevant. Off Windows that is what they already described, so nothing changes there; on Windows they now describe the first record rather than the last. Without this, removing the break would have quietly changed the SQLSTATE every `database_error` reports on Linux, which several tests assert on.

## Testing

```
sqlite       All tests passed (1657 assertions in 89 test cases)
postgresql   All tests passed (5908 assertions in 93 test cases)
mysql        All tests passed (2117 assertions in 90 test cases)
mssql        All tests passed (35767 assertions in 143 test cases)
```

The issue also floats `std::nested_exception`. This does not go there: it changes what is collected without changing the shape of what is thrown, so nothing downstream has to be rewritten to benefit. Nesting remains open as a separate design question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)