### PR TITLE
Test against IBM Db2

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -638,3 +638,65 @@ jobs:
         run: |
           export NANODBC_TEST_CONNSTR_FIREBIRD="Driver={Firebird};DBNAME=localhost/3050:/var/lib/firebird/data/nanodbc.fdb;UID=sysdba;PWD=nanodbc;CHARSET=UTF8;"
           ctest --test-dir ${GITHUB_WORKSPACE}/build --output-on-failure --no-tests=error -R firebird_tests
+
+  test-db2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        cxxstd: ["17"]
+    name: test-db2 (c++${{ matrix.cxxstd }})
+    services:
+      db2:
+        image: icr.io/db2_community/db2:latest
+        ports:
+          - 50000:50000
+        options: >-
+          --privileged
+          --health-cmd "su - db2inst1 -c 'db2 connect to nanodbc'"
+          --health-interval 15s
+          --health-timeout 10s
+          --health-retries 40
+          --health-start-period 300s
+        env:
+          LICENSE: accept
+          DB2INSTANCE: db2inst1
+          DB2INST1_PASSWORD: nanodbc
+          DBNAME: nanodbc
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install
+        run: |
+          apt-get -o DPkg::Lock::Timeout=120 update
+          apt-get -o DPkg::Lock::Timeout=120 install -y ccache unixodbc unixodbc-dev odbcinst
+        shell: sudo bash {0}
+      # The download needs no credentials. The licence is IBM's International Program
+      # License Agreement, carried in the tarball under clidriver/license.
+      - name: Install the Db2 CLI driver
+        run: |
+          curl -fsSL -o /tmp/db2-clidriver.tar.gz https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/linuxx64_odbc_cli.tar.gz
+          sudo mkdir -p /opt/ibm
+          sudo tar -xzf /tmp/db2-clidriver.tar.gz -C /opt/ibm
+          echo /opt/ibm/clidriver/lib | sudo tee /etc/ld.so.conf.d/db2-clidriver.conf
+          sudo ldconfig
+          printf '[IBM DB2 ODBC DRIVER]\nDescription=IBM Data Server Driver for ODBC and CLI\nDriver=/opt/ibm/clidriver/lib/libdb2.so\n' \
+            | sudo odbcinst -i -d -r
+      - name: Configure
+        run: |
+          cmake -S ${GITHUB_WORKSPACE} -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd }}
+      - name: Build
+        run: |
+          cmake --build ${GITHUB_WORKSPACE}/build --parallel --target db2_tests
+      # TEMPORARY: this push is a diagnostic. The indicator probe establishes, on a native
+      # x86_64 runner, whether the driver writes only 32 bits of an 8 byte SQLLEN, and the
+      # loop reports which shared cases pass there. Both go before this is ready to merge.
+      - name: Diagnose the driver on native x86_64
+        run: |
+          export NANODBC_TEST_CONNSTR_DB2="Driver={IBM DB2 ODBC DRIVER};Database=nanodbc;Hostname=localhost;Port=50000;Protocol=TCPIP;Uid=db2inst1;Pwd=nanodbc;"
+          gcc -o /tmp/np2 ${GITHUB_WORKSPACE}/utility/db2-indicator-probe.c -lodbc
+          /tmp/np2 "$NANODBC_TEST_CONNSTR_DB2" || true
+          echo "===== per-test triage ====="
+          for t in $(${GITHUB_WORKSPACE}/build/test/db2_tests --list-tests --verbosity quiet | sed 's/^  //' | grep '^test_'); do
+            if ${GITHUB_WORKSPACE}/build/test/db2_tests "$t" >/dev/null 2>&1; then echo "PASS $t"; else echo "FAIL $t"; fi
+          done

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -92,6 +92,22 @@ RUN arch="$(uname -m)" \
     | odbcinst -i -d -r \
     ; else echo "ClickHouse ODBC is x86_64 only; skipping on ${arch}"; fi
 
+# The IBM Data Server Driver for ODBC and CLI, published for Linux on x86_64 only, so it
+# is registered only where it can load, as Instant Client and ClickHouse ODBC are. The
+# download needs no credentials; the licence is IBM's International Program License
+# Agreement, which the tarball carries under clidriver/license.
+RUN arch="$(uname -m)" \
+    && if [ "${arch}" = "x86_64" ]; then \
+    curl -fsSL -o /tmp/db2-clidriver.tar.gz https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/linuxx64_odbc_cli.tar.gz \
+    && mkdir -p /opt/ibm \
+    && tar -xzf /tmp/db2-clidriver.tar.gz -C /opt/ibm \
+    && rm /tmp/db2-clidriver.tar.gz \
+    && echo /opt/ibm/clidriver/lib > /etc/ld.so.conf.d/db2-clidriver.conf \
+    && ldconfig \
+    && printf '[IBM DB2 ODBC DRIVER]\nDescription=IBM Data Server Driver for ODBC and CLI\nDriver=/opt/ibm/clidriver/lib/libdb2.so\n' \
+    | odbcinst -i -d -r \
+    ; else echo "The Db2 CLI driver is x86_64 only; skipping on ${arch}"; fi
+
 # Firebird ODBC, published for x86_64 and arm64 alike, so unlike Instant Client and
 # ClickHouse above it is registered wherever the image is built. The driver loads
 # libfbclient by its unversioned name, which only the development package carries, so the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,6 +147,34 @@ services:
       retries: 30
       start_period: 30s
 
