### PR TITLE
Read a column into a std::any

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -8211,6 +8211,68 @@ result::operator bool() const noexcept
     return static_cast<bool>(impl_);
 }
 
+#ifdef NANODBC_HAS_STD_ANY
+namespace
+{
+// Reads a column as whatever it says it holds. What a column holds is the driver's to
+// say, so this asks rather than being told by the caller.
+std::any read_column_as_its_own_type(result const& results, short column)
+{
+    switch (results.column_datatype(column))
+    {
+    case SQL_BIT:
+        return std::any(results.get<bool>(column));
+    case SQL_TINYINT:
+        return std::any(results.get<signed char>(column));
+    case SQL_SMALLINT:
+        return std::any(results.get<short>(column));
+    case SQL_INTEGER:
+        return std::any(results.get<int>(column));
+    case SQL_BIGINT:
+        return std::any(results.get<long long>(column));
+    case SQL_REAL:
+        return std::any(results.get<float>(column));
+    case SQL_FLOAT:
+    case SQL_DOUBLE:
+        return std::any(results.get<double>(column));
+    case SQL_DATE:
+    case SQL_TYPE_DATE:
+        return std::any(results.get<date>(column));
+    case SQL_TIME:
+    case SQL_TYPE_TIME:
+        return std::any(results.get<time>(column));
+    case SQL_TIMESTAMP:
+    case SQL_TYPE_TIMESTAMP:
+        return std::any(results.get<timestamp>(column));
+    case SQL_BINARY:
+    case SQL_VARBINARY:
+    case SQL_LONGVARBINARY:
+        return std::any(results.get<std::vector<std::uint8_t>>(column));
+    default:
+        // Character types, and the numeric ones carrying more digits than a double holds,
+        // where the text the driver renders is the value rather than an approximation of
+        // it.
+        return std::any(results.get<string>(column));
+    }
+}
+} // namespace
+
+template <>
+std::any result::get(short column) const
+{
+    if (is_null(column))
+        return std::any{};
+
+    return read_column_as_its_own_type(*this, column);
+}
+
+template <>
+std::any result::get(string const& column_name) const
+{
+    return get<std::any>(this->column(column_name));
+}
+#endif
+
 // The following are the only supported instantiations of result::get_ref().
 template void result::get_ref(short, std::string::value_type&) const;
 template void result::get_ref(short, wide_string::value_type&) const;

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -96,6 +96,8 @@
 #define NANODBC_HAS_STD_OPTIONAL
 #include <variant>
 #define NANODBC_HAS_STD_VARIANT
+#include <any>
+#define NANODBC_HAS_STD_ANY
 #endif
 
 /// \brief The entirety of nanodbc can be found within this one namespace.
@@ -2054,6 +2056,11 @@ public:
     /// \throws index_range_error
     /// \throws type_incompatible_error
     /// \throws null_access_error
+    ///
+    /// Where the library is built as C++17 or later, T may be std::any, which is filled
+    /// according to what the column says it holds rather than what the caller asks for.
+    /// A null column gives an any holding nothing.
+    /// \see column_datatype()
     template <class T>
     T get(short column) const;
 

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -264,6 +264,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_std_optional", "[mssql][optional]")
     test_std_optional();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_std_any", "[mssql][any]")
