### PR TITLE
Test against ClickHouse, and say what its driver will not do

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -512,3 +512,61 @@ jobs:
       - name: Test
         run: |
           ctest --test-dir ${GITHUB_WORKSPACE}/build --output-on-failure --no-tests=error -R sqlite_tests
+
+  test-clickhouse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        cxxstd: ["17", "20"]
+        # The release ships an ANSI and a Unicode driver, and either serves either width
+        # of build, so each is covered by the build that matches it.
+        build:
+          - { unicode: "OFF", driver: "ANSI" }
+          - { unicode: "ON", driver: "Unicode" }
+    name: test-clickhouse (unicode ${{ matrix.build.unicode }}, c++${{ matrix.cxxstd }})
+    services:
+      clickhouse:
+        image: clickhouse/clickhouse-server:latest
+        ports:
+          - 8123:8123
+        env:
+          CLICKHOUSE_USER: nanodbc
+          CLICKHOUSE_PASSWORD: nanodbc
+          CLICKHOUSE_DB: nanodbc
+        options: >-
+          --health-cmd "clickhouse-client --user nanodbc --password nanodbc --query 'select 1'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Both drivers are registered; the connection string below names the one this
+      # build uses. The Linux assets are published for x86_64 only, which the runners are.
+      - name: Install
+        run: |
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y ccache unixodbc-dev unzip
+          curl -fsSL -o /tmp/clickhouse-odbc.zip https://github.com/ClickHouse/clickhouse-odbc/releases/download/v1.5.5.20260810/clickhouse-odbc-linux-Clang-UnixODBC-Release.zip
+          unzip -oq /tmp/clickhouse-odbc.zip -d /tmp/clickhouse-odbc
+          sudo tar -xzf /tmp/clickhouse-odbc/clickhouse-odbc-1.5.5-Linux.tar.gz -C /opt
+          sudo mv /opt/clickhouse-odbc-1.5.5-Linux /opt/clickhouse-odbc
+          printf '[ClickHouse ODBC Driver (ANSI)]\nDescription=ODBC Driver (ANSI) for ClickHouse\nDriver=/opt/clickhouse-odbc/lib/libclickhouseodbc.so\n\n[ClickHouse ODBC Driver (Unicode)]\nDescription=ODBC Driver (Unicode) for ClickHouse\nDriver=/opt/clickhouse-odbc/lib/libclickhouseodbcw.so\n' \
+            | sudo odbcinst -i -d -r
+          odbcinst -q -d
+      - name: Restore compiled objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.ccache
+          key: ccache-clickhouse-${{ matrix.build.unicode }}-${{ matrix.cxxstd }}-${{ github.sha }}
+          restore-keys: ccache-clickhouse-${{ matrix.build.unicode }}-${{ matrix.cxxstd }}-
+      - name: Configure
+        run: |
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }} -DNANODBC_ENABLE_UNICODE=${{ matrix.build.unicode }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+      - name: Build
+        run: |
+          cmake --build ${GITHUB_WORKSPACE}/build --parallel --target clickhouse_tests
+      - name: Test
+        run: |
+          export NANODBC_TEST_CONNSTR_CLICKHOUSE="Driver={ClickHouse ODBC Driver (${{ matrix.build.driver }})};Server=localhost;Port=8123;Database=nanodbc;UID=nanodbc;PWD=nanodbc;"
+          ctest --test-dir ${GITHUB_WORKSPACE}/build --output-on-failure --no-tests=error -R clickhouse_tests

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -542,18 +542,22 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Both drivers are registered; the connection string below names the one this
-      # build uses. The Linux assets are published for x86_64 only, which the runners are.
       - name: Install
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y ccache unixodbc-dev unzip
+          apt-get -o DPkg::Lock::Timeout=120 update
+          apt-get -o DPkg::Lock::Timeout=120 install -y ccache unixodbc unixodbc-dev odbcinst unzip
+        shell: sudo bash {0}
+      # The release ships an ANSI and a Unicode driver and both are registered; the
+      # connection string below names the one this build uses. The Linux assets are
+      # published for x86_64 only, which the runners are.
+      - name: Install the ClickHouse ODBC driver
+        run: |
           curl -fsSL -o /tmp/clickhouse-odbc.zip https://github.com/ClickHouse/clickhouse-odbc/releases/download/v1.5.5.20260810/clickhouse-odbc-linux-Clang-UnixODBC-Release.zip
           unzip -oq /tmp/clickhouse-odbc.zip -d /tmp/clickhouse-odbc
           sudo tar -xzf /tmp/clickhouse-odbc/clickhouse-odbc-1.5.5-Linux.tar.gz -C /opt
           sudo mv /opt/clickhouse-odbc-1.5.5-Linux /opt/clickhouse-odbc
           printf '[ClickHouse ODBC Driver (ANSI)]\nDescription=ODBC Driver (ANSI) for ClickHouse\nDriver=/opt/clickhouse-odbc/lib/libclickhouseodbc.so\n\n[ClickHouse ODBC Driver (Unicode)]\nDescription=ODBC Driver (Unicode) for ClickHouse\nDriver=/opt/clickhouse-odbc/lib/libclickhouseodbcw.so\n' \
             | sudo odbcinst -i -d -r
-          odbcinst -q -d
       - name: Restore compiled objects
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- ClickHouse is covered by a suite of its own and a CI job, running against the server's own container and the Apache-2.0 ODBC driver, in a narrow build and a Unicode one. Its driver answers `SQLDescribeParam` with `SQL_UNKNOWN_TYPE` rather than failing, so the suite describes each parameter itself, and it covers what the driver does with an array of values, a rolled back transaction, a view and a null in a column not declared to hold one, none of which behaves the way the shared cases assume. [`#485`](https://github.com/nanodbc/nanodbc/issues/485)
+- ClickHouse is tested, in a suite of its own, its driver needing every parameter described first. [`#485`](https://github.com/nanodbc/nanodbc/issues/485)
 
 ## v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## Unreleased
+
+- ClickHouse is covered by a suite of its own and a CI job, running against the server's own container and the Apache-2.0 ODBC driver, in a narrow build and a Unicode one. Its driver answers `SQLDescribeParam` with `SQL_UNKNOWN_TYPE` rather than failing, so the suite describes each parameter itself, and it covers what the driver does with an array of values, a rolled back transaction, a view and a null in a column not declared to hold one, none of which behaves the way the shared cases assume. [`#485`](https://github.com/nanodbc/nanodbc/issues/485)
+
 ## v3.0.0
 
 - The documentation's landing page is titled "nanodbc - C++ ODBC wrapper", which fits on one line where the longer wording wrapped, the heading's own anchor link taking up the width that tipped it over.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -75,6 +75,23 @@ RUN arch="$(uname -m)" \
     | odbcinst -i -d -r \
     ; else echo "Instant Client is x86_64 only; skipping on ${arch}"; fi
 
+# ClickHouse ODBC, published for x86_64 only, so the driver is registered only where it
+# can load, the way Instant Client above is. The release ships an ANSI and a Unicode
+# driver, and both are registered, either serving either width of build.
+RUN arch="$(uname -m)" \
+    && if [ "${arch}" = "x86_64" ]; then \
+    apt-get -qy update \
+    && apt-get -qy install --no-upgrade --no-install-recommends unzip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL -o /tmp/clickhouse-odbc.zip https://github.com/ClickHouse/clickhouse-odbc/releases/download/v1.5.5.20260810/clickhouse-odbc-linux-Clang-UnixODBC-Release.zip \
+    && unzip -oq /tmp/clickhouse-odbc.zip -d /tmp/clickhouse-odbc \
+    && tar -xzf /tmp/clickhouse-odbc/clickhouse-odbc-1.5.5-Linux.tar.gz -C /opt \
+    && rm -rf /tmp/clickhouse-odbc.zip /tmp/clickhouse-odbc \
+    && mv /opt/clickhouse-odbc-1.5.5-Linux /opt/clickhouse-odbc \
+    && printf '[ClickHouse ODBC Driver (ANSI)]\nDescription=ODBC Driver (ANSI) for ClickHouse\nDriver=/opt/clickhouse-odbc/lib/libclickhouseodbc.so\n\n[ClickHouse ODBC Driver (Unicode)]\nDescription=ODBC Driver (Unicode) for ClickHouse\nDriver=/opt/clickhouse-odbc/lib/libclickhouseodbcw.so\n' \
+    | odbcinst -i -d -r \
+    ; else echo "ClickHouse ODBC is x86_64 only; skipping on ${arch}"; fi
+
 # MySQL names the x86_64 build x86-64bit and the arm64 one aarch64.
 RUN arch="$(uname -m)" \
     && if [ "${arch}" = "x86_64" ]; then arch="x86-64bit"; fi \

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ root@hash:/opt/nanodbc# ctest --test-dir build --output-on-failure -R sqlite_tes
 
 The SQLite and utility tests need no server at all, so they are the quickest way to check a change.
 
-`POSTGRES_VERSION`, `MYSQL_VERSION`, `MARIADB_VERSION` and `MSSQL_VERSION` override the image tag of the matching service, each defaulting to a current release of that server. This is how a version from the CI matrix is reproduced: the PostgreSQL matrix in [ci-linux.yml](.github/workflows/ci-linux.yml) covers every release still under support, 14 through 18, and the MySQL, MariaDB and PostgreSQL matrices in [ci-windows.yml](.github/workflows/ci-windows.yml) cover their own sets. The compose defaults do not all appear in those matrices, so pin the version explicitly when reproducing a CI failure:
+`POSTGRES_VERSION`, `MYSQL_VERSION`, `MARIADB_VERSION`, `MSSQL_VERSION` and `CLICKHOUSE_VERSION` override the image tag of the matching service, each defaulting to a current release of that server. This is how a version from the CI matrix is reproduced: the PostgreSQL matrix in [ci-linux.yml](.github/workflows/ci-linux.yml) covers every release still under support, 14 through 18, and the MySQL, MariaDB and PostgreSQL matrices in [ci-windows.yml](.github/workflows/ci-windows.yml) cover their own sets. The compose defaults do not all appear in those matrices, so pin the version explicitly when reproducing a CI failure:
 
 ```shell
 POSTGRES_VERSION=14 docker compose up -d pgsql
@@ -200,6 +200,8 @@ docker compose run --rm \
 ```
 
 The Vertica tests need Vertica's own ODBC driver, which the development image does not carry, so a full `ctest` run excludes them with `-E vertica_tests`.
+
+ClickHouse's ODBC driver is published for Linux on x86_64 only, so the development image registers it only there. On an Apple Silicon host the server still starts, but nothing can reach it, and a full run excludes that suite as well with `-E 'vertica_tests|clickhouse_tests'`.
 
 When you are done, `docker compose down` stops everything, and `docker compose down -v` also discards the databases' data.
 
@@ -225,7 +227,7 @@ The tests structure:
 To add new test case:
 
 1. In `test/test_case_fixture.h` file, add a new test case method to `test_case_fixture` class (e.g. `void my_feature_test()`).
-2. In each `test/<database>_test.cpp` file, copy and paste the `TEST_CASE_METHOD` boilerplate, updating name, tags, etc.
+2. In each `test/<database>_test.cpp` file, copy and paste the `TEST_CASE_METHOD` boilerplate, updating name, tags, etc. `clickhouse_test.cpp` runs only part of the shared set, its driver and server being unable to do the rest, so a new shared case belongs there only if it passes.
 
 If a feature requires a database-specific test case for each database, then skip the `test/test_case_fixture.h` step and write a dedicated test case directly in `test/<database>_test.cpp` file.
 

--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -86,9 +86,9 @@ The tests are built with the ``tests`` target and run with `ctest`_. They are la
 * ``test/test_case_fixture.h`` holds the test cases that run against every backend.
 * ``test/<database>_test.cpp`` is the source for an independent test program that includes both the common and the database-specific test cases. ``test/main.cpp`` supplies the ``main()`` each of them links against, and ``test/CMakeLists.txt`` lists the databases a program is built for.
 
-To add a new test case, add a method to ``test_case_fixture`` in ``test/test_case_fixture.h``, then copy the ``TEST_CASE_METHOD`` boilerplate into each ``test/<database>_test.cpp``, updating name and tags. A test that only makes sense for one database goes straight into that database's source file instead.
+To add a new test case, add a method to ``test_case_fixture`` in ``test/test_case_fixture.h``, then copy the ``TEST_CASE_METHOD`` boilerplate into each ``test/<database>_test.cpp``, updating name and tags. A test that only makes sense for one database goes straight into that database's source file instead. ``clickhouse_test.cpp`` runs only part of the shared set, its driver and server being unable to do the rest, so a new shared case belongs there only if it passes.
 
-The SQLite and utility tests need no server, so they are the quickest way to check a change. The Vertica tests need Vertica's own ODBC driver, which the development image does not carry, so a full run excludes them:
+The SQLite and utility tests need no server, so they are the quickest way to check a change. The Vertica tests need Vertica's own ODBC driver, which the development image does not carry, so a full run excludes them. ClickHouse's driver is published for Linux on x86_64 only, so on an Apple Silicon host that suite has to be excluded as well, with ``-E 'vertica_tests|clickhouse_tests'``:
 
 .. code-block:: console
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -141,7 +141,7 @@ Why should you use nanodbc?
 * Portable! nanodbc uses only standard C++ headers in addition to the ODBC API headers.
 * Robust! Where it makes sense, error handling is done with exceptions instead of return codes.
 * Features! nanodbc supports ODBC 3, SQLDriverConnect(), transactions, bound parameters, bulk operations, and much more.
-* Tested! The suites cover SQLite, PostgreSQL, MySQL, MariaDB, SQL Server and Vertica, each of which runs as a container so that none of them has to be installed to work on nanodbc.
+* Tested! The suites cover SQLite, PostgreSQL, MySQL, MariaDB, SQL Server, Oracle, ClickHouse and Vertica, each of which runs as a container so that none of them has to be installed to work on nanodbc.
 * Documented! These pages cover :ref:`installation <install>` and :ref:`usage <use>`, and the :ref:`API reference <api>` is generated from the source.
 * Active! nanodbc is maintained and open to contributions, see :ref:`Develop <develop>`.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -157,7 +157,7 @@ There is one test program per database, so a single suite can be run on its own:
 
   ctest --test-dir build --output-on-failure -R sqlite_tests
 
-The utility tests need no database at all, and the SQLite tests need only a SQLite ODBC driver, registered as ``SQLite3`` on \*nix systems and as ``SQLite3 ODBC Driver`` on Windows, since the tests name the driver rather than a data source. Those two are the quickest way to check a build. The remaining suites need a running server, and the Vertica tests additionally need Vertica's own ODBC driver, which is why a full run excludes them.
+The utility tests need no database at all, and the SQLite tests need only a SQLite ODBC driver, registered as ``SQLite3`` on \*nix systems and as ``SQLite3 ODBC Driver`` on Windows, since the tests name the driver rather than a data source. Those two are the quickest way to check a build. The remaining suites need a running server, and the Vertica tests additionally need Vertica's own ODBC driver, which is why a full run excludes them. ClickHouse's driver is published for Linux on x86_64 only, so that suite has to be excluded too on any other host.
 
 Each suite reads its own ``NANODBC_TEST_CONNSTR_<DB>`` environment variable for the connection string, falling back to ``NANODBC_TEST_CONNSTR``. Rather than installing the servers, use the containers the repository provides, which preset those variables; see :ref:`Develop <develop>`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,33 @@ services:
       retries: 30
       start_period: 60s
 
+  clickhouse:
+    image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-latest}
+    container_name: nanoclickhouse
+    restart: unless-stopped
+    ports:
+      - "8123:8123"
+    environment:
+      CLICKHOUSE_USER: *default_credential
+      CLICKHOUSE_PASSWORD: *default_credential
+      CLICKHOUSE_DB: *default_credential
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "clickhouse-client",
+          "--user",
+          "nanodbc",
+          "--password",
+          "nanodbc",
+          "--query",
+          "select 1",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
   oracle:
     image: gvenzl/oracle-free:${ORACLE_VERSION:-23-slim-faststart}
     container_name: nanooracle
@@ -133,6 +160,8 @@ services:
         condition: service_healthy
       mssql:
         condition: service_healthy
+      clickhouse:
+        condition: service_healthy
     # Oracle is deliberately not depended on: it takes minutes to open and its driver is
     # published for x86_64 only, so waiting for it would cost every run on every host to
     # serve the one suite that cannot run on some of them. Start it when it is wanted,
@@ -160,3 +189,6 @@ services:
       NANODBC_TEST_CONNSTR_MARIADB: "Driver={MariaDB Unicode};Server=mariadb;Port=3306;Database=nanodbc;User=root;Password=nanodbc;"
       NANODBC_TEST_CONNSTR_MSSQL: "Driver={ODBC Driver 18 for SQL Server};Server=mssql;Database=master;UID=sa;PWD=Password12!;TrustServerCertificate=yes;"
       NANODBC_TEST_CONNSTR_ORACLE: "Driver={Oracle};DBQ=oracle:1521/FREEPDB1;UID=system;PWD=nanodbc;"
+      # Either of the two drivers the release ships serves either width of build; the
+      # Unicode one is named here, and CI pairs each with the build that matches it.
+      NANODBC_TEST_CONNSTR_CLICKHOUSE: "Driver={ClickHouse ODBC Driver (Unicode)};Server=clickhouse;Port=8123;Database=nanodbc;UID=nanodbc;PWD=nanodbc;"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@ target_compile_features(utility_tests PRIVATE cxx_std_17)
 add_test(NAME utility_tests COMMAND utility_tests)
 add_dependencies(tests utility_tests)
 
-set(test_list mssql mysql oracle postgresql sqlite vertica)
+set(test_list clickhouse mssql mysql oracle postgresql sqlite vertica)
 
 foreach(test_item IN LISTS test_list)
   if (DEFINED ENV{CI} AND DEFINED ENV{DB})

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -257,7 +257,8 @@ struct base_test_fixture
         postgresql,
         mysql,
         sqlserver,
-        vertica
+        vertica,
+        clickhouse
     };
 
     base_test_fixture()