+  db2:
+    image: icr.io/db2_community/db2:${DB2_VERSION:-latest}
+    container_name: nanodb2
+    restart: unless-stopped
+    # Db2 Community Edition is published for x86_64 only, and the engine wants the
+    # capabilities a privileged container has.
+    platform: linux/amd64
+    privileged: true
+    ports:
+      - "50000:50000"
+    environment:
+      LICENSE: accept
+      DB2INSTANCE: db2inst1
+      DB2INST1_PASSWORD: *default_credential
+      DBNAME: *default_credential
+    # The first start lays down an instance and a database, which takes minutes rather
+    # than seconds, so the start period is generous and the retries many.
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "su - db2inst1 -c 'db2 connect to nanodbc' > /dev/null 2>&1",
+        ]
+      interval: 15s
+      timeout: 10s
+      retries: 40
+      start_period: 300s
+
   oracle:
     image: gvenzl/oracle-free:${ORACLE_VERSION:-23-slim-faststart}
     container_name: nanooracle
@@ -186,10 +214,10 @@ services:
         condition: service_healthy
       firebird:
         condition: service_healthy
-    # Oracle is deliberately not depended on: it takes minutes to open and its driver is
-    # published for x86_64 only, so waiting for it would cost every run on every host to
-    # serve the one suite that cannot run on some of them. Start it when it is wanted,
-    # with docker compose up -d oracle.
+    # Oracle and Db2 are deliberately not depended on: each takes minutes to open and each
+    # driver is published for x86_64 only, so waiting for them would cost every run on every
+    # host to serve two suites that cannot run on some of them. Start one when it is wanted,
+    # with docker compose up -d oracle or docker compose up -d db2.
 
     volumes:
       - .:/opt/nanodbc
@@ -219,3 +247,4 @@ services:
       # A narrow build only: the driver's Unicode entry points cannot open a connection,
       # so a Unicode build of nanodbc has no way to reach Firebird.
       NANODBC_TEST_CONNSTR_FIREBIRD: "Driver={Firebird};DBNAME=firebird/3050:/var/lib/firebird/data/nanodbc.fdb;UID=sysdba;PWD=nanodbc;CHARSET=UTF8;"
+      NANODBC_TEST_CONNSTR_DB2: "Driver={IBM DB2 ODBC DRIVER};Database=nanodbc;Hostname=db2;Port=50000;Protocol=TCPIP;Uid=db2inst1;Pwd=nanodbc;"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@ target_compile_features(utility_tests PRIVATE cxx_std_17)
 add_test(NAME utility_tests COMMAND utility_tests)
 add_dependencies(tests utility_tests)
 
-set(test_list clickhouse firebird mssql mysql oracle postgresql sqlite vertica)
+set(test_list clickhouse db2 firebird mssql mysql oracle postgresql sqlite vertica)
 
 foreach(test_item IN LISTS test_list)
   # The Firebird driver's Unicode entry points cannot open a connection, so that suite is

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -259,7 +259,8 @@ struct base_test_fixture
         sqlserver,
         vertica,
         clickhouse,
-        firebird
+        firebird,
+        db2
     };
 
     base_test_fixture()
@@ -310,6 +311,8 @@ struct base_test_fixture
             return database_vendor::clickhouse;
         else if (contains_string(dbms, NANODBC_TEXT("Firebird")))
             return database_vendor::firebird;
+        else if (contains_string(dbms, NANODBC_TEXT("DB2")))
+            return database_vendor::db2;
         else
             return database_vendor::unknown;
     }
@@ -422,12 +425,13 @@ struct base_test_fixture
         }
     }
 
