### PR TITLE
Run the suites at C++17 as well as C++14

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -317,7 +317,14 @@ jobs:
       fail-fast: false
       matrix:
         postgres: [14, 15, 16, 17, 18]
-    name: test-postgresql (${{ matrix.postgres }})
+        cxxstd: ["14"]
+        # The newest server also runs the suite built as C++17, which is where the
+        # std::optional cases exist at all. Repeating that for every server version
+        # would buy nothing, what differs being the library rather than the server.
+        include:
+          - postgres: 18
+            cxxstd: "17"
+    name: test-postgresql (${{ matrix.postgres }}, c++${{ matrix.cxxstd }})
     services:
       postgresql:
         image: postgres:${{ matrix.postgres }}
@@ -341,11 +348,11 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.ccache
-          key: ccache-postgresql-${{ github.sha }}
-          restore-keys: ccache-postgresql-
+          key: ccache-postgresql-${{ matrix.cxxstd }}-${{ github.sha }}
+          restore-keys: ccache-postgresql-${{ matrix.cxxstd }}-
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
         run: |
           cmake --build ${GITHUB_WORKSPACE}/build --parallel --target postgresql_tests
@@ -357,6 +364,11 @@ jobs:
   test-oracle:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        cxxstd: ["14", "17"]
+    name: test-oracle (c++${{ matrix.cxxstd }})
     services:
       oracle:
         image: gvenzl/oracle-free:23-slim-faststart
@@ -396,11 +408,11 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.ccache
-          key: ccache-oracle-${{ github.sha }}
-          restore-keys: ccache-oracle-
+          key: ccache-oracle-${{ matrix.cxxstd }}-${{ github.sha }}
+          restore-keys: ccache-oracle-${{ matrix.cxxstd }}-
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
         run: |
           cmake --build ${GITHUB_WORKSPACE}/build --parallel --target oracle_tests
@@ -416,7 +428,8 @@ jobs:
       fail-fast: false
       matrix:
         unicode: ["OFF", "ON"]
-    name: test-mssql (unicode ${{ matrix.unicode }})
+        cxxstd: ["14", "17"]
+    name: test-mssql (unicode ${{ matrix.unicode }}, c++${{ matrix.cxxstd }})
     services:
       sqlserver:
         image: mcr.microsoft.com/mssql/server:2022-latest
@@ -438,11 +451,11 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.ccache
-          key: ccache-mssql-${{ matrix.unicode }}-${{ github.sha }}
-          restore-keys: ccache-mssql-${{ matrix.unicode }}-
+          key: ccache-mssql-${{ matrix.unicode }}-${{ matrix.cxxstd }}-${{ github.sha }}
+          restore-keys: ccache-mssql-${{ matrix.unicode }}-${{ matrix.cxxstd }}-
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DNANODBC_ENABLE_UNICODE=${{ matrix.unicode }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }} -DNANODBC_ENABLE_UNICODE=${{ matrix.unicode }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
         run: |
           cmake --build ${GITHUB_WORKSPACE}/build --parallel --target mssql_tests
@@ -458,7 +471,8 @@ jobs:
       fail-fast: false
       matrix:
         unicode: ["OFF", "ON"]
-    name: test-sqlite (unicode ${{ matrix.unicode }})
+        cxxstd: ["14", "17"]
+    name: test-sqlite (unicode ${{ matrix.unicode }}, c++${{ matrix.cxxstd }})
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install
@@ -480,11 +494,11 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.ccache
-          key: ccache-sqlite-${{ matrix.unicode }}-${{ github.sha }}
-          restore-keys: ccache-sqlite-${{ matrix.unicode }}-
+          key: ccache-sqlite-${{ matrix.unicode }}-${{ matrix.cxxstd }}-${{ github.sha }}
+          restore-keys: ccache-sqlite-${{ matrix.unicode }}-${{ matrix.cxxstd }}-
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DNANODBC_ENABLE_UNICODE=${{ matrix.unicode }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }} -DNANODBC_ENABLE_UNICODE=${{ matrix.unicode }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
         run: |
           cmake --build ${GITHUB_WORKSPACE}/build --parallel --target sqlite_tests


### PR DESCRIPTION
Closes #514.

**Stacked on #526** — the SQLite Unicode job at C++17 segfaults without that fix, which is what this change exposed. GitHub will retarget this to `main` once #526 merges.

Every test job built at the CMake default of C++14, so anything behind `NANODBC_HAS_STD_OPTIONAL` or `NANODBC_HAS_STD_VARIANT` was compiled by the build jobs and executed by nobody.

Two bugs reached main through that gap, both found while writing this:

- `test_std_optional` was registered for Oracle and fails there at C++17, reaching a time column Oracle has no type for. Fixed in #516; CI reported green on a test it was not running.
- `result::get_ref` reads a column into a `std::optional` that holds nothing, which crashes for a wide string. That is #525, fixed in #526, and it needed C++17 *and* Unicode together — a pair no job ran.

## The matrix

| job | jobs | why |
| --- | --- | --- |
| test-sqlite | 4 | unicode × standard |
| test-mssql | 4 | unicode × standard |
| test-oracle | 2 | standard |
| test-postgresql | 6 | five server versions at C++14, the newest also at C++17 |

PostgreSQL uses an `include` rather than a full cross product. What differs at C++17 is the library, not the server, so running all five versions twice would buy nothing for five extra jobs.

The ccache key carries the standard, so the two builds of a job do not evict one another.

## Testing

Every new combination, run locally against the real databases:

```
sqlite      c++17 uni=OFF All tests passed (1731 assertions in 89 test cases)
sqlite      c++17 uni=ON  All tests passed (1731 assertions in 89 test cases)
postgresql  c++17 uni=OFF All tests passed (5998 assertions in 93 test cases)
mssql       c++17 uni=OFF All tests passed (35938 assertions in 145 test cases)
mssql       c++17 uni=ON  All tests passed (35928 assertions in 146 test cases)
```

Oracle at C++17 passes as well, 64 cases and 1073 assertions, run through an amd64 container against Oracle Database Free 23.

PostgreSQL with Unicode is not in the matrix and stays out: it fails 15 cases with `HYC00`, the driver refusing the C type a string parameter binds with. That is #519.

## A note on the YAML

An earlier attempt at this added a second `strategy:` and `name:` to the PostgreSQL job, which already had both. `yaml.safe_load` accepts duplicate keys silently, last one winning, so it validated cleanly while the matrix it added was being discarded. It is now checked with a loader that rejects duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)