### PR TITLE
Title the landing page so it fits on one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v3.0.0
 
+- The documentation's landing page is titled "nanodbc - C++ ODBC wrapper", which fits on one line where the longer wording wrapped, the heading's own anchor link taking up the width that tipped it over.
 - nanodbc requires C++17. C++11 and C++14 are no longer supported, and the conditionals standing in for `std::optional`, `std::variant`, `std::any` and `std::string_view` are gone, the four being there unconditionally. The `NANODBC_HAS_STD_*` macros are still defined, so code asking whether the feature is there keeps compiling.
 - `statement::bind` and `statement::bind_strings` take a `std::optional`, and a vector of them, so an absent value binds as null without a sentry value or an array of flags kept in step with the values. The sentry and flag overloads remain.
 - The observers whose answer is the whole point are `[[nodiscard]]`: `result::next` and the rest of the navigation, `is_null`, `get`, `get_as` and the column accessors, along with `connected`, `rows`, `columns` and `affected_rows`. Discarding one of them was a quiet way to read the wrong row. `execute` and `transact` are left alone, ignoring their result being a fair thing to do.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,7 @@
 .. _index:
 
 ##############################################################################
-nanodbc - C++ wrapper for ODBC API
+nanodbc - C++ ODBC wrapper
 ##############################################################################
 
 nanodbc is a small library that makes ODBC API programming easy and fun again.


### PR DESCRIPTION
## What does this PR do?

Retitles the documentation landing page so the heading stops wrapping.

`nanodbc - C++ wrapper for ODBC API` wrapped, orphaning "API" on a second line. Dropping "API" alone only moved the wrap onto "ODBC" — the cause is the anchor link Sphinx appends to every heading, which reserves about 27px at the end of the line, and the phrase sat right at that boundary either way. Removing the anchor in the page drops the old title to one line, which is what identified it.

`nanodbc - C++ ODBC wrapper` clears the boundary. Measured at 1600, 1320, 1150, 1024 and 900px: one line at every width, in light and dark.

| Title | Result |
| --- | --- |
| `nanodbc - C++ wrapper for ODBC API` (was) | wraps, "API" orphaned |
| `nanodbc - C++ wrapper for ODBC` | wraps, "ODBC" orphaned |
| `nanodbc - C++ ODBC wrapper` | one line |

Nothing links to the heading's generated anchor, which changes from `#nanodbc-c-wrapper-for-odbc` to `#nanodbc-c-odbc-wrapper`; the `.. _index:` label that pages actually cross-reference is unchanged. The "A small C++ wrapper for the native C ODBC API" brief in `README.md`, `doc/conf.py` and `doc/Doxyfile` is a description rather than the page title and is left alone.

## What are related issues/pull requests?

Follows #537. The changelog entry goes under `v3.0.0` rather than opening a section of its own: this is docs-only and 3.0.0 is minutes old, so the tag is being moved onto the merge commit and the Release workflow re-run, rather than spending a 3.0.1 on a page title.

## Tasklist

- [x] Retitle the landing page
- [x] Changelog entry under v3.0.0
- [ ] Review
- [ ] Adjust for comments
- [ ] All CI builds and checks have passed

## Environment

Not applicable; documentation only. Built locally with `make -C doc clean html`, warning-free from Sphinx and Doxygen, and rstcheck and markdownlint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
