### PR TITLE
Lint the CMake scripts, and leave their formatting alone

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,21 @@
+# Configuration for cmakelang, of which only the linter is run. See .github/workflows/lint.yml.
+#
+# cmake-format is deliberately not run. Its output rewrites these files whole — 385 of the
+# 365 lines across them with its defaults, and 329 of CMakeLists.txt's 259 even when told
+# this project's line width — because it does not keep the spacing inside parentheses that
+# the files are written with. That is a change of style rather than a formatting pass, and
+# not one worth making to gain a check.
+lint:
+  disabled_codes:
+    # Line length, which clang-format sets at 100 for the C++ and these files follow.
+    - "C0301"
+    # Variable naming. Local variables here are lower case, as CMake's own documentation
+    # writes them; cmake-lint wants upper case for everything that is not function-local.
+    - "C0103"
+    # A missing COMMENT argument, which these files leave out where the command says what
+    # it is doing.
+    - "C0113"
+    # Indentation, which follows the same two spaces as the rest of the project and not
+    # the layout cmake-format would impose.
+    - "C0307"
+  max_arguments: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,10 @@ jobs:
         run: sudo apt-get -o DPkg::Lock::Timeout=120 install -y unixodbc-dev
       - name: Run rstcheck
         run: rstcheck doc/*.rst
+      - name: Install cmakelang
+        run: python3 -m pip install --disable-pip-version-check "cmakelang==0.6.13"
+      - name: Run cmake-lint
+        run: cmake-lint $(git ls-files '*CMakeLists.txt' '*.cmake')
 
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #394.

The issue asks for cmakelang to be evaluated. Both halves were, and they come out differently.

## cmake-lint: adopted

Clean on all four files once the checks that are style preferences rather than mistakes are turned off:

```
files scanned: 4
found lint:
exit=0
```

The four disabled, each with its reason in `.cmake-format.yaml`:

- **C0301 line length** — it wants 80; clang-format sets 100 for the C++ here and these files follow that.
- **C0103 variable naming** — it wants upper case for anything not function-local; these are lower case, as CMake's own documentation writes them.
- **C0113 missing COMMENT** — left out where the command already says what it is doing.
- **C0307 indentation** — it wants what cmake-format would impose, which is the next section.

What remains catches structural mistakes, costs nothing today, and holds for what comes later.

## cmake-format: not adopted

It rewrites the files whole. Measured, since "some churn" would be a fair thing to accept and this is not that:

| | changed lines | file length |
| --- | --- | --- |
| `CMakeLists.txt` | 385 | 259 |
| `test/CMakeLists.txt` | 41 | |
| `example/CMakeLists.txt` | 31 | |
| `example/client/CMakeLists.txt` | 4 | |

385 changed lines in a 259-line file, and 365 lines across all four. Configuring it to this project's line width and leaving command case alone brings `CMakeLists.txt` to 329, no better in kind: it does not keep the spacing inside parentheses these files are written with —

```cmake
option( NANODBC_ENABLE_UNICODE "Enable Unicode support (default on)" OFF )
```

— so every command in every file changes. That is replacing the project's CMake style, which is a decision worth making on its own merits rather than as the side effect of gaining a check that currently finds nothing.

If you would rather have it, the config is already there and needs one section adding, and I am happy to open that as its own PR where the diff is the point rather than a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)