### PR TITLE
Write down what 2.19.0 carried, and what has landed since

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,28 @@
 # ChangeLog
 
+## Unreleased
+
+- Every diagnostic a failure carries reaches the message, where all but the first were dropped outside Windows, and each arrives once rather than trailing the buffer it was read into. [`#315`](https://github.com/nanodbc/nanodbc/issues/315)
+- `result::get_ref` builds the value before reading a column into a `std::optional`, having read into one that held nothing, which crashes for a wide string. [`#525`](https://github.com/nanodbc/nanodbc/issues/525)
+- `statement::parameter_is_null` says whether a parameter bound for output came back null, which its value cannot, the driver leaving the caller's buffer alone. [`#436`](https://github.com/nanodbc/nanodbc/issues/436)
+- The suites run at C++17 as well as C++14, so what is written behind `std::optional` and `std::variant` is executed rather than only compiled. [`#514`](https://github.com/nanodbc/nanodbc/issues/514)
+- A test covers a connection to each of several threads, which is the arrangement the library asks for and nothing exercised. [`#285`](https://github.com/nanodbc/nanodbc/issues/285)
+
 ## v2.19.0
 
 - A date or time parameter bound as text is declared as the driver describes it, Oracle refusing the ODBC literal form when it is declared as text. [`#248`](https://github.com/nanodbc/nanodbc/issues/248)
 - `statement::execute` takes a `batch_ops`, so the rowset size and the parameter array length can differ. [`#162`](https://github.com/nanodbc/nanodbc/issues/162)
 - Documented that how far a batch of parameters carries is the driver's to decide, with measurements. [`#241`](https://github.com/nanodbc/nanodbc/issues/241)
+- Oracle runs in the test suite and in CI, against Oracle Database Free through Instant Client, carrying the cases the other backends share. [`#487`](https://github.com/nanodbc/nanodbc/issues/487)
+- The Oracle job starts a prepared database rather than opening one on first boot, which is most of the difference between three minutes fifty and two minutes five.
+- `bind_rows` binds a batch held as rows, naming one accessor per parameter, and copies the columns into the statement so the rows need not outlive it. [`#443`](https://github.com/nanodbc/nanodbc/issues/443)
+- The constructors taking connection and statement attributes are reachable at C++14, the nested `attribute` having been private there and the `connection` overloads compiled out altogether. [`#494`](https://github.com/nanodbc/nanodbc/issues/494)
+- Connection attributes reach the driver before it connects, which is what several of them govern; setting them on an allocated handle beforehand cannot work, since `connect()` allocates another. [`#215`](https://github.com/nanodbc/nanodbc/issues/215)
+- A test covers reading a result other than forwards, which asks the driver for a cursor that scrolls; `move()` counts rows from one, which it did not say. [`#368`](https://github.com/nanodbc/nanodbc/issues/368)
+- Tests pin down what `affected_rows` reports for the statements whose count is defined, a statement matching nothing included. [`#168`](https://github.com/nanodbc/nanodbc/issues/168)
+- The SQLite and SQL Server suites also run built for Unicode, and SQL Server is tested through the ODBC driver the development container has used for some time. [`#265`](https://github.com/nanodbc/nanodbc/issues/265)
+- `test_std_optional` leaves out its date and time cases on Oracle, which has no TIME type and describes a DATE as a timestamp, as the tests they wrap are already left out there.
+- Documented reading many rows into containers, which is the rowset size and `get_ref` rather than any binding of output buffers. [`#163`](https://github.com/nanodbc/nanodbc/issues/163)
 
 ## v2.18.0
 


### PR DESCRIPTION
The 2.19.0 notes list three changes. The tag at `fa982d7` carries PRs #509 through #522, so most of what shipped went unmentioned.

## Added under v2.19.0

Everything below is an ancestor of the v2.19.0 tag, checked with `git merge-base --is-ancestor` rather than assumed from dates:

- Oracle in the test suite and CI [`#487`]
- the Oracle job's start-up cost, three minutes fifty to two minutes five
- `bind_rows` [`#443`]
- the attribute constructors at C++14 [`#494`]
- connection attributes before connecting [`#215`]
- reading a result other than forwards, and `move()` counting from one [`#368`]
- what `affected_rows` reports [`#168`]
- the Unicode jobs, and SQL Server on the driver the dev container uses [`#265`]
- the Oracle date and time optionals
- reading many rows into containers [`#163`]

## Added under Unreleased

What has merged since the tag:

- every diagnostic reaching the message, once each [`#315`]
- `get_ref` building the value before reading into an optional [`#525`]
- `parameter_is_null` [`#436`]
- the suites running at C++17 [`#514`]
- a connection to each of several threads [`#285`]

The heading is `Unreleased` rather than a version. Every other heading here is a version, so this one is out of step, but naming the next release is yours and a wrong guess would be worse than an obvious placeholder — rename it when you cut.

Two open PRs are deliberately absent, `get<std::any>` (#530) and PostgreSQL's Unicode driver (#531). A changelog describing what is not in `main` would be wrong; they can go in when they merge.

## Style

Each entry states what is now the case rather than what was done, one sentence, with the issue at the end, which is how the 2.18.0 and 2.19.0 entries read. Two have no link, being changes with no issue behind them, as with several existing entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)