### PR TITLE
Answer the C++ Core Guidelines checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The C++ Core Guidelines checks are answered, closing the code scanning alerts they raised.
 - ClickHouse is tested, in a suite of its own, its driver needing every parameter described first. [`#485`](https://github.com/nanodbc/nanodbc/issues/485)
 
 ## v3.0.0

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -1153,7 +1153,7 @@ attribute::attribute(attribute const& other) noexcept
 {
     this->extractValuePtr();
 }
-void attribute::extractValuePtr()
+void attribute::extractValuePtr() noexcept
 {
     std::visit(
         [this](auto&& arg)
@@ -4818,6 +4818,8 @@ inline void result::result_impl::get_ref_impl<date>(short column, date& result) 
             return;
         }
     }
+        // A binary column that is not a timestampoffset is answered by the throw below.
+        [[fallthrough]];
     default:
         break;
     }
@@ -4848,6 +4850,8 @@ inline void result::result_impl::get_ref_impl<time>(short column, time& result) 
             return;
         }
     }
+        // A binary column that is not a timestampoffset is answered by the throw below.
+        [[fallthrough]];
     default:
         break;
     }
@@ -4880,6 +4884,8 @@ inline void result::result_impl::get_ref_impl<timestamp>(short column, timestamp
             return;
         }
     }
+        // A binary column that is not a timestampoffset is answered by the throw below.
+        [[fallthrough]];
     default:
         break;
     }
@@ -4914,6 +4920,8 @@ result::result_impl::get_ref_impl<timestampoffset>(short column, timestampoffset
             return;
         }
     }
+        // A binary column that is not a timestampoffset is answered by the throw below.
+        [[fallthrough]];
     default:
         break;
     }
@@ -5063,8 +5071,7 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
         }
         else
         { // bound and not blob
-            void* const data = col.pdata_.get() + rowset_position_ * col.clen_;
-            SQLWCHAR const* s = static_cast<SQLWCHAR*>(data);
+            void const* const data = col.pdata_.get() + rowset_position_ * col.clen_;
             // The indicator counts the characters available, which exceeds what the buffer
             // holds when the driver under-reported the column size and would not hand the
             // column over again. Reading past the buffer is not among the options.
@@ -5074,8 +5081,10 @@ inline void result::result_impl::get_ref_impl(short column, T& result) const
                 sizeof(SQLWCHAR);
             auto const str_size = static_cast<string::size_type>(
                 std::min(available, capacity > 0 ? capacity - 1 : std::size_t{0}));
-            // No-op, or unsigned short to signed char16_t.
-            auto const us = static_cast<wide_char_t const*>(static_cast<void const*>(s));
+            // The buffer holds SQLWCHAR, which is wide_char_t itself where the two agree
+            // and an unsigned short beside a signed char16_t where they do not, so the
+            // read goes through the void the buffer is already held as.
+            auto const us = static_cast<wide_char_t const*>(data);
             convert(us, str_size, result);
         }
         return;
@@ -6179,6 +6188,12 @@ statement::statement(class connection& conn, std::list<attribute> const& attribu
 {
 }
 
+// statement assigns by taking its right hand side by value and swapping with it, which is
+// one operation serving as both copy assignment and move assignment. C26432 counts the
+// declarations rather than what they do, and reads the pair it cannot find as missing.
+#ifdef _MSC_VER
+#pragma warning(suppress : 26432)
+#endif
 statement::statement(statement&& rhs) noexcept
     : impl_(std::move(rhs.impl_))
 {

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -447,7 +447,10 @@ public:
 
 protected:
     /// \brief Points value_ptr_ at the resource, according to which type it holds.
-    void extractValuePtr();
+    ///
+    /// Visiting a variant that always holds an alternative cannot throw, and the two
+    /// constructors calling this are themselves noexcept.
+    void extractValuePtr() noexcept;
 
     long attribute_;     ///< The Attribute argument of the ODBC call.
     long string_length_; ///< The StringLength argument of the ODBC call.
@@ -877,8 +880,6 @@ public:
     class attribute : public nanodbc::attribute
     {
     public:
-        attribute(attribute const& other) noexcept
-            : nanodbc::attribute(other) {};
         attribute(
             long const& attribute,
             long const& string_length,
@@ -1646,8 +1647,6 @@ public:
     class attribute : public nanodbc::attribute
     {
     public:
-        attribute(attribute const& other) noexcept
-            : nanodbc::attribute(other) {};
         attribute(
             long const& attribute,
             long const& string_length,
@@ -2927,7 +2926,7 @@ struct hold_column_value;
 template <>
 struct hold_column_value<std::any>
 {
-    static std::any from(std::any value) { return value; }
+    static std::any from(std::any value) noexcept { return value; }
 };
 
 template <class Alternative, class Variant>


### PR DESCRIPTION
The MSVC code analysis job raises eleven alerts on `main`. Each is answered in the source rather than turned off, except one, which is a false positive and is suppressed where it is raised, with the reason.

| Rule | Where | Answer |
|---|---|---|
| C26819 ×4 | `get_ref_impl` for `date`, `time`, `timestamp`, `timestampoffset` | The fall through from a binary column that is not a `timestampoffset` to the `throw` below it is what should happen, so it is annotated `[[fallthrough]]`. |
| C26447 ×2 | `attribute`'s two constructors | `extractValuePtr` is `noexcept`. Visiting a variant that always holds an alternative cannot throw, and both constructors were already `noexcept`, so they promised this on its behalf. |
| C26432 ×2 | `statement::attribute`, `connection::attribute` | Both declared a copy constructor doing exactly what the implicit one does, which is the only reason they held one default operation of five. Removed. |
| C26440 | `hold_column_value<std::any>::from` | `noexcept`. Moving a `std::any` is. |
| C26474 | `get_ref_impl` for a bound wide column | `pdata_` is already held as `void`, so the cast to `SQLWCHAR const*` and back through `void const*` was a round trip. One cast now, out of the void it is already in. |
| C26432 | `nanodbc::statement` | **False positive.** `statement` assigns by taking its right hand side by value and swapping — one operation serving as both copy assignment and move assignment. C26432 counts declarations rather than what they do, and reads the pair it cannot find as missing. Declaring the two separately would make assignment ambiguous, so this is suppressed at the point it is raised. |

The suppression is `#pragma warning(suppress : 26432)` behind `_MSC_VER`, not a `nanodbc.ruleset` entry, so the rule stays live everywhere else — it did real work on the two `attribute` classes.

## Verification

Built clean with no warnings in all four configurations (C++17 and C++20, narrow and Unicode), and the suites pass:

- narrow C++17: `utility`, `sqlite`, `mssql`, `mysql`, `postgresql`
- Unicode C++17: `utility`, `sqlite`, `mssql`, `mysql`, `postgresql`

The Unicode MSSQL run matters most here: it is what drives the bound wide column path the C26474 change touches. clang-format is clean.

The MSVC rules themselves can only be checked by the `CppCoreCheckRules` job on this PR, since the analysis needs MSVC.

## Not in this PR

The Security tab also shows a Flawfinder configuration error, that `.github/workflows/flawfinder.yml` no longer exists. There is nothing to change in the repository for it: the workflow was folded into `analysis.yml` by 13ac351, and what remains is one stale analysis GitHub still keys to the old path, beside 364 live ones from `analysis.yml`. It is cleared by deleting that analysis, not by a commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)