### PR TITLE
Test PostgreSQL through its Unicode driver

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Run the suites
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/profraw"
-          export NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL ANSI};Server=localhost;Port=5432;Database=nanodbc;UID=postgres;PWD=postgres"
+          export NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Database=nanodbc;UID=postgres;PWD=postgres"
           export NANODBC_TEST_CONNSTR_MSSQL="Driver={ODBC Driver 17 for SQL Server};Server=localhost;Database=master;UID=sa;PWD=Password!123;"
           for suite in utility sqlite postgresql mssql; do
             LLVM_PROFILE_FILE="${GITHUB_WORKSPACE}/profraw/${suite}-%p.profraw" \
@@ -318,13 +318,20 @@ jobs:
       matrix:
         postgres: [14, 15, 16, 17, 18]
         cxxstd: ["14"]
+        unicode: ["OFF"]
         # The newest server also runs the suite built as C++17, which is where the
         # std::optional cases exist at all. Repeating that for every server version
         # would buy nothing, what differs being the library rather than the server.
         include:
           - postgres: 18
             cxxstd: "17"
-    name: test-postgresql (${{ matrix.postgres }}, c++${{ matrix.cxxstd }})
+            unicode: "OFF"
+          # The newest server also runs a Unicode build, through the Unicode driver, the
+          # ANSI one being unable to take a wide parameter.
+          - postgres: 18
+            cxxstd: "14"
+            unicode: "ON"
+    name: test-postgresql (${{ matrix.postgres }}, c++${{ matrix.cxxstd }}, unicode ${{ matrix.unicode }})
     services:
       postgresql:
         image: postgres:${{ matrix.postgres }}
@@ -348,17 +355,17 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.ccache
-          key: ccache-postgresql-${{ matrix.cxxstd }}-${{ github.sha }}
-          restore-keys: ccache-postgresql-${{ matrix.cxxstd }}-
+          key: ccache-postgresql-${{ matrix.cxxstd }}-${{ matrix.unicode }}-${{ github.sha }}
+          restore-keys: ccache-postgresql-${{ matrix.cxxstd }}-${{ matrix.unicode }}-
       - name: Configure
         run: |
-          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }} -DNANODBC_ENABLE_UNICODE=${{ matrix.unicode }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
         run: |
           cmake --build ${GITHUB_WORKSPACE}/build --parallel --target postgresql_tests
       - name: Test
         run: |
-          export NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL ANSI};Server=localhost;Port=5432;Database=nanodbc;UID=postgres;PWD=postgres"
+          export NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Database=nanodbc;UID=postgres;PWD=postgres"
           ctest --test-dir ${GITHUB_WORKSPACE}/build --output-on-failure --no-tests=error -R postgresql_tests
 
   test-oracle:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,9 @@ services:
       PGPASSWORD: *default_credential
       PGDATABASE: *default_credential
       NANODBC_TEST_CONNSTR_SQLITE: "Driver={SQLite3};Database=/tmp/nanodbc.db;"
-      NANODBC_TEST_CONNSTR_PGSQL: "Driver={PostgreSQL ANSI};Server=pgsql;Port=5432;Database=nanodbc;UID=nanodbc;PWD=nanodbc;"
+      # The Unicode driver, which serves a narrow build as well as a wide one. The ANSI
+      # driver refuses a wide parameter, as it should, so a Unicode build cannot use it.
+      NANODBC_TEST_CONNSTR_PGSQL: "Driver={PostgreSQL Unicode};Server=pgsql;Port=5432;Database=nanodbc;UID=nanodbc;PWD=nanodbc;"
       NANODBC_TEST_CONNSTR_MYSQL: "Driver={MySQL ODBC 8.4 ANSI Driver};Server=mysql;Database=nanodbc;User=root;Password=nanodbc;big_packets=1;"
       NANODBC_TEST_CONNSTR_MARIADB: "Driver={MariaDB Unicode};Server=mariadb;Port=3306;Database=nanodbc;User=root;Password=nanodbc;"
       NANODBC_TEST_CONNSTR_MSSQL: "Driver={ODBC Driver 18 for SQL Server};Server=mssql;Database=master;UID=sa;PWD=Password12!;TrustServerCertificate=yes;"


### PR DESCRIPTION
Closes #519.

A Unicode build failed fifteen of the PostgreSQL cases, every one of them binding a string:

```
HYC00: Unrecognized C_parameter type in copy_statement_with_parameters
```

**Not a nanodbc bug.** The tests connect through `Driver={PostgreSQL ANSI}`, and an ANSI driver cannot take a `SQL_C_WCHAR` parameter. Refusing it is correct.

`odbc-postgresql` installs both drivers, and the container has had them all along:

```
[PostgreSQL ANSI]
[PostgreSQL Unicode]
```

Through the Unicode one, the same build passes everything:

```
c++14 unicode=ON   All tests passed (5948 assertions in 94 test cases)
```

## One driver for both builds

The Unicode driver serves a narrow build as well, so this is a single connection string rather than one per configuration:

```
c++14 unicode=OFF  All tests passed (5948 assertions in 94 test cases)
c++17 unicode=OFF  All tests passed (6022 assertions in 94 test cases)
c++14 unicode=ON   All tests passed (5948 assertions in 94 test cases)
```

Changed in `docker-compose.yml` and in both places the workflow sets it, the coverage job included.

## PostgreSQL joins the Unicode matrix

#520 left it out because of this, so the exclusion goes. The newest server now also runs a Unicode build, on the same reasoning the C++17 entry uses: what differs is the library, not the server, so running all five versions again would buy nothing.

`test-postgresql` goes from 6 jobs to 7.

## What this says about #519 as filed

I wrote that issue while adding the Unicode jobs, and framed it as psqlODBC refusing something nanodbc does. It was the test configuration, and the driver was behaving correctly — worth being plain about, since the issue reads as a library defect and is not one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)