### PR TITLE
Read a column into a std::variant

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -8215,7 +8215,9 @@ result::operator bool() const noexcept
 namespace
 {
 // Reads a column as whatever it says it holds. What a column holds is the driver's to
-// say, so this asks rather than being told by the caller.
+// say, so this asks rather than being told by the caller. It lives here rather than in
+// the header because the type codes come from the ODBC headers, which nanodbc.h does not
+// carry into everything that includes it.
 std::any read_column_as_its_own_type(result const& results, short column)
 {
     switch (results.column_datatype(column))

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -2060,7 +2060,7 @@ public:
     /// Where the library is built as C++17 or later, T may be std::any, which is filled
     /// according to what the column says it holds rather than what the caller asks for.
     /// A null column gives an any holding nothing.
-    /// \see column_datatype()
+    /// \see column_datatype(), get_as()
     template <class T>
     T get(short column) const;
 
@@ -2076,6 +2076,35 @@ public:
     /// \throws type_incompatible_error
     template <class T>
     T get(short column, T const& fallback) const;
+
+#if defined(NANODBC_HAS_STD_ANY) || defined(NANODBC_HAS_STD_VARIANT)
+    /// \brief Reads a column as whatever it holds, into a type able to hold any of them.
+    ///
+    /// Where get() reads a column as the type the caller names, converting where it can,
+    /// this reads it as the type the column says it is and hands back a T holding that.
+    /// T may be std::any, or a std::variant naming the alternatives to choose between.
+    ///
+    /// A null column gives a T built from nothing: an any holding nothing, or a variant
+    /// on its first alternative, which is what std::monostate is for.
+    ///
+    /// \code
+    /// using v_t = std::variant<std::monostate, nanodbc::string, int>;
+    /// auto v = results.get_as<v_t>(0);
+    /// \endcode
+    ///
+    /// \param column position.
+    /// \throws database_error
+    /// \throws index_range_error
+    /// \throws type_incompatible_error if the column holds something T cannot.
+    /// \see get(), column_datatype()
+    template <class T>
+    T get_as(short column) const;
+
+    /// \brief Reads a column by name as whatever it holds.
+    /// \see get_as(short)
+    template <class T>
+    T get_as(string const& column_name) const;
+#endif
 
     /// \brief Gets data from the given column by name of the current rowset.
     ///
@@ -2810,6 +2839,74 @@ private:
 // 888     888    88888888 88888888      888     888  888 888  888 888      888    888 888  888 888  888 "Y8888b.
 // 888     888    Y8b.     Y8b.          888     Y88b 888 888  888 Y88b.    Y88b.  888 Y88..88P 888  888      X88
 // 888     888     "Y8888   "Y8888       888      "Y88888 888  888  "Y8888P  "Y888 888  "Y88P"  888  888  88888P'
+#if defined(NANODBC_HAS_STD_ANY) || defined(NANODBC_HAS_STD_VARIANT)
+/// \brief Implementation details, not part of the interface.
+namespace detail
+{
+
+// Moves what a column held, which get<std::any>() worked out from the type the driver
+// reports, into whatever the caller asked to hold it.
+template <class T>
+struct hold_column_value;
+
+#ifdef NANODBC_HAS_STD_ANY
+template <>
+struct hold_column_value<std::any>
+{
+    static std::any from(std::any value) { return value; }
+};
+#endif
+
+#ifdef NANODBC_HAS_STD_VARIANT
+template <class Alternative, class Variant>
+inline bool hold_alternative(Variant& variant, std::any const& value)
+{
+    if (auto const* held = std::any_cast<Alternative>(&value))
+    {
+        variant = *held;
+        return true;
+    }
+    return false;
+}
+
+template <class... Ts>
+struct hold_column_value<std::variant<Ts...>>
+{
+    static std::variant<Ts...> from(std::any const& value)
+    {
+        std::variant<Ts...> variant;
+        if (!value.has_value())
+            return variant; // the first alternative, which is what monostate is for
+
+        bool held = false;
+        bool const each[] = {false, (held = held || hold_alternative<Ts>(variant, value))...};
+        (void)each;
+
+        // The column holds something none of the alternatives can, which the compiler
+        // cannot catch: what a column holds is only known once the driver has said.
+        if (!held)
+            throw type_incompatible_error();
+
+        return variant;
+    }
+};
+#endif
+
+} // namespace detail
+
+template <class T>
+T result::get_as(short column) const
+{
+    return detail::hold_column_value<T>::from(get<std::any>(column));
+}
+
+template <class T>
+T result::get_as(string const& column_name) const
+{
+    return get_as<T>(this->column(column_name));
+}
+#endif
+
 // MARK: Free Functions -
 // clang-format on
 

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -269,6 +269,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_std_any", "[mssql][any]")
     test_std_any();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_std_variant", "[mssql][variant]")
+{
+    test_std_variant();
+}
+
 TEST_CASE_METHOD(
     mssql_fixture,
     "test_batch_insert_describe_param",

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -176,6 +176,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_std_any", "[mysql][any]")
     test_std_any();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_std_variant", "[mysql][variant]")
+{
+    test_std_variant();
+}
+
 TEST_CASE_METHOD(
     mysql_fixture,
     "test_bind_timestamp_as_string",

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -114,6 +114,11 @@ TEST_CASE_METHOD(postgresql_fixture, "test_std_any", "[postgresql][any]")
     test_std_any();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "test_std_variant", "[postgresql][variant]")
+{
+    test_std_variant();
+}
+
 TEST_CASE_METHOD(
     postgresql_fixture,
     "test_catalog_list_catalogs",

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -162,6 +162,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_std_any", "[sqlite][any]")
     test_std_any();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_std_variant", "[sqlite][variant]")
+{
+    test_std_variant();
+}
+
 TEST_CASE_METHOD(
     sqlite_fixture,
     "test_bind_timestamp_as_string",

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -5525,6 +5525,49 @@ PRIMARY KEY(t2_fid)
 #endif
     }
 
+    void test_std_variant()
+    {
+#ifdef NANODBC_HAS_STD_VARIANT
+        using value = std::variant<std::monostate, nanodbc::string, int, double>;
+
+        auto connection = connect();
+        create_table(
+            connection,
+            NANODBC_TEXT("test_std_variant"),
+            NANODBC_TEXT("(i int, s varchar(10), n int)"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_std_variant (i, s, n) values (42, 'text', NULL);"));
+
+        auto results = execute(connection, NANODBC_TEXT("select i, s, n from test_std_variant;"));
+        REQUIRE(results.next());
+
+        auto const i = results.get_as<value>(0);
+        REQUIRE(std::holds_alternative<int>(i));
+        REQUIRE(std::get<int>(i) == 42);
+
+        auto const s = results.get_as<value>(1);
+        REQUIRE(std::holds_alternative<nanodbc::string>(s));
+        REQUIRE(std::get<nanodbc::string>(s) == NANODBC_TEXT("text"));
+
+        // A null column leaves the variant on its first alternative, as the issue asks.
+        auto const n = results.get_as<value>(2);
+        REQUIRE(n.index() == 0);
+        REQUIRE(std::holds_alternative<std::monostate>(n));
+
+        // And by name, which reads the same column.
+        auto const by_name = results.get_as<value>(as_identifier(NANODBC_TEXT("i")));
+        REQUIRE(std::get<int>(by_name) == 42);
+
+        // A variant with nowhere to put what the column holds says so, which the compiler
+        // cannot: what the column holds is the driver's to say.
+        using narrow = std::variant<std::monostate, double>;
+        REQUIRE_THROWS_AS(results.get_as<narrow>(1), nanodbc::type_incompatible_error);
+#else
+        SUCCEED("std::variant needs C++17 or later");
+#endif
+    }
+
     void test_std_optional()
     {
 #ifdef NANODBC_HAS_STD_OPTIONAL


### PR DESCRIPTION
Closes #324.

```cpp
using v_t = std::variant<std::monostate, nanodbc::string, int>;
auto v0 = r.get_as<v_t>(0);
```

`get_as` reads a column as the type the driver says it is and hands back something able to hold it, where `get` reads it as the type the caller names and converts where it can. `std::any` works through it too, and `get<std::any>` now shares the path.

A null column leaves the variant on its first alternative — `index() == 0`, which is what `std::monostate` is for — as the issue asks. A variant with nowhere to put what the column holds raises `type_incompatible_error` rather than guessing at an alternative; that cannot be caught at compile time, since what a column holds is only known once the driver has said.

## Why `get_as` and not `get`

This is the shape I described on the issue, and the reason has not changed: `result::get` is instantiated in the library for a fixed list of types. `std::any` joins that list, being one concrete type. A `std::variant<Ts...>` is a different type for every caller and cannot be pre-instantiated, and a function template cannot be partially specialized, so `get<v_t>` has nowhere to link from.

Of the three ways out, this is the second: a differently named member the header can define inline. Nothing moves, and one name serves both `std::any` and `std::variant`.

## Where the pieces sit

The first attempt put the whole thing in the header and did not compile:

```
error: use of undeclared identifier 'SQL_BIT'
```

`nanodbc.h` does not include the ODBC headers, deliberately — a caller writing `SQL_ATTR_CURSOR_TYPE` includes `sql.h` themselves. So the type dispatch stays in the implementation, where it already was, and the header asks `get<std::any>` for the value and moves it into whatever the caller wanted. The type codes are not carried into everything that includes nanodbc.h.

## Testing

`test_std_variant` reads an integer, a string and a null column, checks the alternative each lands on, reads one by name, and checks a variant too narrow for the column raises.

```
sqlite       All tests passed (11 assertions in 1 test case)
postgresql   All tests passed (11 assertions in 1 test case)
mysql        All tests passed (11 assertions in 1 test case)
mssql        All tests passed (11 assertions in 1 test case)
```

Both standards, since `std::variant` exists in one of them:

```
sqlite   c++14 All tests passed (1670 assertions in 93 test cases)
mssql    c++14 All tests passed (35835 assertions in 148 test cases)
sqlite   c++17 All tests passed (1765 assertions in 93 test cases)
mssql    c++17 All tests passed (35976 assertions in 150 test cases)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)