+{
+    test_std_any();
+}
+
 TEST_CASE_METHOD(
     mssql_fixture,
     "test_batch_insert_describe_param",

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -171,6 +171,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_std_optional", "[mysql][optional]")
     test_std_optional();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_std_any", "[mysql][any]")
+{
+    test_std_any();
+}
+
 TEST_CASE_METHOD(
     mysql_fixture,
     "test_bind_timestamp_as_string",

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -109,6 +109,11 @@ TEST_CASE_METHOD(postgresql_fixture, "test_std_optional", "[postgresql][optional
     test_std_optional();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "test_std_any", "[postgresql][any]")
+{
+    test_std_any();
+}
+
 TEST_CASE_METHOD(
     postgresql_fixture,
     "test_catalog_list_catalogs",

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -157,6 +157,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_std_optional", "[sqlite][optional]")
     test_std_optional();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_std_any", "[sqlite][any]")
+{
+    test_std_any();
+}
+
 TEST_CASE_METHOD(
     sqlite_fixture,
     "test_bind_timestamp_as_string",

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -5477,6 +5477,54 @@ PRIMARY KEY(t2_fid)
         REQUIRE(results.get<int>(0) == static_cast<int>(thread_count * rows_each));
     }
 
+    void test_std_any()
+    {
+#ifdef NANODBC_HAS_STD_ANY
+        auto connection = connect();
+        create_table(
+            connection,
+            NANODBC_TEXT("test_std_any"),
+            NANODBC_TEXT("(i int, d float, s varchar(10), n int)"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_std_any (i, d, s, n) values (42, 3.5, 'text', NULL);"));
+
+        auto results = execute(connection, NANODBC_TEXT("select i, d, s, n from test_std_any;"));
+        REQUIRE(results.next());
+
+        // What comes back is what the column holds, not what the caller guessed.
+        auto const i = results.get<std::any>(0);
+        REQUIRE(i.has_value());
+        REQUIRE(std::any_cast<int>(i) == 42);
+
+        // Whether a float column describes itself as SQL_REAL or SQL_DOUBLE is the
+        // driver's to say, and they disagree: MySQL says the first, PostgreSQL and SQL
+        // Server the second. The any holds whichever it said.
+        auto const d = results.get<std::any>(1);
+        REQUIRE(d.has_value());
+        double const floating =
+            d.type() == typeid(double) ? std::any_cast<double>(d) : std::any_cast<float>(d);
+        REQUIRE(floating == Catch::Approx(3.5));
+
+        auto const s = results.get<std::any>(2);
+        REQUIRE(s.has_value());
+        REQUIRE(std::any_cast<nanodbc::string>(s) == NANODBC_TEXT("text"));
+
+        // A null column holds nothing at all, rather than a value standing in for one.
+        auto const n = results.get<std::any>(3);
+        REQUIRE(!n.has_value());
+
+        // And by name, which reads the same column.
+        auto const by_name = results.get<std::any>(as_identifier(NANODBC_TEXT("i")));
+        REQUIRE(std::any_cast<int>(by_name) == 42);
+
+        // Asking for the wrong type is the caller's mistake, and says so.
+        REQUIRE_THROWS_AS(std::any_cast<nanodbc::string>(i), std::bad_any_cast);
+#else
+        SUCCEED("std::any needs C++17 or later");
+#endif
+    }
+
     void test_std_optional()
     {
 #ifdef NANODBC_HAS_STD_OPTIONAL


### PR DESCRIPTION
Closes #325.

```cpp
auto v0 = r.get<std::any>(0);
auto v1 = r.get<std::any>(1);
```

The any is filled according to what the column says it holds rather than what the caller asks for, which is the point of asking for one. A null column gives an any holding nothing, so `has_value()` answers what `is_null` answers elsewhere — both as the issue specifies.

## What each type becomes

The obvious mapping, with two worth stating:

- A column carrying more digits than a `double` holds — `DECIMAL` and `NUMERIC` — arrives as the text the driver renders. That text is the value; a `double` would be an approximation of it.
- Whether a `float` column calls itself `SQL_REAL` or `SQL_DOUBLE` is the driver's to say, and they disagree. MySQL says the first, PostgreSQL and SQL Server the second, so the any holds a `float` on one and a `double` on the others. The test accepts either rather than pretending otherwise.

## Testing

`test_std_any` reads an integer, a float, a string and a null column, checks each holds what the column does, reads one by name as well, and checks that asking for the wrong type raises `std::bad_any_cast` rather than answering.

```
sqlite       All tests passed (12 assertions in 1 test case)
postgresql   All tests passed (12 assertions in 1 test case)
mysql        All tests passed (12 assertions in 1 test case)
mssql        All tests passed (12 assertions in 1 test case)
```

Built both ways, since `std::any` exists in only one of them:

```
sqlite   c++14 All tests passed (1664 assertions in 91 test cases)
mssql    c++14 All tests passed (35804 assertions in 145 test cases)
sqlite   c++17 All tests passed (1749 assertions in 91 test cases)
mssql    c++17 All tests passed (35992 assertions in 147 test cases)
```

## Why #324 is not closed alongside this

`std::variant` was written first and taken out again. `result::get` is declared `template <class T> T get(short) const` and explicitly instantiated in the .cpp for a fixed list of types. `std::any` fits that model: it is one concrete type, so an explicit specialization is the same as adding a row to the list.

A `std::variant<Ts...>` is a different type for every caller and can never be pre-instantiated, and a function template cannot be partially specialized, so `get<std::variant<int, std::string>>` has nowhere to come from and fails to link. Supporting it means either defining `get` in the header, which would need `result_impl` visible there, or adding a differently-named member the header can define inline. That is a decision about the shape of the interface, so I have described it on #324 rather than picking one.

The dispatch this adds is written so that whichever shape is chosen can use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)