-    // An unquoted identifier folds to upper case on Oracle and on Firebird, which is what
+    // An unquoted identifier folds to upper case on Oracle, Firebird and Db2, which is what
     // the standard asks for, so a name written lower case in a query comes back upper case
     // from the catalog and has to be looked up that way.
     nanodbc::string as_identifier(nanodbc::string const& name) const
     {
-        if (vendor_ != database_vendor::oracle && vendor_ != database_vendor::firebird)
+        if (vendor_ != database_vendor::oracle && vendor_ != database_vendor::firebird &&
+            vendor_ != database_vendor::db2)
             return name;
 
         nanodbc::string folded;

--- a/test/db2_test.cpp
+++ b/test/db2_test.cpp
@@ -1,0 +1,224 @@
+#include "test_case_fixture.h"
+
+namespace
+{
+struct db2_fixture : public test_case_fixture
+{
+    db2_fixture()
+        : test_case_fixture()
+    {
+        // connection string from command line or NANODBC_TEST_CONNSTR environment variable
+        if (connection_string_.empty())
+            connection_string_ = get_env("NANODBC_TEST_CONNSTR_DB2");
+    }
+};
+} // namespace
+
+TEST_CASE_METHOD(db2_fixture, "test_driver", "[db2][driver]")
+{
+    test_driver();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_driver_info", "[db2][driver][metadata][info]")
+{
+    test_driver_info();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_datasources", "[db2][datasources]")
+{
+    test_datasources();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_batch_insert_integer", "[db2][batch][integral]")
+{
+    test_batch_insert_integral();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_batch_insert_null", "[db2][batch][null]")
+{
+    test_batch_insert_null();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_batch_insert_string", "[db2][batch][string]")
+{
+    test_batch_insert_string();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_batch_insert_mixed", "[db2][batch]")
+{
+    test_batch_insert_mixed();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_catalog_list_catalogs", "[db2][catalog][catalogs]")
+{
+    test_catalog_list_catalogs();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_catalog_list_schemas", "[db2][catalog][schemas]")
+{
+    test_catalog_list_schemas();
+}
+
+TEST_CASE_METHOD(
+    db2_fixture,
+    "test_catalog_list_table_types",
+    "[db2][catalog][table_types]")
+{
+    test_catalog_list_table_types();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_catalog_columns", "[db2][catalog][columns]")
+{
+    test_catalog_columns();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_catalog_primary_keys", "[db2][catalog][primary_keys]")
+{
+    test_catalog_primary_keys();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_catalog_tables", "[db2][catalog][tables]")
+{
+    test_catalog_tables();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_connection_environment", "[db2][connection]")
+{
+    test_connection_environment();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_dbms_info", "[db2][dmbs][metadata][info]")
+{
+    test_dbms_info();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_get_info", "[db2][dmbs][metadata][info]")
+{
+    test_get_info();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_decimal_conversion", "[db2][decimal][conversion]")
+{
+    test_decimal_conversion();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_error", "[db2][error]")
+{
+    test_error();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_exception", "[db2][exception]")
+{
+    test_exception();
+}
+
+TEST_CASE_METHOD(
+    db2_fixture,
+    "test_execute_multiple_transaction",
+    "[db2][execute][transaction]")
+{
+    test_execute_multiple_transaction();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_execute_multiple", "[db2][execute]")
+{
+    test_execute_multiple();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_integral", "[db2][integral]")
+{
+    test_integral<db2_fixture>();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_integral_small_types", "[db2][integral]")
+{
+    test_integral_small_types();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_integral_small_types_batch", "[db2][integral][batch]")
+{
+    test_integral_small_types_batch();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_move", "[db2][move]")
+{
+    test_move();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_null", "[db2][null]")
+{
+    test_null();
+}
+
+TEST_CASE_METHOD(
+    db2_fixture,
+    "test_null_with_bound_columns_unbound",
+    "[db2][null][unbound]")
+{
+    test_null_with_bound_columns_unbound();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_result_at_end", "[db2][result]")
+{
+    test_result_at_end();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_result_iterator", "[db2][result][iterator]")
+{
+    test_result_iterator();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_simple", "[db2]")
+{
+    test_simple();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_statement_usable_when_result_gone", "[db2][statement]")
+{
+    test_statement_usable_when_result_gone();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_string", "[db2][string]")
+{
+    test_string();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_string_vector", "[db2][string]")
+{
+    test_string_vector();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_string_view_vector", "[db2][string]")
+{
+    test_string_view_vector();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_time", "[db2][time]")
+{
+    test_time();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_transaction", "[db2][transaction]")
+{
+    test_transaction();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_blob_binary", "[db2][blob][binary]")
+{
+    test_blob_binary();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_batch_binary", "[db2][binary]")
+{
+    test_batch_binary();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_while_not_end_iteration", "[db2][looping]")
+{
+    test_while_not_end_iteration();
+}
+
+TEST_CASE_METHOD(db2_fixture, "test_while_next_iteration", "[db2][looping]")
+{
+    test_while_next_iteration();
+}

--- a/utility/db2-indicator-probe.c
+++ b/utility/db2-indicator-probe.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sql.h>
+#include <sqlext.h>
+int main(int argc, char** argv)
+{
+    SQLHENV env; SQLHDBC dbc; SQLHSTMT s;
+    SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
+    SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
+    SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+    SQLCHAR out[1024]; SQLSMALLINT ol;
+    SQLDriverConnect(dbc, NULL, (SQLCHAR*)argv[1], SQL_NTS, out, sizeof(out), &ol, SQL_DRIVER_NOPROMPT);
+    printf("sizeof(SQLLEN)=%zu\n", sizeof(SQLLEN));
+
+    SQLAllocHandle(SQL_HANDLE_STMT, dbc, &s);
+    SQLExecDirect(s, (SQLCHAR*)"drop table nulltest", SQL_NTS);
+    SQLExecDirect(s, (SQLCHAR*)"create table nulltest (i integer)", SQL_NTS);
+    SQLExecDirect(s, (SQLCHAR*)"insert into nulltest values (7)", SQL_NTS);
+    SQLExecDirect(s, (SQLCHAR*)"insert into nulltest values (null)", SQL_NTS);
+    SQLFreeHandle(SQL_HANDLE_STMT, s);
+    SQLAllocHandle(SQL_HANDLE_STMT, dbc, &s);
+    SQLINTEGER iv; SQLLEN ind_i;
+    SQLExecDirect(s, (SQLCHAR*)"select i from nulltest order by i", SQL_NTS);
+    SQLBindCol(s, 1, SQL_C_SLONG, &iv, 0, &ind_i);
+    int row = 0;
+    while (1)
+    {
+        // Poison the whole indicator so we can see exactly which bytes the driver writes.
+        memset(&ind_i, 0xAB, sizeof(ind_i));
+        if (SQLFetch(s) != SQL_SUCCESS) break;
+        unsigned char* b = (unsigned char*)&ind_i;
+        printf("row %d bytes:", ++row);
+        for (size_t k = 0; k < sizeof(ind_i); ++k) printf(" %02x", b[k]);
+        int32_t low; memcpy(&low, &ind_i, sizeof(low));
+        printf("   as SQLLEN=%ld   low 32 bits=%d (%s)\n", (long)ind_i, low,
+               low == -1 ? "SQL_NULL_DATA" : "length");
+    }
+    return 0;
+}


### PR DESCRIPTION
**Draft — this push is a diagnostic, not the finished suite.** Closes #488 when it is.

## The licence question the issue asks to settle first

- **The driver downloads unattended, with no credentials.** `https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/linuxx64_odbc_cli.tar.gz`, 27MB, plain HTTPS GET, no login and no click-through in the path.
- **The licence is IBM's International Program License Agreement**, `i125-3301-15 (10-2021)`, for "IBM Data Server Driver for ODBC and CLI v12.1.4 (Tool)", carried in the tarball under `clidriver/license/`. It is proprietary. Its Redistributables clause governs shipping the driver inside a product, which is not what CI does.
- **There is precedent in this repository**: Oracle Instant Client is already fetched unattended, under the OTN licence, by `Dockerfile.dev` and the `test-oracle` job. Db2's terms are not Oracle's, so this is still a maintainer's call rather than mine, but it is the same shape of dependency.

Both server and Linux driver are x86_64 only, so this suite is x86_64 only, as Oracle's and ClickHouse's are.

## Why this is a draft

Db2 is the best behaved of the four backends I have looked at this week — `SQLDescribeParam` works, array binding inserts every row, transactions really roll back, the catalog answers in clean ASCII. 22 of the shared cases pass on my machine.

But reading a bound column gives an indicator that is only half written. Poisoning the whole `SQLLEN` with `0xAB` before each fetch:

| row | indicator bytes | low 32 bits |
|---|---|---|
| `i = 7` | `04 00 00 00` `ab ab ab ab` | 4, the length |
| `i = null` | `ff ff ff ff` `ab ab ab ab` | −1, `SQL_NULL_DATA` |

`sizeof(SQLLEN)` is 8 under unixODBC and the driver writes 4, leaving the rest as it found it. The answer is right in the low half and garbage as a whole, which is why `is_null()` returns false for a null and why lengths come back wrong. It accounts for most of the failures I see, and it would mean nanodbc silently misreports nulls for any Db2 user on 64-bit Linux — a bigger thing than a test suite.

**My development machine runs amd64 under emulation**, and I will not assert a defect in IBM's driver on that evidence alone. So this push runs the same probe on a native x86_64 runner, and reports which shared cases pass there. The suite gets written around whatever that says, and the diagnostic step comes out before this is ready to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)