### PR TITLE
Ask the driver what it needs in order to connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- `connection::browse_connect` asks the driver what it needs in order to connect, which SQL Server's answers with the attributes it wants and most others decline. [`#235`](https://github.com/nanodbc/nanodbc/issues/235)
+- `result::get_as` reads a column as the type the driver says it is, into a `std::variant` naming the alternatives to choose between. [`#324`](https://github.com/nanodbc/nanodbc/issues/324)
+- A parameter described with `describe_parameters` can be bound without preparing first, which is what a stored procedure with known parameters wants. [`#207`](https://github.com/nanodbc/nanodbc/issues/207)
+- `cmake-lint` reads the CMake scripts in CI; `cmake-format` is not run, its output rewriting them whole. [`#394`](https://github.com/nanodbc/nanodbc/issues/394)
+- PostgreSQL is tested through its Unicode driver, the ANSI one being unable to take the wide parameter a Unicode build binds. [`#519`](https://github.com/nanodbc/nanodbc/issues/519)
+- `result::get` reads a column into a `std::any`, holding what the column holds, or nothing where it is null. [`#325`](https://github.com/nanodbc/nanodbc/issues/325)
 - Every diagnostic a failure carries reaches the message, where all but the first were dropped outside Windows, and each arrives once rather than trailing the buffer it was read into. [`#315`](https://github.com/nanodbc/nanodbc/issues/315)
 - `result::get_ref` builds the value before reading a column into a `std::optional`, having read into one that held nothing, which crashes for a wide string. [`#525`](https://github.com/nanodbc/nanodbc/issues/525)
 - `statement::parameter_is_null` says whether a parameter bound for output came back null, which its value cannot, the driver leaving the caller's buffer alone. [`#436`](https://github.com/nanodbc/nanodbc/issues/436)

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1583,6 +1583,58 @@ public:
         return rc;
     }
 
+    // SQLBrowseConnect is asked the same question repeatedly, each answer carrying more
+    // of what the driver wants, so the handle has to live across the calls. connect()
+    // frees and allocates one every time, which would lose the exchange halfway.
+    string browse(string const& connection_string, bool& more_wanted)
+    {
+        allocate_env_handle(env_);
+        if (dbc_ == nullptr)
+            allocate_dbc_handle(dbc_, env_);
+
+        RETCODE rc = SQL_SUCCESS;
+        std::vector<NANODBC_SQLCHAR> out(1024);
+        SQLSMALLINT length = 0;
+
+        NANODBC_CALL_RC(
+            NANODBC_FUNC(SQLBrowseConnect),
+            rc,
+            dbc_,
+            (NANODBC_SQLCHAR*)connection_string.c_str(),
+            SQL_NTS,
+            out.data(),
+            (SQLSMALLINT)out.size(),
+            &length);
+
+        // A driver wanting more room than was offered says so, and says how much.
+        if (rc == SQL_SUCCESS_WITH_INFO && length > (SQLSMALLINT)out.size())
+        {
+            out.resize(static_cast<std::size_t>(length) + 1);
+            NANODBC_CALL_RC(
+                NANODBC_FUNC(SQLBrowseConnect),
+                rc,
+                dbc_,
+                (NANODBC_SQLCHAR*)connection_string.c_str(),
+                SQL_NTS,
+                out.data(),
+                (SQLSMALLINT)out.size(),
+                &length);
+        }
+
+        if (rc == SQL_NEED_DATA)
+        {
+            more_wanted = true;
+            return string(out.begin(), out.begin() + static_cast<std::ptrdiff_t>(length));
+        }
+
+        if (!success(rc))
+            NANODBC_THROW_DATABASE_ERROR(dbc_, SQL_HANDLE_DBC);
+
+        more_wanted = false;
+        connected_ = true;
+        return string();
+    }
+
     bool connected() const noexcept { return connected_; }
 
     void disconnect()
@@ -5970,6 +6022,11 @@ void connection::connect(
 void connection::connect(string const& connection_string, std::list<attribute> const& attributes)
 {
     impl_->connect(connection_string, attributes);
+}
+
+string connection::browse_connect(string const& connection_string, bool& more_wanted)
+{
+    return impl_->browse(connection_string, more_wanted);
 }
 
 #if !defined(NANODBC_DISABLE_ASYNC) && defined(SQL_ATTR_ASYNC_DBC_EVENT)

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1722,6 +1722,24 @@ public:
     /// \throws database_error
     /// \see connected(), attribute
     void connect(string const& connection_string, std::list<attribute> const& attributes);
+
+    /// \brief Asks the driver what it needs in order to connect.
+    ///
+    /// Wraps ODBC's SQLBrowseConnect, which is asked repeatedly. Each call is given what
+    /// is known so far and answers with the attributes it still wants, spelled as a
+    /// connection string of its own: the required ones first, then the optional, with the
+    /// values a driver can enumerate listed in braces. Filling those in and asking again
+    /// carries the exchange forward until the driver has enough, at which point it
+    /// connects, \a more_wanted is false and the returned string is empty.
+    ///
+    /// A driver need not support this, and one that does not raises.
+    ///
+    /// \param connection_string What is known so far, beginning with the driver or DSN.
+    /// \param more_wanted Set to whether the driver is asking for more.
+    /// \return The attributes wanted next, or nothing once connected.
+    /// \throws database_error
+    /// \see connect(), connected()
+    string browse_connect(string const& connection_string, bool& more_wanted);
 #if !defined(NANODBC_DISABLE_ASYNC)
     /// \brief Initiate an asynchronous connection operation to the given data source.
     ///

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -2756,6 +2756,31 @@ TEST_CASE_METHOD(mssql_fixture, "test_bind_without_prepare", "[mssql][statement]
     REQUIRE_THROWS_AS(undescribed.bind(0, &i), nanodbc::database_error);
 }
 
+// SQLBrowseConnect asks the driver what it needs in order to connect. SQL Server's driver
+// answers; most do not, and say so.
+TEST_CASE_METHOD(mssql_fixture, "test_browse_connect", "[mssql][connection][browse]")
+{
+    nanodbc::connection connection;
+    bool more_wanted = false;
+
+    // Whichever driver the suite is pointed at, rather than a name that is right on one
+    // runner and absent on the next.
+    auto const driver = NANODBC_TEXT("Driver={") +
+                        connection_string_parameter(NANODBC_TEXT("Driver")) + NANODBC_TEXT("}");
+    REQUIRE(driver != NANODBC_TEXT("Driver={}"));
+
+    auto const wanted = connection.browse_connect(driver, more_wanted);
+
+    // Given nothing but the driver, it wants the rest, and says which in a connection
+    // string of its own: the required attributes first, then the optional ones starred.
+    REQUIRE(more_wanted);
+    REQUIRE(!connection.connected());
+    REQUIRE(!wanted.empty());
+    REQUIRE(wanted.find(NANODBC_TEXT("SERVER")) != nanodbc::string::npos);
+    REQUIRE(wanted.find(NANODBC_TEXT("UID")) != nanodbc::string::npos);
+    REQUIRE(wanted.find(NANODBC_TEXT("PWD")) != nanodbc::string::npos);
+}
+
 // Binding a parameter in a direction other than PARAM_IN, which is what maps onto
 // SQL_PARAM_OUTPUT and SQL_PARAM_INPUT_OUTPUT.
 TEST_CASE_METHOD(mssql_fixture, "test_output_parameters", "[mssql][statement][bind]")

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -251,6 +251,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_connection_per_thread", "[mysql][connectio
     test_connection_per_thread();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_browse_connect_unsupported", "[mysql][connection][browse]")
+{
+    test_browse_connect_unsupported();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_dbms_info", "[mysql][dmbs][metadata][info]")
 {
     test_dbms_info();

--- a/test/oracle_test.cpp
+++ b/test/oracle_test.cpp
@@ -127,6 +127,11 @@ TEST_CASE_METHOD(oracle_fixture, "test_connection_per_thread", "[oracle][connect
     test_connection_per_thread();
 }
 
+TEST_CASE_METHOD(oracle_fixture, "test_browse_connect_unsupported", "[oracle][connection][browse]")
+{
+    test_browse_connect_unsupported();
+}
+
 TEST_CASE_METHOD(oracle_fixture, "test_datasources", "[oracle][datasources]")
 {
     test_datasources();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -192,6 +192,14 @@ TEST_CASE_METHOD(
     test_connection_per_thread();
 }
 
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "test_browse_connect_unsupported",
+    "[postgresql][connection][browse]")
+{
+    test_browse_connect_unsupported();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_dbms_info", "[postgresql][dmbs][metadata][info]")
 {
     test_dbms_info();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -260,6 +260,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_connection_per_thread", "[sqlite][connect
     test_connection_per_thread();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "test_browse_connect_unsupported", "[sqlite][connection][browse]")
+{
+    test_browse_connect_unsupported();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_date", "[sqlite][date]")
 {
     test_date();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -5568,6 +5568,19 @@ PRIMARY KEY(t2_fid)
 #endif
     }
 
+    // A driver that cannot answer what SQLBrowseConnect asks says so through the
+    // diagnostics rather than by any other means, so a caller learns it by asking. This
+    // is registered for the backends whose drivers do not support it; SQL Server's does,
+    // and is covered by test_browse_connect.
+    void test_browse_connect_unsupported()
+    {
+        nanodbc::connection connection;
+        bool more_wanted = false;
+        REQUIRE_THROWS_AS(
+            connection.browse_connect(connection_string_, more_wanted), nanodbc::database_error);
+        REQUIRE(!connection.connected());
+    }
+
     void test_std_optional()
     {
 #ifdef NANODBC_HAS_STD_OPTIONAL


### PR DESCRIPTION
Closes #235.

`connection::browse_connect` wraps `SQLBrowseConnect`, which answers with the attributes a driver still wants, spelled as a connection string of its own. Given nothing but its name, SQL Server's driver says:

```
SERVER:Server={};UID:Login ID=?;PWD:Password=?;Trusted_Connection:Use Integrated Security=?;*APP:AppName=?;*WSID:WorkStation ID=?;
```

The required attributes come first and the optional ones are starred, which is the discovery the issue asks for.

```cpp
nanodbc::connection conn;
bool more_wanted = false;
auto wanted = conn.browse_connect(NANODBC_TEXT("Driver={ODBC Driver 18 for SQL Server}"), more_wanted);
```

The handle lives across the calls. `connect()` frees and allocates one every time, which would lose the exchange halfway, so browsing keeps the one it started with.

## Which drivers answer

Measured rather than assumed:

| driver | |
| --- | --- |
| ODBC Driver 18 for SQL Server | answers |
| PostgreSQL Unicode | `HYC00: Function not implemented` |
| SQLite3 | `IM001: not supported` |
| MySQL ODBC 8.4 | `Driver does not support this API` |

Each of those arrives as a `database_error`, so a caller finds out by asking, which is the only way ODBC offers.

## What is not covered

The exchange is meant to be repeated, each answer carrying more of what the driver wants until it has enough and connects. **It does not complete on this stack.** Given the server, login and password, SQL Server's driver returns `SQL_NEED_DATA` again with the same request, and never connects.

That is not this wrapper. The same happens through raw ODBC with nanodbc out of the picture:

```
step1 rc=99 (SQL_NEED_DATA) out=[SERVER:Server={};UID:Login ID=?;...]
step2 rc=99 (SQL_NEED_DATA) out=[SERVER:Server={};UID:Login ID=?;...]
```

Tried with the value braced as the request spells it, `SERVER={mssql}`, with the same result. Whether unixODBC carries the browse state between calls, or the driver wants the attributes in some form I have not found, I could not settle — so the first request is what is tested, and connecting by this route is not. Worth knowing before anyone relies on it.

## Testing

```
mssql        All tests passed (6 assertions in 1 test case)   # the request enumerates attributes
sqlite       All tests passed (2 assertions in 1 test case)   # raises, as its driver does not
postgresql   All tests passed (2 assertions in 1 test case)
mysql        All tests passed (2 assertions in 1 test case)
```

Full suites:

```
sqlite       All tests passed (1671 assertions in 93 test cases)
postgresql   All tests passed (5973 assertions in 97 test cases)
mysql        All tests passed (2152 assertions in 94 test cases)
mssql        All tests passed (35830 assertions in 148 test cases)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)