### PR TITLE
Build the value before reading a column into an optional

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4269,6 +4269,10 @@ public:
             opt_reset(result);
             return;
         }
+        // The value has to exist before it can be read into. An optional holding nothing
+        // has storage for one but has not built it, and writing into what is not there is
+        // undefined however well it may appear to work for a type that is trivial.
+        result.emplace();
         get_ref_impl<std::remove_reference_t<decltype(*result)>>(column, *result);
 
         // An unbound column's null is only known once SQLGetData has run.
@@ -4327,6 +4331,8 @@ public:
             opt_reset(result);
             return;
         }
+        // As above: the value is built before it is read into.
+        result.emplace();
         get_ref_impl<std::remove_reference_t<decltype(*result)>>(column, *result);
 
         // An unbound column's null is only known once SQLGetData has run.


### PR DESCRIPTION
Closes #525.

`result::get_ref` taking a `std::optional` read the column into `*result` while the optional still held nothing:

```cpp
get_ref_impl<std::remove_reference_t<decltype(*result)>>(column, *result);
```

Dereferencing an optional that holds nothing does not build the value. The storage is there, the object is not, so the column was read into something never constructed. Both overloads did it, the one taking a column index and the one taking a column name.

For a trivial type the bytes land in storage that happens to exist and it appears to work. For a string it is undefined, and crashes once the string is wide:

```
$ cmake -DCMAKE_CXX_STANDARD=17 -DNANODBC_ENABLE_UNICODE=ON ...
$ ./sqlite_tests
exit=139                                  # SIGSEGV
test cases: 13 | 12 passed | 1 failed     # of 89
```

It dies in `test_string_optional`, on `results.get_ref(0, ref)` with `ref` a `std::optional<nanodbc::string>`.

## Why nothing caught it

Two conditions have to meet: `std::optional` needs C++17, and the crash needs a wide string. No job runs both. The test jobs build at the default C++14, where these tests compile to nothing, and the Unicode jobs added recently build at C++14 as well — that is #514, which is what turned this up while adding a C++17 dimension. A narrow C++17 build does not crash, so the C++17 work alone would not have found it either, though it is undefined there too.

## Testing

Every combination the jobs will run, before and after:

```
sqlite      c++14 uni=OFF All tests passed (1657 assertions in 89 test cases)
postgresql  c++14 uni=OFF All tests passed (5924 assertions in 93 test cases)
mssql       c++14 uni=OFF All tests passed (35783 assertions in 143 test cases)
sqlite      c++17 uni=OFF All tests passed (1731 assertions in 89 test cases)
postgresql  c++17 uni=OFF All tests passed (5998 assertions in 93 test cases)
mssql       c++17 uni=OFF All tests passed (35938 assertions in 145 test cases)
sqlite      c++17 uni=ON  All tests passed (1731 assertions in 89 test cases)
mssql       c++17 uni=ON  All tests passed (35928 assertions in 146 test cases)
```

The first of those was the crash: 89 cases now where 13 ran before.

PostgreSQL at C++17 with Unicode still fails 15 cases, 13 of them `HYC00: Unrecognized C_parameter type`, with no crash among them. That is #519, the driver refusing the C type a string parameter binds with, and is untouched here — checked rather than assumed, since a crash fix that left a crash behind would be worth knowing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)