### PR TITLE
Cover a connection to each of several threads

### DIFF
--- a/doc/use.rst
+++ b/doc/use.rst
@@ -296,6 +296,41 @@ Allocating a connection and setting attributes on it by hand before calling ``co
 Where the library is built as C++17 or later, an attribute's value may also be a string or a binary buffer, which it holds for as long as the attribute lives. Below that the value is a ``std::uintptr_t``, which covers the integer attributes.
 
 ******************************************************************************
+Threads
+******************************************************************************
+
+A connection belongs to the thread that made it. Several threads working at once, each with a connection of its own, is the arrangement nanodbc is built for and needs no locking of its own:
+
+.. code-block:: cpp
+
+    #include <nanodbc/nanodbc.h>
+    #include <thread>
+    #include <vector>
+
+    int main()
+    {
+        std::vector<std::thread> threads;
+        for (int t = 0; t < 8; ++t)
+        {
+            threads.emplace_back(
+                []()
+                {
+                    nanodbc::connection conn(NANODBC_TEXT("dsn"));
+                    nanodbc::statement stmt(conn);
+                    prepare(stmt, NANODBC_TEXT("insert into t (i) values (?)"));
+                    // ... bind and execute
+                });
+        }
+
+        for (auto& thread : threads)
+            thread.join();
+    }
+
+Each connection allocates an ODBC environment of its own, so nothing is shared between them and the driver sees one connection per thread, which is what a threading-enabled driver expects.
+
+Sharing one connection between threads is a different matter, and nanodbc makes no guarantee about it. A ``connection``, a ``statement`` and a ``result`` are handles onto driver state; two threads using one at the same time is for the caller to synchronize. Every thread joining before the objects it used go out of scope is the caller's business too — a crash on shutdown is more often threads outliving what they captured than anything the driver did.
+
+******************************************************************************
 Examples
 ******************************************************************************
 

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -946,6 +946,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_connection_attributes", "[mssql][connectio
     test_connection_attributes();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_connection_per_thread", "[mssql][connection][threads]")
+{
+    test_connection_per_thread();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_dbms_info", "[mssql][dmbs][metadata][info]")
 {
     test_dbms_info();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -236,6 +236,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_connection_attributes", "[mysql][connectio
     test_connection_attributes();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_connection_per_thread", "[mysql][connection][threads]")
+{
+    test_connection_per_thread();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_dbms_info", "[mysql][dmbs][metadata][info]")
 {
     test_dbms_info();

--- a/test/oracle_test.cpp
+++ b/test/oracle_test.cpp
@@ -122,6 +122,11 @@ TEST_CASE_METHOD(oracle_fixture, "test_connection_attributes", "[oracle][connect
     test_connection_attributes();
 }
 
+TEST_CASE_METHOD(oracle_fixture, "test_connection_per_thread", "[oracle][connection][threads]")
+{
+    test_connection_per_thread();
+}
+
 TEST_CASE_METHOD(oracle_fixture, "test_datasources", "[oracle][datasources]")
 {
     test_datasources();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -174,6 +174,14 @@ TEST_CASE_METHOD(
     test_connection_attributes();
 }
 
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_connection_per_thread",
+    "[postgresql][connection][threads]")
+{
+    test_connection_per_thread();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_dbms_info", "[postgresql][dmbs][metadata][info]")
 {
     test_dbms_info();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -245,6 +245,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_connection_attributes", "[sqlite][connect
     test_connection_attributes();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_connection_per_thread", "[sqlite][connection][threads]")
+{
+    test_connection_per_thread();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_date", "[sqlite][date]")
 {
     test_date();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -4,12 +4,14 @@
 #include "base_test_fixture.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <limits>
 #include <list>
 #include <random>
 #include <set>
+#include <thread>
 #include <tuple>
 #include <vector>
 
@@ -5415,6 +5417,64 @@ PRIMARY KEY(t2_fid)
         // Trailing space is not checked. Oracle's driver reports its message with a long
         // run of it, counted in the length it gives, so it is the driver's text rather
         // than anything left over from reading it.
+    }
+
+    // A connection belongs to the thread that made it. Several threads working at once,
+    // each with its own, is the arrangement nanodbc asks for, and this is that.
+    void test_connection_per_thread()
+    {
+        std::size_t const thread_count = 8;
+        std::size_t const rows_each = 25;
+
+        auto connection = connect();
+        create_table(
+            connection,
+            NANODBC_TEXT("test_connection_per_thread"),
+            NANODBC_TEXT("(tid int, i int)"));
+
+        nanodbc::string const connection_string = connection_string_;
+        std::atomic<int> failures(0);
+        std::vector<std::thread> threads;
+
+        for (std::size_t t = 0; t < thread_count; ++t)
+        {
+            threads.emplace_back(
+                [connection_string, t, rows_each, &failures]()
+                {
+                    try
+                    {
+                        nanodbc::connection own(connection_string);
+                        nanodbc::statement statement(own);
+                        prepare(
+                            statement,
+                            NANODBC_TEXT(
+                                "insert into test_connection_per_thread (tid, i) values (?, ?);"));
+
+                        for (std::size_t i = 0; i < rows_each; ++i)
+                        {
+                            int tid = static_cast<int>(t);
+                            int value = static_cast<int>(i);
+                            statement.bind(0, &tid);
+                            statement.bind(1, &value);
+                            execute(statement);
+                        }
+                    }
+                    catch (...)
+                    {
+                        ++failures;
+                    }
+                });
+        }
+
+        for (auto& thread : threads)
+            thread.join();
+
+        REQUIRE(failures.load() == 0);
+
+        auto results =
+            execute(connection, NANODBC_TEXT("select count(*) from test_connection_per_thread;"));
+        REQUIRE(results.next());
+        REQUIRE(results.get<int>(0) == static_cast<int>(thread_count * rows_each));
     }
 
     void test_std_optional()


### PR DESCRIPTION
Closes #285.

The issue reports `double free or corruption` from a connection made in each of ten threads. That is the arrangement the header asks for:

> If you want to use nanodbc objects in threads I recommend each thread keep their own connection to the database.

and nothing exercised it.

**It works.** `test_connection_per_thread` runs eight threads at once, each opening its own connection, preparing its own statement and inserting through it, then checks every row arrived and that no thread raised:

```
sqlite       All tests passed (5 assertions in 1 test case)
postgresql   All tests passed (5 assertions in 1 test case)
mysql        All tests passed (5 assertions in 1 test case)
mssql        All tests passed (5 assertions in 1 test case)
```

Repeatedly, too — eight runs of the SQLite case and six of the PostgreSQL one, no failures. A threaded test that only usually passes is worse than none, and SQLite writing one file from eight threads is exactly where that would show.

`connection_impl` allocates an ODBC environment of its own per connection, so there is no shared state between them for threads to race on, which is consistent with the result.

## So what happened to the reporter

Not reproducible here, and their snippet shows the shape of it: the lambda captures by reference and no `join()` appears. Threads outliving what they captured will free twice regardless of what they are doing with a database.

## Documentation

The usage guide had nothing on threads. It now covers what belongs to a thread, that sharing one connection between threads is the caller's to synchronize, and that a crash on shutdown is more often threads outliving what they captured than anything the driver did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)