### PR TITLE
Cover binding a parameter without preparing first

### DIFF
--- a/doc/use.rst
+++ b/doc/use.rst
@@ -331,6 +331,46 @@ Each connection allocates an ODBC environment of its own, so nothing is shared b
 Sharing one connection between threads is a different matter, and nanodbc makes no guarantee about it. A ``connection``, a ``statement`` and a ``result`` are handles onto driver state; two threads using one at the same time is for the caller to synchronize. Every thread joining before the objects it used go out of scope is the caller's business too — a crash on shutdown is more often threads outliving what they captured than anything the driver did.
 
 ******************************************************************************
+Binding without preparing
+******************************************************************************
+
+Binding a value asks the driver what the parameter is — its type, its size, its scale — through ``SQLDescribeParam``, and that needs a prepared statement. So a bind before ``prepare()`` fails:
+
+.. code-block:: text
+
+    HY010: [unixODBC][Driver Manager]Function sequence error
+
+For a stored procedure whose parameters the caller already knows, preparing is a round trip spent asking a question with a known answer. ``describe_parameters`` supplies it instead, after which binding has nothing to ask and ``execute_direct`` runs the statement:
+
+.. code-block:: cpp
+
+    #include <nanodbc/nanodbc.h>
+    #include <sql.h>
+    #include <sqlext.h>
+    #include <vector>
+
+    int main()
+    {
+        nanodbc::connection conn(NANODBC_TEXT("dsn"));
+        nanodbc::statement stmt(conn);
+
+        std::vector<short> const index{0, 1};
+        std::vector<short> const type{SQL_INTEGER, SQL_VARCHAR};
+        std::vector<unsigned long> const size{10, 20};
+        std::vector<short> const scale{0, 0};
+        stmt.describe_parameters(index, type, size, scale);
+
+        int const i = 7;
+        nanodbc::string const s = NANODBC_TEXT("no prepare");
+        stmt.bind(0, &i);
+        stmt.bind(1, s.c_str());
+
+        stmt.execute_direct(conn, NANODBC_TEXT("insert into t (i, s) values (?, ?)"));
+    }
+
+A description holds for as long as the statement does, so a statement executed repeatedly is described once. Describing only some of the parameters is allowed; the rest are asked about as usual, which then needs the statement prepared.
+
+******************************************************************************
 Examples
 ******************************************************************************
 

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -2714,6 +2714,43 @@ TEST_CASE_METHOD(mssql_fixture, "test_output_parameter_is_null", "[mssql][statem
     REQUIRE_THROWS_AS(statement.parameter_is_null(0, 64), nanodbc::index_range_error);
 }
 
+// Binding without preparing first. A bind asks the driver what the parameter is, which
+// needs a prepared statement, unless it has been told already.
+TEST_CASE_METHOD(mssql_fixture, "test_bind_without_prepare", "[mssql][statement][bind]")
+{
+    auto connection = connect();
+    create_table(
+        connection,
+        NANODBC_TEXT("test_bind_without_prepare"),
+        NANODBC_TEXT("(i int, s varchar(20))"));
+
+    nanodbc::statement statement(connection);
+
+    // Saying what the parameters are, so that binding does not have to ask.
+    std::vector<short> const index{0, 1};
+    std::vector<short> const type{SQL_INTEGER, SQL_VARCHAR};
+    std::vector<unsigned long> const size{10, 20};
+    std::vector<short> const scale{0, 0};
+    statement.describe_parameters(index, type, size, scale);
+
+    int const i = 7;
+    nanodbc::string const s = NANODBC_TEXT("no prepare");
+    statement.bind(0, &i);
+    statement.bind(1, s.c_str());
+
+    statement.execute_direct(
+        connection, NANODBC_TEXT("insert into test_bind_without_prepare (i, s) values (?, ?)"));
+
+    auto results = execute(connection, NANODBC_TEXT("select i, s from test_bind_without_prepare;"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<int>(0) == 7);
+    REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("no prepare"));
+
+    // Without describing them, the bind has to ask, and there is nothing to ask about.
+    nanodbc::statement undescribed(connection);
+    REQUIRE_THROWS_AS(undescribed.bind(0, &i), nanodbc::database_error);
+}
+
 // Binding a parameter in a direction other than PARAM_IN, which is what maps onto
 // SQL_PARAM_OUTPUT and SQL_PARAM_INPUT_OUTPUT.
 TEST_CASE_METHOD(mssql_fixture, "test_output_parameters", "[mssql][statement][bind]")


### PR DESCRIPTION
Closes #207.

The issue asks to bind input and output parameters for a stored procedure without preparing, preparing being a round trip it does not need. **That works today**, and I said otherwise on the issue in an earlier pass — this corrects it.

Binding asks the driver what a parameter is through `SQLDescribeParam`, which needs a prepared statement, so a bind before `prepare()` fails:

```
HY010: [unixODBC][Driver Manager]Function sequence error
```

That is what I tested before, and concluded from it that the whole thing was impossible pending new API. It is not: `describe_parameters` supplies the answer, so binding has nothing to ask.

```cpp
nanodbc::statement stmt(conn);

std::vector<short> const index{0, 1};
std::vector<short> const type{SQL_INTEGER, SQL_VARCHAR};
std::vector<unsigned long> const size{10, 20};
std::vector<short> const scale{0, 0};
stmt.describe_parameters(index, type, size, scale);

stmt.bind(0, &i);
stmt.bind(1, s.c_str());
stmt.execute_direct(conn, NANODBC_TEXT("insert into t (i, s) values (?, ?)"));
```

The row lands, with no prepare and no `SQLDescribeParam`. The method has been public and documented since long before the issue was filed, saying exactly this:

> Calling this method is optional: if a parameter is not described using a call to this method, then during a bind an attempt is made to identify it using a call to the ODBC SQLDescribeParam API handle.

Nothing pointed from the problem to the method, which is why it stayed open for six years.

## What this adds

- `test_bind_without_prepare` covers it, and covers the failure too: an undescribed parameter bound without preparing still raises, so the reason it works is the description rather than anything incidental.
- `doc/use.rst` gains a section, since the answer being in a method's own documentation is no help to someone who does not know to look there.

The other half of the issue, that `execute_direct` reopens the statement and discards what was bound, stopped happening some time ago: `open()` returns early when the statement is already open on that connection. Checked again here — the bindings survive and the insert uses them.

## Testing

```
test_bind_without_prepare   All tests passed (6 assertions in 1 test case)
mssql full suite            All tests passed (35885 assertions in 148 test cases)
```

SQL Server only, as with the other tests that need a stored procedure or a specific parameter shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)