@@ -304,6 +305,8 @@ struct base_test_fixture
             return database_vendor::sqlserver;
         else if (contains_string(dbms, NANODBC_TEXT("Vertica")))
             return database_vendor::vertica;
+        else if (contains_string(dbms, NANODBC_TEXT("ClickHouse")))
+            return database_vendor::clickhouse;
         else
             return database_vendor::unknown;
     }

--- a/test/clickhouse_test.cpp
+++ b/test/clickhouse_test.cpp
@@ -1,0 +1,508 @@
+#include "test_case_fixture.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace
+{
+struct clickhouse_fixture : public test_case_fixture
+{
+    clickhouse_fixture()
+        : test_case_fixture()
+    {
+        // connection string from command line or NANODBC_TEST_CONNSTR environment variable
+        if (connection_string_.empty())
+            connection_string_ = get_env("NANODBC_TEST_CONNSTR_CLICKHOUSE");
+    }
+
+    // The driver answers SQLDescribeParam with SQL_UNKNOWN_TYPE rather than failing, so
+    // nanodbc has no type to bind with and ClickHouse rejects the parameter as `Nothing`.
+    // Every test here that binds a parameter says what it is binding first, which is what
+    // statement::describe_parameters is for.
+    static void describe(
+        nanodbc::statement& statement,
+        std::vector<short> const& type,
+        std::vector<unsigned long> const& size)
+    {
+        std::vector<short> index(type.size());
+        for (std::size_t i = 0; i < index.size(); ++i)
+            index[i] = static_cast<short>(i);
+        statement.describe_parameters(index, type, size, std::vector<short>(type.size(), 0));
+    }
+};
+} // namespace
+
+// Test cases shared with the other backends.
+//
+// The set is smaller than theirs, and what is missing is missing because the driver or the
+// server cannot do it rather than because it went unconsidered: array binding, which the
+// driver takes one row of; transactions, which ClickHouse does not have; views and schemas,
+// which the driver does not report; and any column that has to hold a null, which needs a
+// Nullable type rather than the plain one the shared table definitions use. Each of those
+// is covered below by a test of its own that states what does happen.
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_driver", "[clickhouse][driver]")
+{
+    test_driver();
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_driver_info", "[clickhouse][driver][metadata][info]")
+{
+    test_driver_info();
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_datasources", "[clickhouse][datasources]")
+{
+    test_datasources();
+}
+
+TEST_CASE_METHOD(
+    clickhouse_fixture,
+    "test_catalog_list_catalogs",
+    "[clickhouse][catalog][catalogs]")
+{
+    test_catalog_list_catalogs();
+}
+
+TEST_CASE_METHOD(
+    clickhouse_fixture,
+    "test_catalog_list_table_types",
+    "[clickhouse][catalog][table_types]")
+{
+    test_catalog_list_table_types();
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_connection_environment", "[clickhouse][connection]")
+{
+    test_connection_environment();
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_dbms_info", "[clickhouse][dmbs][metadata][info]")
+{
+    test_dbms_info();
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_get_info", "[clickhouse][dmbs][metadata][info]")
+{
+    test_get_info();
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_execute_multiple", "[clickhouse][execute]")
+{
+    test_execute_multiple();
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_move", "[clickhouse][move]")
+{
+    test_move();
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_result_at_end", "[clickhouse][result]")
+{
+    test_result_at_end();
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_result_iterator", "[clickhouse][result][iterator]")
+{
+    test_result_iterator();
+}
+
+TEST_CASE_METHOD(
+    clickhouse_fixture,
+    "test_statement_usable_when_result_gone",
+    "[clickhouse][statement]")
+{
+    test_statement_usable_when_result_gone();
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_while_not_end_iteration", "[clickhouse][looping]")
+{
+    test_while_not_end_iteration();
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_while_next_iteration", "[clickhouse][looping]")
+{
+    test_while_next_iteration();
+}
+
+// ClickHouse-specific test cases.
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_vendor", "[clickhouse][dmbs][metadata][info]")
+{
+    auto connection = connect();
+    REQUIRE(vendor_ == database_vendor::clickhouse);
+}
+
+// The parameter description the driver will not give.
+TEST_CASE_METHOD(
+    clickhouse_fixture,
+    "test_parameter_not_described",
+    "[clickhouse][statement][bind]")
+{
+    auto connection = connect();
+    create_table(connection, NANODBC_TEXT("test_parameter_not_described"), NANODBC_TEXT("(i int)"));
+
+    nanodbc::statement statement(connection);
+    prepare(statement, NANODBC_TEXT("insert into test_parameter_not_described (i) values (?)"));
+    REQUIRE(statement.parameters() == 1);
+
+    // SQLDescribeParam succeeds and says nothing, which is the whole difficulty: a driver
+    // that failed the call outright would at least raise it here.
+    REQUIRE(statement.parameter_type(0) == SQL_UNKNOWN_TYPE);
+    REQUIRE(statement.parameter_size(0) == 0);
+    REQUIRE(statement.parameter_scale(0) == 0);
+
+    // Binding on that description reaches the server as an untyped parameter, which it
+    // refuses. The tests below describe the parameter first, and none of them sees this.
+    int value = 1;
+    statement.bind(0, &value);
+    REQUIRE_THROWS_AS(nanodbc::just_execute(statement), nanodbc::database_error);
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_bind_integral", "[clickhouse][bind][integral]")
+{
+    auto connection = connect();
+    create_table(
+        connection,
+        NANODBC_TEXT("test_bind_integral"),
+        NANODBC_TEXT("(i int, b bigint, f double)"));
+
+    nanodbc::statement statement(connection);
+    prepare(statement, NANODBC_TEXT("insert into test_bind_integral (i, b, f) values (?, ?, ?)"));
+    REQUIRE(statement.parameters() == 3);
+    describe(statement, {SQL_INTEGER, SQL_BIGINT, SQL_DOUBLE}, {10, 19, 15});
+
+    std::int32_t const i = -2147483648LL + 1;
+    std::int64_t const b = 9007199254740993LL; // more digits than a double holds exactly
+    double const f = 3.25;                     // exact in binary, so it compares equal
+    statement.bind(0, &i);
+    statement.bind(1, &b);
+    statement.bind(2, &f);
+    nanodbc::just_execute(statement);
+
+    auto results =
+        nanodbc::execute(connection, NANODBC_TEXT("select i, b, f from test_bind_integral"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<std::int32_t>(0) == i);
+    REQUIRE(results.get<std::int64_t>(1) == b);
+    REQUIRE(results.get<double>(2) == f);
+    REQUIRE(!results.next());
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_bind_string", "[clickhouse][bind][string]")
+{
+    auto connection = connect();
+    create_table(connection, NANODBC_TEXT("test_bind_string"), NANODBC_TEXT("(s varchar(60))"));
+
+    nanodbc::statement statement(connection);
+    prepare(statement, NANODBC_TEXT("insert into test_bind_string (s) values (?)"));
+    describe(statement, {SQL_VARCHAR}, {60});
+
+    auto const value = NANODBC_TEXT("this is a test");
+    statement.bind(0, value);
+    nanodbc::just_execute(statement);
+
+    auto results = nanodbc::execute(connection, NANODBC_TEXT("select s from test_bind_string"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<nanodbc::string>(0) == nanodbc::string(value));
+}
+
+// The round trip the backend was added for: ClickHouse types an unbounded varchar as
+// String, so a value far longer than the column was declared with survives it.
+TEST_CASE_METHOD(clickhouse_fixture, "test_bind_long_string", "[clickhouse][bind][string]")
+{
+    auto connection = connect();
+    create_table(
+        connection, NANODBC_TEXT("test_bind_long_string"), NANODBC_TEXT("(s varchar(60))"));
+
+    auto const value = create_random_string<nanodbc::string>(3000, 3000);
+    REQUIRE(value.size() == 3000);
+
+    nanodbc::statement statement(connection);
+    prepare(statement, NANODBC_TEXT("insert into test_bind_long_string (s) values (?)"));
+    describe(statement, {SQL_VARCHAR}, {static_cast<unsigned long>(value.size())});
+    statement.bind(0, value.c_str());
+    nanodbc::just_execute(statement);
+
+    auto results = nanodbc::execute(
+        connection, NANODBC_TEXT("select s, length(s) from test_bind_long_string"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<std::int64_t>(1) == 3000);
+    REQUIRE(results.get<nanodbc::string>(0) == value);
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_bind_date_and_timestamp", "[clickhouse][bind][time]")
+{
+    auto connection = connect();
+    create_table(
+        connection,
+        NANODBC_TEXT("test_bind_date_and_timestamp"),
+        NANODBC_TEXT("(d date, ts timestamp)"));
+
+    nanodbc::statement statement(connection);
+    prepare(
+        statement, NANODBC_TEXT("insert into test_bind_date_and_timestamp (d, ts) values (?, ?)"));
+    describe(statement, {SQL_DATE, SQL_TIMESTAMP}, {10, 19});
+
+    nanodbc::date date{2026, 8, 30};
+    nanodbc::timestamp timestamp{2026, 8, 30, 11, 45, 59, 0};
+    statement.bind(0, &date);
+    statement.bind(1, &timestamp);
+    nanodbc::just_execute(statement);
+
+    auto results = nanodbc::execute(
+        connection, NANODBC_TEXT("select d, ts from test_bind_date_and_timestamp"));
+    REQUIRE(results.next());
+
+    auto const d = results.get<nanodbc::date>(0);
+    REQUIRE(d.year == 2026);
+    REQUIRE(d.month == 8);
+    REQUIRE(d.day == 30);
+
+    // ClickHouse's DateTime counts whole seconds, so the fraction the timestamp carries is
+    // not part of the round trip.
+    auto const ts = results.get<nanodbc::timestamp>(1);
+    REQUIRE(ts.year == 2026);
+    REQUIRE(ts.month == 8);
+    REQUIRE(ts.day == 30);
+    REQUIRE(ts.hour == 11);
+    REQUIRE(ts.min == 45);
+    REQUIRE(ts.sec == 59);
+}
+
+// A column holds a null only if its type says so. ClickHouse spells that Nullable(T), and
+// a plain column asked to take a null quietly stores the type's default instead, which is
+// why the shared null tests, whose tables are declared with plain types, are not run here.
+TEST_CASE_METHOD(clickhouse_fixture, "test_null_needs_a_nullable_column", "[clickhouse][null]")
+{
+    auto connection = connect();
+
+    create_table(
+        connection,
+        NANODBC_TEXT("test_null_needs_a_nullable_column"),
+        NANODBC_TEXT("(plain int, nullable Nullable(Int32))"));
+    execute(
+        connection,
+        NANODBC_TEXT("insert into test_null_needs_a_nullable_column values (null, null);"));
+
+    auto results = nanodbc::execute(
+        connection, NANODBC_TEXT("select plain, nullable from test_null_needs_a_nullable_column"));
+    REQUIRE(results.next());
+
+    // The null the plain column was given is gone, and a zero stands in its place.
+    REQUIRE(!results.is_null(0));
+    REQUIRE(results.get<int>(0) == 0);
+
+    REQUIRE(results.is_null(1));
+    REQUIRE(results.get<int>(1, -1) == -1);
+    REQUIRE(results.get<nanodbc::string>(1, NANODBC_TEXT("null")) == NANODBC_TEXT("null"));
+    REQUIRE_THROWS_AS(results.get<int>(1), nanodbc::null_access_error);
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_bind_null", "[clickhouse][bind][null]")
+{
+    auto connection = connect();
+    create_table(
+        connection,
+        NANODBC_TEXT("test_bind_null"),
+        NANODBC_TEXT("(i Nullable(Int32), s Nullable(String))"));
+
+    nanodbc::statement statement(connection);
+    prepare(statement, NANODBC_TEXT("insert into test_bind_null (i, s) values (?, ?)"));
+    describe(statement, {SQL_INTEGER, SQL_VARCHAR}, {10, 60});
+    statement.bind_null(0);
+    statement.bind_null(1);
+    nanodbc::just_execute(statement);
+
+    auto results = nanodbc::execute(connection, NANODBC_TEXT("select i, s from test_bind_null"));
+    REQUIRE(results.next());
+    REQUIRE(results.is_null(0));
+    REQUIRE(results.is_null(1));
+    REQUIRE(!results.next());
+}
+
+// A bound array reaches the server as its first element and the rest is dropped, without
+// a diagnostic to say so. Covered so that the day the driver learns to bind an array, this
+// fails and the shared batch tests can be turned on for ClickHouse too.
+TEST_CASE_METHOD(clickhouse_fixture, "test_batch_binds_one_row", "[clickhouse][batch]")
+{
+    auto connection = connect();
+    create_table(connection, NANODBC_TEXT("test_batch_binds_one_row"), NANODBC_TEXT("(i int)"));
+
+    std::size_t const batch_size = 5;
+    int values[batch_size] = {1, 2, 3, 4, 5};
+
+    nanodbc::statement statement(connection);
+    prepare(statement, NANODBC_TEXT("insert into test_batch_binds_one_row (i) values (?)"));
+    describe(statement, {SQL_INTEGER}, {10});
+    statement.bind(0, values, batch_size);
+    nanodbc::just_execute(statement, batch_size);
+
+    auto results = nanodbc::execute(
+        connection,
+        NANODBC_TEXT("select toInt32(count()), toInt32(sum(i)) from test_batch_binds_one_row"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<int>(0) == 1);
+    REQUIRE(results.get<int>(1) == values[0]);
+}
+
+// ClickHouse has no transactions, and the driver says so through SQLGetInfo rather than by
+// refusing the calls: a commit is accepted and a rollback leaves the work in place.
+TEST_CASE_METHOD(clickhouse_fixture, "test_transaction_is_not_one", "[clickhouse][transaction]")
+{
+    auto connection = connect();
+    REQUIRE(connection.get_info<unsigned short>(SQL_TXN_CAPABLE) == SQL_TC_NONE);
+
+    create_table(connection, NANODBC_TEXT("test_transaction_is_not_one"), NANODBC_TEXT("(i int)"));
+    execute(connection, NANODBC_TEXT("insert into test_transaction_is_not_one values (1);"));
+
+    {
+        nanodbc::transaction transaction(connection);
+        execute(connection, NANODBC_TEXT("insert into test_transaction_is_not_one values (2);"));
+        transaction.rollback();
+    }
+
+    auto results = nanodbc::execute(
+        connection, NANODBC_TEXT("select toInt32(count()) from test_transaction_is_not_one"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<int>(0) == 2); // the rolled back row is still there
+}
+
+// A ClickHouse database stands where a schema would, and the driver reports it as a
+// catalog, leaving the schema list empty.
+TEST_CASE_METHOD(
+    clickhouse_fixture,
+    "test_catalog_has_no_schemas",
+    "[clickhouse][catalog][schemas]")
+{
+    auto connection = connect();
+    nanodbc::catalog catalog(connection);
+
+    REQUIRE(catalog.list_schemas().empty());
+
+    auto const catalogs = catalog.list_catalogs();
+    REQUIRE(!catalogs.empty());
+    REQUIRE(
+        std::find(catalogs.cbegin(), catalogs.cend(), NANODBC_TEXT("system")) != catalogs.cend());
+}
+
+// Only tables are reported. A view exists and can be selected from, but SQLTables does not
+// list it and VIEW is not among the table types the driver names.
+TEST_CASE_METHOD(clickhouse_fixture, "test_catalog_tables_only", "[clickhouse][catalog][tables]")
+{
+    auto connection = connect();
+    nanodbc::catalog catalog(connection);
+
+    nanodbc::string const table_name(NANODBC_TEXT("test_catalog_tables_only"));
+    nanodbc::string const view_name(NANODBC_TEXT("test_catalog_tables_only_view"));
+    create_table(connection, table_name, NANODBC_TEXT("(i int)"));
+    drop_table(connection, view_name, true);
+    execute(
+        connection,
+        NANODBC_TEXT("create view ") + view_name + NANODBC_TEXT(" as select i from ") + table_name);
+
+    {
+        auto const types = catalog.list_table_types();
+        REQUIRE(std::find(types.cbegin(), types.cend(), NANODBC_TEXT("TABLE")) != types.cend());
+        REQUIRE(std::find(types.cbegin(), types.cend(), NANODBC_TEXT("VIEW")) == types.cend());
+    }
+
+    {
+        auto tables = catalog.find_tables(table_name);
+        REQUIRE(tables.next());
+        REQUIRE(tables.table_name() == table_name);
+        REQUIRE(tables.table_type() == NANODBC_TEXT("TABLE"));
+        REQUIRE(!tables.table_catalog().empty()); // the database the connection opened
+        REQUIRE(tables.table_schema().empty());
+        REQUIRE(!tables.next());
+    }
+
+    {
+        auto views = catalog.find_tables(view_name, NANODBC_TEXT("VIEW"));
+        REQUIRE(!views.next());
+    }
+
+    // The view is there all the same, which is what makes its absence the driver's doing.
+    auto results =
+        nanodbc::execute(connection, NANODBC_TEXT("select toInt32(count()) from ") + view_name);
+    REQUIRE(results.next());
+}
+
+TEST_CASE_METHOD(clickhouse_fixture, "test_catalog_columns", "[clickhouse][catalog][columns]")
+{
+    auto connection = connect();
+    nanodbc::catalog catalog(connection);
+
+    nanodbc::string const table_name(NANODBC_TEXT("test_catalog_columns"));
+    create_table(
+        connection,
+        table_name,
+        NANODBC_TEXT(
+            "(c0 int, c1 smallint, c2 decimal(9, 3), c3 date, c4 varchar(60), "
+            "c5 Nullable(Int32))"));
+
+    auto columns = catalog.find_columns(NANODBC_TEXT("%"), table_name);
+
+    REQUIRE(columns.next());
+    REQUIRE(columns.column_name() == NANODBC_TEXT("c0"));
+    REQUIRE(columns.table_name() == table_name);
+    REQUIRE(columns.ordinal_position() == 1);
+    REQUIRE(columns.sql_data_type() == SQL_INTEGER);
+    REQUIRE(columns.type_name() == NANODBC_TEXT("Int32"));
+    // The reported size counts the sign among an Int32's eleven characters.
+    REQUIRE(columns.column_size() == 11);
+    REQUIRE(columns.decimal_digits() == 0);
+    REQUIRE(columns.nullable() == SQL_NO_NULLS);
+    REQUIRE(columns.is_nullable() == NANODBC_TEXT("NO"));
+
+    REQUIRE(columns.next());
+    REQUIRE(columns.column_name() == NANODBC_TEXT("c1"));
+    REQUIRE(columns.sql_data_type() == SQL_SMALLINT);
+    REQUIRE(columns.column_size() == 6);
+
+    REQUIRE(columns.next());
+    REQUIRE(columns.column_name() == NANODBC_TEXT("c2"));
+    REQUIRE(columns.sql_data_type() == SQL_DECIMAL);
+    REQUIRE(columns.column_size() == 9);
+    REQUIRE(columns.decimal_digits() == 3);
+
+    REQUIRE(columns.next());
+    REQUIRE(columns.column_name() == NANODBC_TEXT("c3"));
+    REQUIRE(columns.data_type() == SQL_TYPE_DATE);
+    REQUIRE(columns.column_size() == 10);
+
+    REQUIRE(columns.next());
+    REQUIRE(columns.column_name() == NANODBC_TEXT("c4"));
+    REQUIRE(columns.sql_data_type() == SQL_VARCHAR);
+    REQUIRE(columns.type_name() == NANODBC_TEXT("String"));
+
+    // Only the column declared Nullable is reported as one.
+    REQUIRE(columns.next());
+    REQUIRE(columns.column_name() == NANODBC_TEXT("c5"));
+    REQUIRE(columns.nullable() == SQL_NULLABLE);
+    REQUIRE(columns.is_nullable() == NANODBC_TEXT("YES"));
+
+    REQUIRE(!columns.next());
+}
+
+// The shared decimal test expects the scale the column was declared with to be part of the
+// text; ClickHouse's driver formats the value and drops what is trailing.
+TEST_CASE_METHOD(clickhouse_fixture, "test_decimal_conversion", "[clickhouse][decimal][conversion]")
+{
+    auto connection = connect();
+    create_table(
+        connection, NANODBC_TEXT("test_decimal_conversion"), NANODBC_TEXT("(d decimal(9, 3))"));
+    execute(connection, NANODBC_TEXT("insert into test_decimal_conversion values (12345.987);"));
+    execute(connection, NANODBC_TEXT("insert into test_decimal_conversion values (5.600);"));
+    execute(connection, NANODBC_TEXT("insert into test_decimal_conversion values (-1.333);"));
+
+    auto results = nanodbc::execute(
+        connection, NANODBC_TEXT("select d from test_decimal_conversion order by 1 desc;"));
+
+    REQUIRE(results.next());
+    REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("12345.987"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("5.6"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("-1.333"));
+}


### PR DESCRIPTION
Closes #485.

ClickHouse runs as a container beside the other servers, and the Apache-2.0 ODBC driver is installed in `Dockerfile.dev` and in a new `test-clickhouse` CI job. The Linux release is published for x86_64 only, so the driver is registered only there, the way Instant Client already is; on an Apple Silicon host the server starts and the suite is excluded.

## What the suite covers

`clickhouse_test.cpp` runs the shared cases the backend can take, and covers the rest itself, because four things do not work the way the shared cases assume. Each has a test of its own asserting what *does* happen, so if the driver changes, the suite says so.

- **`SQLDescribeParam` answers `SQL_UNKNOWN_TYPE` and reports success.** A parameter bound on that description reaches the server untyped and is refused with `Serialization is not implemented for type Nothing`. Every test that binds states its parameters with `statement::describe_parameters` first, and with that, binding works for integers, strings, doubles, dates, timestamps and nulls. This is the first backend covered that needs the call, which is worth having exercised.
- **An array of values is bound as its first element** and the rest is dropped, with no diagnostic — so none of the shared batch cases is run.
- **A column holds a null only if declared `Nullable(T)`.** A plain column asked to take a null quietly stores the type's default instead, which is why the shared null cases, whose tables use plain types, are not run.
- **No schemas, no views, no transactions.** A ClickHouse database is reported as a catalog, `SQLTables` does not list views and `VIEW` is not among the table types, and a rolled back transaction keeps its work (`SQL_TXN_CAPABLE` is `SQL_TC_NONE`).

Also covered: the 3000-character round trip from the issue, catalog columns, and the driver's decimal formatting, which drops trailing zeros where the shared case expects the declared scale.

The shared fixtures are untouched apart from `database_vendor::clickhouse` and its `dbms_name` match. Making `test_catalog_columns` pass would have taken vendor branches at half its assertions, which is the kind of thing `base_test_fixture.h` already warns against, so it is covered by a ClickHouse-specific case instead.

## Verification

All 29 cases pass. Run on this branch against `clickhouse/clickhouse-server` 26.8.1 with driver v1.5.5.20260810, in an x86_64 container, for:

- narrow build and Unicode build, at C++17 and C++20
- the ANSI driver and the Unicode driver, each with both build widths — hence the CI matrix pairing each driver with the build that matches it
- the `docker-compose.yml` connection string against the compose-managed server

Also checked: the `Dockerfile.dev` guard skips cleanly on arm64 and registers no ClickHouse driver there; the other suites still build and `utility_tests` and `sqlite_tests` still pass; clang-format, hadolint, cmake-lint, rstcheck and markdownlint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)