### PR TITLE
Say whether a parameter came back null

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2532,6 +2532,17 @@ public:
         }
     }
 
+    bool parameter_is_null(short param_index, std::size_t batch_index) const
+    {
+        auto const indicators = bind_len_or_null_.find(param_index);
+        if (indicators == bind_len_or_null_.end())
+            throw programming_error("no value is bound to that parameter");
+        if (batch_index >= indicators->second.size())
+            throw index_range_error();
+
+        return indicators->second[batch_index] == SQL_NULL_DATA;
+    }
+
     // initializes bind_len_or_null_ and gets information for bind
     void prepare_bind(
         short param_index,
@@ -6382,6 +6393,11 @@ short statement::parameter_scale(short param_index) const
 short statement::parameter_type(short param_index) const
 {
     return impl_->parameter_type(param_index);
+}
+
+bool statement::parameter_is_null(short param_index, std::size_t batch_index) const
+{
+    return impl_->parameter_is_null(param_index, batch_index);
 }
 
 // We need to instantiate each form of bind() for each of our supported data types.

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1217,6 +1217,19 @@ public:
     /// \brief Returns parameter type for indicated parameter placeholder in a prepared statement.
     short parameter_type(short param_index) const;
 
+    /// \brief Whether the parameter came back null.
+    ///
+    /// A parameter bound for output carries an indicator the driver writes when the
+    /// statement runs, saying whether a value came back at all. Reading it tells a null
+    /// apart from a buffer the driver left alone, which the value cannot.
+    ///
+    /// \param param_index Zero-based index of the parameter marker.
+    /// \param batch_index Which of the bound values to ask about, where several were.
+    /// \throws programming_error if nothing is bound to that parameter.
+    /// \throws index_range_error if there is no such value in the batch.
+    /// \see bind(), PARAM_OUT, PARAM_INOUT
+    bool parameter_is_null(short param_index, std::size_t batch_index = 0) const;
+
     /// \addtogroup binding Binding parameters
     /// \brief These functions are used to bind values to ODBC parameters.
     ///

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -2663,6 +2663,47 @@ TEST_CASE_METHOD(mssql_fixture, "test_binary_read_shapes", "[mssql][result][bina
     test_binary_read_shapes();
 }
 
+// An output parameter that comes back null leaves the buffer as it found it, so the value
+// alone cannot say whether the procedure set it. The indicator can.
+TEST_CASE_METHOD(mssql_fixture, "test_output_parameter_is_null", "[mssql][statement][bind]")
+{
+    auto connection = connect();
+    nanodbc::string const name = NANODBC_TEXT("test_output_parameter_is_null_proc");
+    try
+    {
+        execute(connection, NANODBC_TEXT("DROP PROCEDURE ") + name);
+    }
+    catch (...)
+    {
+    }
+    execute(
+        connection,
+        NANODBC_TEXT("CREATE PROCEDURE ") + name +
+            NANODBC_TEXT(
+                " @setme INT OUTPUT, @leaveme INT OUTPUT AS "
+                "BEGIN SET @setme = 42; SET @leaveme = NULL; END;"));
+
+    nanodbc::statement statement(connection);
+    statement.prepare(NANODBC_TEXT("{ CALL ") + name + NANODBC_TEXT("(?, ?) }"));
+
+    int setme = 0;
+    int leaveme = 12345;
+    statement.bind(0, &setme, nanodbc::statement::PARAM_OUT);
+    statement.bind(1, &leaveme, nanodbc::statement::PARAM_OUT);
+    statement.just_execute();
+
+    REQUIRE(setme == 42);
+    REQUIRE(!statement.parameter_is_null(0));
+
+    // The value says 12345, which is what was there before the call. Only the indicator
+    // tells that apart from a procedure that set it to 12345.
+    REQUIRE(statement.parameter_is_null(1));
+
+    // Nothing is bound to the third parameter, and there is no second value in the batch.
+    REQUIRE_THROWS_AS(statement.parameter_is_null(7), nanodbc::programming_error);
+    REQUIRE_THROWS_AS(statement.parameter_is_null(0, 64), nanodbc::index_range_error);
+}
+
 // Binding a parameter in a direction other than PARAM_IN, which is what maps onto
 // SQL_PARAM_OUTPUT and SQL_PARAM_INPUT_OUTPUT.
 TEST_CASE_METHOD(mssql_fixture, "test_output_parameters", "[mssql][statement][bind]")


### PR DESCRIPTION
Closes #436.

A parameter bound with `PARAM_OUT` leaves the caller's buffer as it found it when the procedure sets it to null, so the value cannot say whether anything came back:

```
after execute: out=12345  nulls[0]=false
```

The driver does report it. It writes `SQL_NULL_DATA` into the indicator the statement already holds for that parameter, and nothing read it back.

`statement::parameter_is_null(short param_index, std::size_t batch_index = 0)` reads it:

```cpp
int leaveme = 12345;
statement.bind(1, &leaveme, nanodbc::statement::PARAM_OUT);
statement.just_execute();

// leaveme is still 12345, which is what was there before the call
REQUIRE(statement.parameter_is_null(1));
```

This is the first of the two shapes floated on the issue. The other, writing back into the caller's `nulls` array, is not done here: that array is read while binding and says what to *send*, which is a different question from what came back, and its `bool const*` type forbids writing to it. An accessor also matches `result::is_null`, which answers the same question in the other direction.

## Testing

`test_output_parameter_is_null` calls a procedure that sets one output parameter and leaves the other null, and checks the value alone cannot tell them apart while the indicator can. It also checks the two ways of asking wrongly — an unbound parameter, and a batch index past the end — raise rather than answer.

```
All tests passed (7 assertions in 1 test case)
```

SQL Server only, procedures with output parameters not being portable, which is where the existing `test_output_parameters` lives too.

Full suites unaffected:

```
sqlite       All tests passed (1663 assertions in 90 test cases)
postgresql   All tests passed (5913 assertions in 94 test cases)
mysql        All tests passed (2129 assertions in 91 test cases)
mssql        All tests passed (35770 assertions in 145 test cases)
```

Worth noting that output parameters gained their first test only recently, which is likely why this went unnoticed for so long.

🤖 Generated with [Claude Code](https://claude.com/claude-code)